### PR TITLE
fix(requirements): 拆开第 9 行 typer/fastapi 粘连依赖 (#4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ psycopg[binary]>=3.2
 pydantic>=2.8
 pydantic-settings>=2.4
 python-dotenv>=1.0
-typer>=0.12fastapi>=0.115
+typer>=0.12
+fastapi>=0.115
 uvicorn[standard]>=0.30


### PR DESCRIPTION
修复 `requirements.txt:9` `typer>=0.12fastapi>=0.115` 粘连为一条 PEP 508 非法依赖。

拆为两行：`typer>=0.12` 与 `fastapi>=0.115`。