### PR TITLE
fix(frontend): vite proxy 默认端口改为 8001 并用 loadEnv 读 .env (#5)

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
 # FastAPI 后端地址（本地）
-VITE_API_URL=http://127.0.0.1:8000
+# 默认 8001（CLAUDE.md 启动说明）；如需覆盖在此修改即可被 vite.config.js 通过 loadEnv 拾取
+VITE_API_URL=http://127.0.0.1:8001

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,16 +1,22 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// dev 代理 /api 到 FastAPI（默认 8000）
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: process.env.VITE_API_URL || 'http://127.0.0.1:8000',
-        changeOrigin: true,
+// dev 代理 /api 到 FastAPI（默认 8001，与 CLAUDE.md 启动说明一致）
+// 8000 常被本机其他程序占用，按文档约定使用 8001。
+// 通过 .env 的 VITE_API_URL 覆盖目标地址。
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiUrl = env.VITE_API_URL || 'http://127.0.0.1:8001'
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
## 问题
vite.config.js 直接 `process.env.VITE_API_URL`，但 Vite 不会把 .env 注入 vite.config.js 的 process.env（需 `loadEnv` 或 shell 导出），导致 frontend/.env 配置对 proxy 无效；默认回退 8000，与 CLAUDE.md「后端跑 8001」矛盾。

## 修复
- vite.config.js 改用 `loadEnv` 读取 .env
- 默认目标地址改为 `http://127.0.0.1:8001`（与文档一致）
- .env 同步改为 8001 并加注释