### PR TITLE
fix(api): get_entity 改用 HTTPException(404) 而非 Flask tuple (#6)

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Optional
 
-from fastapi import Depends, FastAPI, Query
+from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -48,7 +48,7 @@ def list_entities(
 def get_entity(entity_id: int, db: Session = Depends(get_db)):
     e = db.get(Entity, entity_id)
     if not e:
-        return {"detail": "not found"}, 404
+        raise HTTPException(status_code=404, detail="entity not found")
     return {"id": e.id, "type": e.entity_type, "name": e.name, "status": e.status,
             "fields": e.fields}
 


### PR DESCRIPTION
## 问题
`get_entity` 写的是 `return {"detail": "not found"}, 404`——Flask 写法；FastAPI 会把 tuple 序列化为 JSON 数组并以 HTTP 200 返回。任何不存在的 entity id 都「成功」返回 200，违反 REST 状态码约定。

## 修复
- 引入 `HTTPException`
- 改写不存在分支：`raise HTTPException(status_code=404, detail='entity not found')`
- 全文件 grep 复查无同类 Flask-style 写法