### PR TITLE
fix(recompute): 起算年内一律传播 + 删除死代码基线赋值 (#7)

### DIFF
--- a/app/core/recompute.py
+++ b/app/core/recompute.py
@@ -17,30 +17,36 @@ from app.model.types import AccountStatus
 
 
 def recompute_account(session: Session, account_id: int, from_year: int) -> dict:
-    """从 from_year 起重算账户余额链（DESIGN §9.2 recompute_one）。"""
+    """从 from_year 起重算账户余额链（DESIGN §9.2 recompute_one）。
+
+    关键约束：
+    1. 基线只取 from_year 前最后一条分录的余额作为起算余额；from_year 起的所有行
+       一律滚动重算（同年内不再「沿用已存在 balance 跳过」）。
+    2. 不再有死代码覆盖：base 永远等于上一行的累计余额（首行则为 from_year 前最后
+       一行的 balance，未取到则为 0）。
+    """
     entries = session.execute(
         select(LedgerEntry).where(LedgerEntry.account_id == account_id)
         .order_by(LedgerEntry.date, LedgerEntry.id)
     ).scalars().all()
-    balance = 0.0
+
+    # 基线：from_year 前最后一条分录的余额；取不到则 0
+    baseline = 0.0
+    for e in entries:
+        if e.date.year < from_year and e.balance is not None:
+            baseline = e.balance
+        elif e.date.year >= from_year:
+            break
+
+    balance = float(baseline)
     years_updated = 0
-    for i, e in enumerate(entries):
-        # 定位 from_year：之前年份的余额视为已定基线，从该年起重滚
+    for e in entries:
         if e.date.year < from_year:
-            balance = e.balance if e.balance is not None else balance
-            continue
-        if i > 0 and entries[i - 1].date.year == e.date.year and e.balance is not None:
-            # 同年内已有基线则继续
-            balance = e.balance if e.balance is not None else balance
-            continue
-        prev = entries[i - 1] if i > 0 else None
-        base = (prev.balance if prev and prev.date.year >= from_year - 1 else 0.0)
-        if e.date.year >= from_year or from_year == 0:
-            base = balance
+            continue                              # 锁定基线之前的行
         inflow = float(e.inflow or 0.0)
         outflow = float(e.outflow or 0.0)
-        balance = inflow - outflow + float(base)
-        if e.balance != balance:
+        balance = balance + inflow - outflow
+        if e.balance is None or float(e.balance) != balance:
             e.balance = balance
             years_updated += 1
     return {"account_id": account_id, "from_year": from_year,


### PR DESCRIPTION
## 问题
`recompute_account` 两个 bug：
1. 同年内已有 balance 的行被原样采信跳过 → 起算年内后续分录余额保持陈旧，错误要拖到下一自然年首条才被纠正。
2. :37 计算的 prev-based base 被 :38-39 的 `if e.date.year >= from_year or from_year == 0: base = balance` 无条件覆盖（<from_year 已在 :29 continue，条件恒真）→ 死代码。

## 修复
- **基线**：扫描 entries 找 from_year 前最后一条 balance（非 None），作为起算基线；from_year 之前所有行 continue（保留已写入的旧余额）。
- **滚动**：from_year 起所有行一律 `balance = prev_balance + inflow - outflow` 滚动重算，不再有同年内跳过。
- 移除原 :32-39 的死代码与 if/else 嵌套。