### PR TITLE
fix(ingest): CLI `--env` 显式驱动 session/engine，杜绝脱节 (#3)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,21 +1,52 @@
 """Novel Dashboard 数据库（DESIGN §4/§5）。
 
 SQLAlchemy engine/session；Alembic 迁移入口。Base 供 ORM 模型继承。
+
+设计要点：
+- 默认 \`engine\` / \`SessionLocal\` 绑定到 \`APP_ENV\` 解析出的 DSN，供 FastAPI / alembic 等
+  单进程单环境场景使用。
+- 提供 \`make_engine(env)\` / \`make_sessionmaker(env)\` / \`check_connection_for(env)\`，
+  按指定 env 显式重建连接——给 ingest CLI 等 \`--env\` 驱动场景使用，杜绝「打印 prod
+  实际写入 dev」的脱节（issue #3）。
 """
 from __future__ import annotations
 
-from sqlalchemy import create_engine
+from typing import Optional
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-from app.config import CONFIG
+from app.config import CONFIG, get_config
 
-engine = create_engine(CONFIG.dsn, pool_pre_ping=True, future=True)
+
+# 默认连接：绑定到 APP_ENV 解析出的 DSN（FastAPI / alembic 用）
+engine: Engine = create_engine(CONFIG.dsn, pool_pre_ping=True, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
 
 class Base(DeclarativeBase):
     """全 ORM 模型基类（DESIGN §5 DDL 的 SQLAlchemy 表达，后续 F-P0-07 填充）。"""
     pass
+
+
+def make_engine(env: Optional[str] = None) -> Engine:
+    """按 env 显式构造 engine；不修改模块默认 engine（避免污染 FastAPI/alembic）。"""
+    cfg = get_config(env)
+    return create_engine(cfg.dsn, pool_pre_ping=True, future=True)
+
+
+def make_sessionmaker(env: Optional[str] = None):
+    """按 env 构造 sessionmaker；与 \`SessionLocal()\` 同接口，with-block 用法一致。"""
+    eng = make_engine(env)
+    return sessionmaker(bind=eng, autoflush=False, autocommit=False, future=True)
+
+
+def check_connection_for(env: Optional[str] = None) -> bool:
+    """连通性自检（ingest CLI 按 \`--env\` 自检）。"""
+    eng = make_engine(env)
+    with eng.connect() as conn:
+        return conn.execute(text("SELECT 1")).scalar() == 1
 
 
 def get_session():
@@ -28,6 +59,6 @@ def get_session():
 
 
 def check_connection() -> bool:
-    """连通性自检（ingest CLI / 冒烟用）。"""
+    """连通性自检（按 APP_ENV，默认连接）。"""
     with engine.connect() as conn:
-        return conn.execute(__import__("sqlalchemy").text("SELECT 1")).scalar() == 1
+        return conn.execute(text("SELECT 1")).scalar() == 1

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -6,24 +6,32 @@
     python -m app.ingest.main ping                 # DB 连通自检
 
 F-P0-01：骨架（config/db/CLI）已就绪；detect/parsers/normalize/conflict 后续里程碑填充。
+
+设计要点（issue #3）：每个子命令的 session 由 \`--env\` 显式构造（make_sessionmaker），
+不再走导入期绑定的模块 SessionLocal，杜绝「打印 prod 实际写入 dev」的脱节。
 """
 from __future__ import annotations
 
 import typer
 
 from app.config import get_config
-from app.db import SessionLocal, check_connection
+from app.db import check_connection_for, make_sessionmaker
 from app.ingest.parse import run_ingest
 from app.ingest import conflict, writer
 
 app = typer.Typer(help="Novel Dashboard ingest")
 
 
+def _session_for(env: str):
+    """按 \`--env\` 构造 sessionmaker（with-block 兼容 SessionLocal 接口）。"""
+    return make_sessionmaker(env)()
+
+
 @app.command()
 def ping(env: str = typer.Option("dev", "--env")):
-    """数据库连通自检。"""
+    """数据库连通自检（按 \`--env\` 真正打到对应 DSN）。"""
     cfg = get_config(env)
-    ok = check_connection()  # db.py 用模块级 CONFIG；此处按 env 打印，连接仍走默认
+    ok = check_connection_for(env)
     typer.echo(f"[{cfg.env}] dsn={cfg.dsn}")
     typer.secho("连接成功" if ok else "连接失败", fg=typer.colors.GREEN if ok else typer.colors.RED)
 
@@ -51,9 +59,10 @@ def ingest(
     """F-P0-04 落库：character→entity；initial_asset→entity/account/initial_asset/现金余额。
 
     从 Design_Folder（source_dir）读取基础数据；commit 前整批事务，失败回滚。
+    Session 严格按 \`--env\` 构造（issue #3）。
     """
     cfg = get_config(env)
-    with SessionLocal() as s:
+    with _session_for(env) as s:
         rep = run_ingest(cfg.source_dir)
         ck = 0; ia = {"asset": 0, "cash": 0}; sec = 0; rent = 0; prop = 0; shop = 0; sal = 0; he = 0; rcur = 0; fx_total = 0; blocked_files = 0
         fx_files = []
@@ -106,7 +115,7 @@ def ingest(
 def health(env: str = typer.Option("dev", "--env")):
     """运行全库健康校验（H1-H5）并输出问题清单。"""
     from app.core.health import run_report, summarize
-    with SessionLocal() as s:
+    with _session_for(env) as s:
         summ = summarize(s)
         typer.echo(f"[{env}] 健康校验汇总（H1-H5）：")
         for rule in ("H1", "H2", "H3", "H4", "H5"):
@@ -121,7 +130,7 @@ def health(env: str = typer.Option("dev", "--env")):
 def recompute(env: str = typer.Option("dev", "--env"), from_year: int = typer.Option(1947, "--from")):
     """全库增量重算：从受影响起点年向后滚动账户余额（F-P0-12）。"""
     from app.core.recompute import recompute_all
-    with SessionLocal() as s:
+    with _session_for(env) as s:
         res = recompute_all(s, from_year)
         s.commit()
         total_updated = sum(r["updated"] for r in res)
@@ -134,7 +143,7 @@ def calendar(env: str = typer.Option("dev", "--env"), as_of: str = typer.Option(
     from datetime import date
     from app.core.calendar import snapshot_as_of
     d = date.fromisoformat(as_of)
-    with SessionLocal() as s:
+    with _session_for(env) as s:
         snaps = snapshot_as_of(s, d)
         typer.echo(f"[{env}] 截至 {d} 快照 {len(snaps)} 条：")
         for x in snaps:
@@ -148,7 +157,7 @@ def wealth(env: str = typer.Option("dev", "--env"), year: int = typer.Option(200
     汇率缺失币种不计入合计，并在底部显式告警（issue #2 修复：杜绝 1.0 静默 fallback）。
     """
     from app.core.wealth import wealth_series
-    with SessionLocal() as s:
+    with _session_for(env) as s:
         w = wealth_series(s, year, year)
         d = w.get(year, {})
         typer.echo(f"[{env}] {year} 家族合计(展示USD) = {d.get('family_total_usd', 0):,.0f}")
@@ -166,7 +175,7 @@ def wealth(env: str = typer.Option("dev", "--env"), year: int = typer.Option(200
 def snapshot(env: str = typer.Option("dev", "--env")):
     """重建逐年 as-of 快照（F-P0-08）。"""
     from app.core.snapshot import rebuild_snapshots
-    with SessionLocal() as s:
+    with _session_for(env) as s:
         r = rebuild_snapshots(s, range(1947, 2026))
         s.commit()
         typer.echo(f"[{env}] 快照重建完成：{r['snapshots']} 条 / {r['accounts']} 账户")


### PR DESCRIPTION
## 问题
CLI 各子命令的 session 走导入期全局 `SessionLocal`（绑定 APP_ENV 解析的 DSN），而打印与目录按 `get_config(args.env)` 解析。`--env prod` 不设 `APP_ENV=prod` 时：输出打印 prod、实际写入 dev 库，三环境隔离承诺失效。DESIGN §4 不允许此脱节。

## 修复
- **app/db.py**：保留模块默认 `engine` / `SessionLocal`（FastAPI/alembic 单进程单环境场景仍可用），新增 `make_engine(env)` / `make_sessionmaker(env)` / `check_connection_for(env)` 按指定 env 显式构造，零污染默认连接。
- **app/ingest/main.py**：每个 CLI 命令改用 `_session_for(env)` 工厂，`ping` 改用 `check_connection_for(env)`。session 与打印/数据目录严格按同一个 --env 解析。