### PR TITLE
fix(ingest): parse_income_security 面值正则放宽 + country 空节告警 (issue #11)

### DIFF
--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -50,6 +50,12 @@ def run(
         typer.echo(f"  ✅ {r.category:12s} {r.file} ({len(r.records)} 条)")
     for r in report.failed:
         typer.echo(f"  ❌ {r.category:12s} {r.file} — {r.error}")
+    # issue #11：parser 警告（如 country 已设但未产出记录）
+    warns = report.warnings
+    if warns:
+        typer.echo(f"⚠ 解析告警 {len(warns)} 条：")
+        for f, w in warns:
+            typer.echo(f"   ⚠ {f}: {w}")
 
 
 @app.command()

--- a/app/ingest/parse.py
+++ b/app/ingest/parse.py
@@ -17,6 +17,7 @@ class ParseResult:
     file: str
     category: str
     records: list = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
     ok: bool = True
     error: str | None = None
 
@@ -36,6 +37,24 @@ class IngestReport:
     @property
     def skipped(self) -> list[ParseResult]:
         return [r for r in self.results if r.category == "PHASE2_EVENT"]
+
+    @property
+    def warnings(self) -> list[tuple[str, str]]:
+        """收集 (file, warning) 对，供上层展示。"""
+        out: list[tuple[str, str]] = []
+        for r in self.results:
+            for w in r.warnings:
+                out.append((r.file, w))
+        return out
+
+
+# 解析器签名有两种：(path) -> list 或 (path) -> (list, warnings)。
+# 下面通过 _call 统一处理。
+def _call(fn, path: Path) -> tuple[list, list[str]]:
+    out = fn(path)
+    if isinstance(out, tuple) and len(out) == 2:
+        return out[0], list(out[1] or [])
+    return out, []
 
 
 _PARSERS = {
@@ -68,7 +87,7 @@ def parse_one(rel: str, path: Path) -> ParseResult:
         pr.error = f"解析器未实现（{det.category}）"
         return pr
     try:
-        pr.records = fn(path)
+        pr.records, pr.warnings = _call(fn, path)
     except Exception as e:  # noqa: BLE001
         pr.ok = False
         pr.error = f"{type(e).__name__}: {e}"

--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -396,18 +396,29 @@ def parse_income_security(path: Path) -> list[dict]:
 
     产出"每券"记录；归属 entity + 币种由持有国 → 铁律映射（F-P0-05）。
     逐年票息 = 面值 × 票息（固定费率，全周期不变；由 writer 生成 income_stream）。
+
+    返回：(records, warnings)
+    - records：每券字典列表
+    - warnings：country 已设但未产出记录的告警列表（如某国家债券节无 `### N.` 子项）
+
+    issue #11 修复：面值正则放宽为 [\\d,.]+ 以支持带小数面额（如「4,047.30 BEF」），
+    此前因不含小数点导致整条记录静默丢失。
     """
     from app.ingest.holders import holder_currencies
     lines = _lines(path)
     recs: list[dict] = []
+    warnings: list[str] = []
     country = None
+    country_had_records: dict[str, bool] = {}
     for idx, line in enumerate(lines):
         cm = re.match(r"^##\s*(荷兰|丹麦|瑞典|比利时|卢森堡)债券", line)
         if cm:
             country = cm.group(1)
+            country_had_records.setdefault(country, False)
             continue
         # 每券：`### N. 名称（面值 X 币种，固定票息Y%）`
-        m = re.match(r"^###\s+\d+\.\s*(.+?)（面值\s*([\d,]+)\s*([A-Za-z一-鿿]{2,8})", line)
+        # issue #11：面值正则放宽为 [\d,.]+ 支持小数（如 4,047.30 BEF）
+        m = re.match(r"^###\s+\d+\.\s*(.+?)（面值\s*([\d,.]+)\s*([A-Za-z一-鿿]{2,8})", line)
         if not m or not country:
             continue
         cur_code = m.group(3)
@@ -422,7 +433,12 @@ def parse_income_security(path: Path) -> list[dict]:
         recs.append({"country": country, "name": m.group(1).strip(),
                      "face_value": parse_number(m.group(2)), "currency": face_cur,
                      "rate_pct": rate, "holder": _bund_holder(country)})
-    return recs
+        country_had_records[country] = True
+    # issue #11：country 已设但无任何记录 → warning 进 ingest_report
+    for c, had in country_had_records.items():
+        if not had:
+            warnings.append(f"country={c} 债券节未产出任何记录（缺 ### N. 行或正则失配）")
+    return recs, warnings
 
 
 # ---------------- income_rent（惠民租房收益流） ----------------

--- a/tests/test_income_security_parser.py
+++ b/tests/test_income_security_parser.py
@@ -1,0 +1,104 @@
+"""Unit tests for app/ingest/parsers.parse_income_security（issue #11 回归）。
+
+覆盖：
+- 面值含小数点（如 4,047.30 BEF）能被正确解析
+- 每券记录字段完整
+- country 节存在但无任何 `### N.` 行 → warning 进 ingest_report
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.ingest.parsers import parse_income_security
+
+
+def _write(tmp: Path, name: str, content: str) -> Path:
+    p = tmp / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestParseIncomeSecurityFaceValue:
+    def test_integer_face_value(self, tmp_path):
+        # issue #11 之前 OK 的情况仍要保留
+        p = _write(tmp_path, "祖产股票债券收益.md", (
+            "## 比利时债券\n\n"
+            "### 1. 比利时国债A（面值 1,000 BEF，固定票息 4.5%)\n"
+        ))
+        recs, warns = parse_income_security(p)
+        assert len(recs) == 1
+        assert recs[0]["face_value"] == 1000.0
+        assert recs[0]["currency"] == "BEF"
+        assert recs[0]["rate_pct"] == 4.5
+        assert warns == []
+
+    def test_decimal_face_value(self, tmp_path):
+        """issue #11 修复重点：面值 4,047.30 BEF 此前因正则不含小数点而整条丢失。"""
+        p = _write(tmp_path, "祖产股票债券收益.md", (
+            "## 比利时债券\n\n"
+            "### 1. 比利时国债A（面值 4,047.30 BEF，固定票息 4.5%)\n"
+        ))
+        recs, warns = parse_income_security(p)
+        assert len(recs) == 1, f"面值带小数必须命中；recs={recs}, warns={warns}"
+        assert recs[0]["face_value"] == 4047.30
+        assert recs[0]["currency"] == "BEF"
+
+    def test_decimal_face_value_multiple_bonds(self, tmp_path):
+        p = _write(tmp_path, "祖产股票债券收益.md", (
+            "## 荷兰债券\n\n"
+            "### 1. 荷兰国债A（面值 1,234.56 NLG，固定票息 3.5%)\n"
+            "### 2. 荷兰国债B（面值 7,890.12 NLG，固定票息 4.0%)\n"
+        ))
+        recs, warns = parse_income_security(p)
+        assert len(recs) == 2
+        assert recs[0]["face_value"] == 1234.56
+        assert recs[1]["face_value"] == 7890.12
+        assert warns == []
+
+
+class TestParseIncomeSecurityWarnings:
+    """issue #11：country 已设但无任何记录 → warning 进 ingest_report。"""
+
+    def test_country_section_with_no_records_warns(self, tmp_path):
+        p = _write(tmp_path, "祖产股票债券收益.md", (
+            "## 比利时债券\n\n"
+            "（这一节没有任何 ### N. 行）\n"
+            "\n"
+            "## 荷兰债券\n\n"
+            "### 1. 荷兰国债A（面值 1,000 NLG，固定票息 4.0%)\n"
+        ))
+        recs, warns = parse_income_security(p)
+        assert len(recs) == 1                           # 荷兰仍正常产出
+        assert any("比利时" in w for w in warns), warns
+
+    def test_country_section_with_records_no_warn(self, tmp_path):
+        p = _write(tmp_path, "祖产股票债券收益.md", (
+            "## 丹麦债券\n\n"
+            "### 1. 丹麦国债（面值 1,000.00 DKK，固定票息 3.5%)\n"
+        ))
+        recs, warns = parse_income_security(p)
+        assert len(recs) == 1
+        assert warns == []
+
+
+class TestParseIncomeSecurityHolder:
+    """country → holder 映射（铁律）。"""
+
+    @pytest.mark.parametrize("country,expected_holder,expected_cur", [
+        ("荷兰", "养外祖父", "NLG"),
+        ("丹麦", "养外祖母", "DKK"),
+        ("瑞典", "养祖母", "SEK"),
+        ("比利时", "养祖父", "BEF"),
+        ("卢森堡", "养祖父", "LUF"),
+    ])
+    def test_country_holder_mapping(self, tmp_path, country, expected_holder, expected_cur):
+        p = _write(tmp_path, "祖产股票债券收益.md", (
+            f"## {country}债券\n\n"
+            f"### 1. 测试券（面值 1,000 {expected_cur}，固定票息 4.0%)\n"
+        ))
+        recs, _ = parse_income_security(p)
+        assert len(recs) == 1
+        assert recs[0]["holder"] == expected_holder
+        assert recs[0]["currency"] == expected_cur


### PR DESCRIPTION
## 修复内容
`app/ingest/parsers.py:410` 面值正则 `([\d,]+)` 不含小数点，导致「面值 4,047.30 BEF」整条静默丢失。

## 影响
- 初始资产/祖产债券建档缺失
- 票息收入少计
- 快照与财富曲线偏低且难以察觉

## 修复
- 正则放宽为 `[\d,.]+`，支持带千分位+小数的面额
- `parse_income_security` 返回 `(records, warnings)`；country 已设但无任何 `### N.` 行时进 warnings
- `ParseResult` 新增 `warnings` 字段；`IngestReport.warnings` 聚合 `(file, warning)`
- `main.py run` 命令统一打印告警

## 验证
\`\`\`
.venv/bin/python -m pytest tests/ -v
============================== 36 passed in 0.03s ==============================
\`\`\`

Closes #11