### PR TITLE
fix(ingest): bank 台账落库主链路打通 + 持有人解析 + kind 推断 (issue #9)

### DIFF
--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -70,7 +70,7 @@ def ingest(
     cfg = get_config(env)
     with _session_for(env) as s:
         rep = run_ingest(cfg.source_dir)
-        ck = 0; ia = {"asset": 0, "cash": 0}; sec = 0; rent = 0; prop = 0; shop = 0; sal = 0; he = 0; rcur = 0; fx_total = 0; tl_n = 0; blocked_files = 0
+        ck = 0; ia = {"asset": 0, "cash": 0}; sec = 0; rent = 0; prop = 0; shop = 0; sal = 0; he = 0; rcur = 0; fx_total = 0; tl_n = 0; bank_n = 0; bank_seg_skip = 0; blocked_files = 0
         fx_files = []
         for r in rep.ok:
             if r.category == "character" and r.records:
@@ -81,6 +81,18 @@ def ingest(
                 fx_files.append(r)        # 收集，权威优先 + 冲突检测在下方统一处理
             if r.category == "timeline" and r.records:
                 tl_n += writer.import_timeline(s, r.records)["n"]
+            if r.category == "bank" and r.records:
+                # issue #9：银行台账幂等（同 source_file 已导入 → 跳过）
+                src = r.file
+                from sqlalchemy import select as _sel_b
+                from app.model import LedgerEntry as _LE
+                already = s.execute(
+                    _sel_b(_LE.id).where(_LE.source_file == src).limit(1)
+                ).scalar_one_or_none()
+                if already is not None:
+                    continue
+                st = writer.import_bank(s, r.records, source_file=src)
+                bank_n += st["ledger"]; bank_seg_skip += st["skipped"]
             if r.category == "initial_asset" and r.records:
                 st = writer.import_initial_assets(s, r.records)
                 ia["asset"] += st["asset"]; ia["cash"] += st["cash"]
@@ -116,7 +128,7 @@ def ingest(
         closed = writer.close_2002_currency(s)["closed"]
         s.flush()
         s.commit()
-        typer.echo(f"[{cfg.env}] 落库完成：人物 {ck}、初始资产 {ia['asset']}、现金 {ia['cash']}、票息 {sec}、租房 {rent}、经营房 {prop}、开店 {shop}、薪资 {sal}、家庭支出 {he}、收益曲线 {rcur}、汇率 {fx_total}、时间线 {tl_n}、2002关池 {closed}、冲突拦截 {blocked_files}")
+        typer.echo(f"[{cfg.env}] 落库完成：人物 {ck}、初始资产 {ia['asset']}、现金 {ia['cash']}、票息 {sec}、租房 {rent}、经营房 {prop}、开店 {shop}、薪资 {sal}、家庭支出 {he}、收益曲线 {rcur}、汇率 {fx_total}、时间线 {tl_n}、银行流水 {bank_n}（seg 跳过 {bank_seg_skip}）、2002关池 {closed}、冲突拦截 {blocked_files}")
 
 
 @app.command()

--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -562,21 +562,67 @@ def parse_household_expense(path: Path) -> list[dict]:
 
 
 # ---------------- bank（银行台账） ----------------
+_BANK_HOLDER_HINTS = (
+    "Henri Peeters", "Joren Peeters", "Johanna Peeters",
+    "祖父", "祖母", "外祖父", "外祖母", "养父", "养母",
+)
+
+
+def _extract_holder_from_title(title: str, fallback: str | None = None) -> str | None:
+    """从节标题 / 文件名抽持有人**规范化 entity.name**（issue #9：补 entity 归属）。
+
+    命中后通过 TITLE_ENTITY 映射回规范 entity.name（如「祖父」→「Henri Peeters」、
+    「外祖父」→「Frederik van Oranje」），确保 account 唯一键一致。
+    """
+    from app.ingest.holders import TITLE_ENTITY
+    # 精确命中
+    if title in TITLE_ENTITY:
+        return TITLE_ENTITY[title]
+    # 子串命中：按长度倒序避免「祖父」误吞「外祖父」（更长的 key 先匹配）
+    for k in sorted(TITLE_ENTITY.keys(), key=len, reverse=True):
+        if k in title:
+            return TITLE_ENTITY[k]
+    # fallback 也走规范映射（如 filename="祖父" → "Henri Peeters"）
+    if fallback is not None:
+        return TITLE_ENTITY.get(fallback, fallback)
+    return None
+
+
+def _extract_bank_name_from_header(lines: list[str]) -> str | None:
+    """从文件头部注释行抽开户行（如 `# 开户行：德意志银行`）。"""
+    for line in lines[:20]:
+        m = re.search(r"开户行[：:]\s*(.+)", line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
 def parse_bank(path: Path) -> list[dict]:
-    """`## 一、…BEF（祖父）` 分币种节 + 流水表 `日期|理由|收入|支出|余额|备注`。"""
+    """`## 一、…BEF（祖父）` 分币种节 + 流水表 `日期|理由|收入|支出|余额|备注`。
+
+    返回：每节 dict（含 seg_title / currency / holder / bank / rows）；rows 中每条流水含
+    date / reason / inflow / outflow / balance / note。
+
+    issue #9：补持有人解析（节标题「BEF（祖父Henri Peeters注入）」→ 祖父；文件 stem
+    `祖父.md` → 祖父；最终回退 holder_entity_name）；补开户行从头部注释抽取。
+    """
+    from app.ingest.holders import holder_entity_name
     lines = _lines(path)
     out: list[dict] = []
     cur_seg: dict | None = None
+    file_holder = holder_entity_name(path.stem)        # 文件名兜底
+    bank_name = _extract_bank_name_from_header(lines)
     i = 0
-    header = ("日期", "理由", "收入", "支出")
     while i < len(lines):
         line = lines[i]
         hm = re.match(r"^##+\s*(.+)$", line.strip())
         if hm:
             title = hm.group(1)
             cur = currency_from(title)
+            seg_holder = _extract_holder_from_title(title, fallback=file_holder)
             cur = cur or (cur_seg["currency"] if cur_seg else None)
-            cur_seg = {"seg_title": title, "currency": cur, "rows": []}
+            cur_seg = {"seg_title": title, "currency": cur,
+                       "holder": seg_holder, "bank": bank_name, "rows": []}
             out.append(cur_seg)
         else:
             cells = _split_table_row(line)

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -6,7 +6,7 @@
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -272,6 +272,78 @@ def import_household_expense(session: Session, records: list[dict]) -> dict:
             source_file=rec.get("source_file"),
         ))
         stats["n"] += 1
+    return stats
+
+
+def _ledger_kind_from_reason(reason: str, *, is_inflow: bool) -> str:
+    """从「理由」文本推断 ledger kind（DESIGN §5.2 ledger_entry.kind）。"""
+    r = (reason or "").strip()
+    if not r:
+        return "income" if is_inflow else "expense"
+    # 投资类收益 → investment_income
+    if any(k in r for k in ("证券收入", "票息", "分红", "杠杆投资", "净值", "投资收入")):
+        return "investment_income"
+    # 划拨/注资/转入 → 仍是 income
+    if any(k in r for k in ("划拨", "注资", "转入", "转入", "增资")):
+        return "income"
+    # 支出/费用 → expense
+    if any(k in r for k in ("支出", "费用", "成本", "用工", "外包")):
+        return "expense"
+    return "income" if is_inflow else "expense"
+
+
+def import_bank(session: Session, segments: list[dict], source_file: str | None = None) -> dict:
+    """银行台账：每个 segment 一个 account(entity,currency,bank)，逐行写 ledger_entry。
+
+    - 缺 entity 归属（holder=None）→ 该 segment 跳过并计入 skipped；不静默丢
+    - 缺 currency → 该 segment 跳过
+    - 同行 inflow/outflow 都为 None → 跳过该行
+    - 余额缺失 → 存 None（重算时按 inflow-outflow 推进）
+
+    返回 {ledger: 行数, account: 账户数, skipped: 跳过 segment 数}
+    """
+    stats: dict[str, int] = {"ledger": 0, "account": 0, "skipped": 0}
+    for seg in segments:
+        holder = seg.get("holder")
+        cur = seg.get("currency")
+        bank = seg.get("bank")
+        rows = seg.get("rows") or []
+        if not holder:
+            stats["skipped"] += 1
+            continue
+        if not cur:
+            stats["skipped"] += 1
+            continue
+        # entity + account（唯一键：entity × currency × bank）
+        ent = upsert_entity(session, "person", holder)
+        acc = session.execute(
+            select(Account).where(
+                Account.entity_id == ent.id, Account.currency == cur, Account.bank == bank)
+        ).scalar_one_or_none()
+        if acc is None:
+            acc = Account(entity_id=ent.id, currency=cur, bank=bank)
+            session.add(acc)
+            session.flush()
+            stats["account"] += 1
+        for row in rows:
+            inflow = row.get("inflow")
+            outflow = row.get("outflow")
+            if inflow is None and outflow is None:
+                continue
+            dt = row.get("date")
+            try:
+                d = datetime.fromisoformat((dt or "").replace("/", "-").replace("－", "-"))
+            except (TypeError, ValueError):
+                continue
+            kind = _ledger_kind_from_reason(row.get("reason", ""),
+                                            is_inflow=(inflow or 0) > 0)
+            session.add(LedgerEntry(
+                account_id=acc.id, date=d, reason=row.get("reason"),
+                inflow=inflow, outflow=outflow, balance=row.get("balance"),
+                kind=kind, note=row.get("note"),
+                source_file=source_file,
+            ))
+            stats["ledger"] += 1
     return stats
 
 

--- a/tests/test_bank_parser.py
+++ b/tests/test_bank_parser.py
@@ -1,0 +1,157 @@
+"""Unit tests for app/ingest/parsers.parse_bank + writer._ledger_kind_from_reason（issue #9 回归）。
+
+覆盖：
+- 节标题含「祖父」→ holder 解析
+- 文件名（path.stem）兜底解析
+- 多币种节（每个 segment 独立 currency/holder）
+- kind 推断（inflow=投资收入 → investment_income；划拨 → income；支出 → expense）
+- 缺 entity/缺 currency 的 segment 跳过
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.ingest.parsers import parse_bank, _extract_holder_from_title, _extract_bank_name_from_header
+from app.ingest.writer import _ledger_kind_from_reason
+
+
+def _write(tmp: Path, name: str, content: str) -> Path:
+    p = tmp / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestExtractHolderFromTitle:
+    """返回规范 entity.name（TITLE_ENTITY 映射后），确保 account 唯一键一致。"""
+
+    def test_exact_match(self):
+        # 祖父 → 规范名 Henri Peeters
+        assert _extract_holder_from_title("祖父") == "Henri Peeters"
+
+    def test_substring_match(self):
+        # 「祖父Henri Peeters注入」：长度倒序先命中 Henri Peeters（更长 key）
+        assert _extract_holder_from_title("祖父Henri Peeters注入") == "Henri Peeters"
+
+    def test_henri_peeters(self):
+        assert _extract_holder_from_title("Henri Peeters 注入") == "Henri Peeters"
+
+    def test_longer_key_wins(self):
+        # 「外祖父」不能误吞「祖父」（外祖父更长 → 先命中）
+        assert _extract_holder_from_title("外祖父 投资") == "Frederik van Oranje"
+
+    def test_fallback_normalized(self):
+        # fallback 也会按 TITLE_ENTITY 规范
+        assert _extract_holder_from_title("随机标题", fallback="祖父") == "Henri Peeters"
+
+    def test_no_match_no_fallback(self):
+        assert _extract_holder_from_title("随机标题") is None
+
+
+class TestExtractBankNameFromHeader:
+    def test_basic(self, tmp_path):
+        p = _write(tmp_path, "x.md", "# 账户\n# 开户行：德意志银行\n\n内容")
+        assert _extract_bank_name_from_header(p.read_text(encoding="utf-8").splitlines()) == "德意志银行"
+
+    def test_no_header(self, tmp_path):
+        p = _write(tmp_path, "x.md", "# 账户\n# 无开户行\n\n内容")
+        assert _extract_bank_name_from_header(p.read_text(encoding="utf-8").splitlines()) is None
+
+
+class TestParseBankHolderResolution:
+    """issue #9 修复重点：补持有人解析（标题 → 文件名兜底）。"""
+
+    def test_holder_from_section_title(self, tmp_path):
+        p = _write(tmp_path, "祖父.md", (
+            "## 一、比利时法郎 BEF（祖父Henri Peeters注入）\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1982-01-01 | 祖父现金投资划拨 | 348.03 | | 348.03 | |\n"
+        ))
+        segs = parse_bank(p)
+        assert len(segs) == 1
+        # 祖父 → 规范名 Henri Peeters
+        assert segs[0]["holder"] == "Henri Peeters"
+        assert segs[0]["currency"] == "BEF"
+        assert len(segs[0]["rows"]) == 1
+
+    def test_holder_from_file_stem_fallback(self, tmp_path):
+        # 节标题不含持有人，但 path.stem = "外祖父" → 通过 holders.py 兜底（规范化为 Frederik van Oranje）
+        p = _write(tmp_path, "外祖父.md", (
+            "## 一、荷兰盾 NLG\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1980-01-01 | 投资划拨 | 100 | | | |\n"
+        ))
+        segs = parse_bank(p)
+        assert segs[0]["holder"] == "Frederik van Oranje"
+        assert segs[0]["currency"] == "NLG"
+
+    def test_multiple_segments(self, tmp_path):
+        p = _write(tmp_path, "祖父.md", (
+            "## 一、比利时法郎 BEF（祖父）\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1982-01-01 | 划拨 | 100 | | 100 | |\n"
+            "\n"
+            "## 二、卢森堡法郎 LUF（祖父）\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1982-01-01 | 划拨 | 50 | | 50 | |\n"
+        ))
+        segs = parse_bank(p)
+        assert len(segs) == 2
+        assert segs[0]["currency"] == "BEF"
+        assert segs[1]["currency"] == "LUF"
+        # 全部规范化为 Henri Peeters
+        assert all(s["holder"] == "Henri Peeters" for s in segs)
+
+    def test_bank_name_from_header(self, tmp_path):
+        p = _write(tmp_path, "祖父.md", (
+            "# 开户行：德意志银行\n\n"
+            "## 一、比利时法郎 BEF（祖父）\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1982-01-01 | 划拨 | 100 | | 100 | |\n"
+        ))
+        segs = parse_bank(p)
+        assert segs[0]["bank"] == "德意志银行"
+
+    def test_no_holder_no_currency_segment_kept_but_holder_none(self, tmp_path):
+        p = _write(tmp_path, "随机.md", (
+            "## 一、某节标题\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1982-01-01 | 划拨 | 100 | | 100 | |\n"
+        ))
+        segs = parse_bank(p)
+        # holder 解析失败 + 无兜底 → None（writer 会跳）
+        assert segs[0]["holder"] is None
+
+
+class TestLedgerKindFromReason:
+    """issue #9：从「理由」推断 ledger.kind。"""
+
+    def test_inflow_default(self):
+        assert _ledger_kind_from_reason("", is_inflow=True) == "income"
+
+    def test_outflow_default(self):
+        assert _ledger_kind_from_reason("", is_inflow=False) == "expense"
+
+    def test_securities_income(self):
+        assert _ledger_kind_from_reason("证券收入×12月", is_inflow=True) == "investment_income"
+
+    def test_leveraged_investment(self):
+        assert _ledger_kind_from_reason("杠杆投资收益R5", is_inflow=True) == "investment_income"
+
+    def test_capital_injection(self):
+        assert _ledger_kind_from_reason("祖父现金投资划拨", is_inflow=True) == "income"
+
+    def test_nlg_transfer(self):
+        # 「资金转入」不在 income 子串里 → 走默认 income
+        assert _ledger_kind_from_reason("NLG资金转入", is_inflow=True) == "income"
+
+    def test_operating_expense(self):
+        assert _ledger_kind_from_reason("运营支出（用工+外包服务）", is_inflow=False) == "expense"
+
+    def test_property_income(self):
+        assert _ledger_kind_from_reason("温泉庄园净值×12月", is_inflow=True) == "investment_income"


### PR DESCRIPTION
## 修复内容
DESIGN §5.2/§6.3 要求 bank 解析后必须落 `ledger_entry`，但：
- `writer.py` 无 `import_bank` 函数
- `main.py ingest` 无 `bank` 分发
- `parse_bank` 不抽持有人（节标题/文件名），产出记录无 entity 归属

## 修复
- `parse_bank` 新增 `_extract_holder_from_title`：节标题「BEF（祖父Henri Peeters注入）」通过 `TITLE_ENTITY` 映射回规范 entity.name（如「祖父」→「Henri Peeters」），filename 兜底也走规范映射；按长度倒序避免「祖父」误吞「外祖父」
- `parse_bank` 新增 `_extract_bank_name_from_header`：抽头部注释「# 开户行：德意志银行」
- `writer.import_bank`：建/取 `account(entity,currency,bank)` → 逐行写 `ledger_entry`，从 `reason` 推断 `kind`（投资类 → `investment_income` / 划拨 → `income` / 支出 → `expense`），缺 entity/缺 currency 的 segment 不静默丢、计入 `skipped`
- `writer._ledger_kind_from_reason`：reason → kind 推断
- `main.py ingest` 新增 `bank` 分发 + 同 `source_file` 幂等 + 落库汇总「银行流水 N」

## 验证
\`\`\`
.venv/bin/python -m pytest tests/
============================== 62 passed in 0.20s ==============================
\`\`\`

## 数据现状
当前 `Design_Folder/经济/银行/个人/` 与 `公司/` 均为空目录，待源数据填充后完整 ingest 链路可见；本 PR 把链路全部铺好。

Closes #9