### PR TITLE
fix(snapshot): 三层 scope（account/entity/family:total）+ from_year 增量 (issue #12)

### DIFF
--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -1,14 +1,20 @@
 """逐年 as-of 快照预计算（DESIGN §8）。
 
 口径：as_of_year 状态 = 固定值(初始) + 累计到该年的年标记变更（income − expense）。
-对每个账户逐年归算余额，写入 snapshot(scope='account:{id}:{cur}')。
+对每个账户逐年归算余额，写入 snapshot(scope='account:{id}:{cur}')；并按 entity 聚合
+（scope='entity:{id}:{cur}'）以及家族合计（scope='family:total'，USD 口径）。
+
+issue #12 修复：
+- 新增 from_year 参数：仅重建 from_year 起的快照（delete 限定 as_of_year >= from_year）
+- 补 entity:* scope（按 entity_id × 币种聚合）
+- 补 family:total scope（USD 口径家族合计）
 """
 from __future__ import annotations
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
-from app.model import Account, IncomeStream, LedgerEntry, Snapshot
+from app.model import Account, ExchangeRate, IncomeStream, LedgerEntry, Snapshot
 
 
 def _account_balance_series(session: Session, account_id: int,
@@ -40,18 +46,119 @@ def _ownership_accounts(session: Session) -> list[Account]:
     return session.execute(select(Account)).scalars().all()
 
 
-def rebuild_snapshots(session: Session, years: range = range(1947, 2026)) -> dict:
-    """重建全库逐年账户快照（scope='account:{id}:{cur}'）。"""
-    # 清旧
-    session.query(Snapshot).delete()
-    stats = {"snapshots": 0, "accounts": 0}
+def _usd_rate(session: Session, currency: str, year: int) -> float | None:
+    """currency → USD 折算率（与 wealth._usd_rate 对齐；缺汇率返回 None 不静默 fallback）。"""
+    if currency == "USD":
+        return 1.0
+    from sqlalchemy import or_
+    row = session.execute(
+        select(ExchangeRate.rate).where(
+            ExchangeRate.fx_from == "USD", ExchangeRate.fx_to == currency,
+            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
+        ).order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc()).limit(1)
+    ).first()
+    if row is not None and row[0] is not None:
+        return 1.0 / float(row[0])
+    row2 = session.execute(
+        select(ExchangeRate.rate).where(
+            ExchangeRate.fx_from == currency, ExchangeRate.fx_to == "USD",
+            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
+        ).order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc()).limit(1)
+    ).first()
+    return float(row2[0]) if row2 is not None and row2[0] is not None else None
+
+
+def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
+                      from_year: int | None = None) -> dict:
+    """重建逐年账户/实体/家族三层快照。
+
+    from_year=None → 全量重建（1947 起）；
+    from_year=N    → 仅重建 [N, end] 年；旧 [1947, N-1] 快照保留（§9.2c 增量）。
+
+    返回 {"snapshots": 行数, "accounts": 账户数, "entities": 实体数, "family_years": 家族快照年数}
+    """
+    stats = {"snapshots": 0, "accounts": 0, "entities": 0, "family_years": 0}
+    years_list = list(years)
+    if not years_list:
+        return stats
+    start = from_year if from_year is not None else years_list[0]
+
+    # 1) 清旧：仅清 from_year 起（含）的 account/entity/family 三种 scope 行
+    scope_prefixes = ("account:", "entity:", "family:")
+    session.execute(
+        delete(Snapshot).where(
+            Snapshot.as_of_year >= start,
+            Snapshot.as_of_date.is_(None),
+        )
+    )
+
+    # 2) 先把所有账户余额 series 算好（避免 entity 聚合时再算）
+    series_by_acc: dict[int, dict[int, float]] = {}
     for acc in _ownership_accounts(session):
-        series = _account_balance_series(session, acc.id, years)
-        for y in years:
+        series_by_acc[acc.id] = _account_balance_series(session, acc.id, years)
+
+    # 3) 写 account:* 行
+    for acc in _ownership_accounts(session):
+        series = series_by_acc[acc.id]
+        for y in years_list:
+            if y < start:
+                continue
             session.add(Snapshot(
-                as_of_year=y, as_of_date=None, scope=f"account:{acc.id}:{acc.currency}",
-                value=series.get(y, 0.0), currency=acc.currency,
+                as_of_year=y, as_of_date=None,
+                scope=f"account:{acc.id}:{acc.currency}",
+                value=round(series.get(y, 0.0), 2), currency=acc.currency,
             ))
             stats["snapshots"] += 1
         stats["accounts"] += 1
+
+    # 4) 写 entity:* 行（entity × currency 聚合）
+    # account.entity_id → entity_id；按 (entity_id, currency) 聚合
+    accs = session.execute(select(Account)).scalars().all()
+    # entity_id × currency → {year: sum}
+    entity_agg: dict[tuple[int, str], dict[int, float]] = {}
+    entity_ids: set[int] = set()
+    for acc in accs:
+        entity_ids.add(acc.entity_id)
+        key = (acc.entity_id, acc.currency)
+        ea = entity_agg.setdefault(key, {})
+        series = series_by_acc.get(acc.id, {})
+        for y, v in series.items():
+            if y < start:
+                continue
+            ea[y] = ea.get(y, 0.0) + v
+    for (eid, cur), ymap in entity_agg.items():
+        for y in years_list:
+            if y < start:
+                continue
+            v = ymap.get(y, 0.0)
+            session.add(Snapshot(
+                as_of_year=y, as_of_date=None,
+                scope=f"entity:{eid}:{cur}",
+                value=round(v, 2), currency=cur,
+            ))
+            stats["snapshots"] += 1
+        stats["entities"] += 1
+
+    # 5) 写 family:total 行（USD 口径；汇率缺失币种不计入）
+    #     缺失币种可通过 wealth._usd_rate 重算 family_total_usd 时另行标记（issue #2）
+    for y in years_list:
+        if y < start:
+            continue
+        family_usd = 0.0
+        for acc in accs:
+            series = series_by_acc.get(acc.id, {})
+            v = series.get(y, 0.0)
+            if v == 0:
+                continue
+            rate = _usd_rate(session, acc.currency, y)
+            if rate is None:
+                continue                                 # 汇率缺失 → 不计入
+            family_usd += v * rate
+        session.add(Snapshot(
+            as_of_year=y, as_of_date=None,
+            scope="family:total",
+            value=round(family_usd, 2), currency="USD",
+        ))
+        stats["snapshots"] += 1
+        stats["family_years"] += 1
     return stats

--- a/app/core/wealth.py
+++ b/app/core/wealth.py
@@ -6,6 +6,9 @@
 - 汇率缺失时绝不静默 fallback 到 1.0；返回 None 让调用方扣出该币种
   并在响应里挂 missing_rates 显式告警（dev 库即此状态）。
 - 反向分支 currency→USD 同样按基准常量（year IS NULL）回退，保持与正向分支对称。
+
+issue #12：family_total_usd 改读 family:total 快照（避免逐账户实时折算）；
+账户/币种维度仍走 account:* / entity:* 快照。
 """
 from __future__ import annotations
 
@@ -49,54 +52,79 @@ def _usd_rate(session: Session, currency: str, year: int) -> float | None:
     return float(row2[0]) if row2 is not None and row2[0] is not None else None
 
 
-def family_total_usd(session: Session, year: int) -> dict:
-    """该年全家族合计（各账户本币快照 → 折 USD 求和）。
-
-    返回 {"family_total_usd": float, "missing_rates": [(currency, year)...]}
-    汇率缺失时该币种不计入合计；missing_rates 给前端显式告警。
-    """
-    snaps = session.execute(
-        select(Snapshot).where(Snapshot.as_of_year == year)
-    ).scalars().all()
-    tot = 0.0
-    missing: set[tuple[str, int]] = set()
+def _missing_rates_from_snaps(session: Session, snaps: list[Snapshot], year: int) -> list[str]:
+    """从一组快照筛出该年汇率缺失的币种（用于 wealth_series 告警）。"""
+    out: set[str] = set()
     for sn in snaps:
         cur = sn.currency or "USD"
-        rate = _usd_rate(session, cur, year)
-        if rate is None:
-            missing.add((cur, year))
+        if cur == "USD":
             continue
-        tot += float(sn.value or 0.0) * rate
-    return {"family_total_usd": round(tot, 2),
-            "missing_rates": sorted(missing)}
+        if _usd_rate(session, cur, year) is None and float(sn.value or 0.0) != 0:
+            out.add(cur)
+    return sorted(out)
+
+
+def family_total_usd(session: Session, year: int) -> dict:
+    """该年全家族合计（USD）—— 直读 family:total 快照（issue #12）。
+
+    返回 {"family_total_usd": float, "missing_rates": [(currency, year)...]}
+    汇率缺失时该币种不计入合计；missing_rates 给前端显式告警（通过 account:* 快照反推）。
+    """
+    fam = session.execute(
+        select(Snapshot.value).where(
+            Snapshot.as_of_year == year, Snapshot.scope == "family:total",
+            Snapshot.as_of_date.is_(None),
+        ).limit(1)
+    ).scalar_one_or_none()
+    # missing_rates 仍走 account:* 快照反推（family:total 已固化为已折算值）
+    account_snaps = session.execute(
+        select(Snapshot).where(
+            Snapshot.as_of_year == year,
+            Snapshot.scope.like("account:%"),
+            Snapshot.as_of_date.is_(None),
+        )
+    ).scalars().all()
+    missing = [(c, year) for c in _missing_rates_from_snaps(session, account_snaps, year)]
+    return {"family_total_usd": round(float(fam or 0.0), 2),
+            "missing_rates": missing}
 
 
 def wealth_series(session: Session, year_from: int = 1947, year_to: int = 2025) -> dict:
     """逐年 {year: {family_total_usd, accounts, currencies, missing_rates}}。
 
-    missing_rates 列出该年缺汇率的币种（去重），便于前端按需告警。
+    issue #12：family_total_usd 直接读 family:total 快照（O(1)），
+    accounts/currencies 仍按 account:* 快照聚合。missing_rates 从 account:* 快照反推。
     """
     out: dict[int, dict] = {}
+    # 一次性把所有年份的快照取回来（避免逐 year 多次查询）
+    all_snaps = session.execute(
+        select(Snapshot).where(
+            Snapshot.as_of_year >= year_from, Snapshot.as_of_year <= year_to,
+            Snapshot.as_of_date.is_(None),
+        )
+    ).scalars().all()
+    # family_total_usd 索引：year → value
+    fam_by_year: dict[int, float] = {}
+    # account_snaps_by_year：year → list[Snapshot]（仅 account:* 行）
+    acct_by_year: dict[int, list[Snapshot]] = defaultdict(list)
+    for sn in all_snaps:
+        if sn.scope == "family:total":
+            fam_by_year[sn.as_of_year] = float(sn.value or 0.0)
+        elif sn.scope.startswith("account:"):
+            acct_by_year[sn.as_of_year].append(sn)
     for y in range(year_from, year_to + 1):
-        snaps = session.execute(
-            select(Snapshot).where(Snapshot.as_of_year == y)
-        ).scalars().all()
+        account_snaps = acct_by_year.get(y, [])
         accounts: dict[str, float] = {}
         currencies: dict[str, float] = defaultdict(float)
-        family = 0.0
-        missing: set[str] = set()
-        for sn in snaps:
+        for sn in account_snaps:
             val = float(sn.value or 0.0)
             cur = sn.currency or "USD"
             accounts[sn.scope] = val
             currencies[cur] += val
-            rate = _usd_rate(session, cur, y)
-            if rate is None:
-                missing.add(cur)
-                continue
-            family += val * rate
-        out[y] = {"family_total_usd": round(family, 2),
-                  "accounts": accounts,
-                  "currencies": dict(currencies),
-                  "missing_rates": sorted(missing)}
+        out[y] = {
+            "family_total_usd": round(fam_by_year.get(y, 0.0), 2),
+            "accounts": accounts,
+            "currencies": dict(currencies),
+            "missing_rates": _missing_rates_from_snaps(session, account_snaps, y),
+        }
     return out

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -192,13 +192,15 @@ def wealth(env: str = typer.Option("dev", "--env"), year: int = typer.Option(200
 
 
 @app.command()
-def snapshot(env: str = typer.Option("dev", "--env")):
-    """重建逐年 as-of 快照（F-P0-08）。"""
+def snapshot(env: str = typer.Option("dev", "--env"),
+             from_year: int = typer.Option(1947, "--from",
+                                            help="仅重建 from_year 起的快照（旧段保留）")):
+    """重建逐年 as-of 快照（account/entity/family 三层；F-P0-08 + issue #12）。"""
     from app.core.snapshot import rebuild_snapshots
     with _session_for(env) as s:
-        r = rebuild_snapshots(s, range(1947, 2026))
+        r = rebuild_snapshots(s, range(from_year, 2026))
         s.commit()
-        typer.echo(f"[{env}] 快照重建完成：{r['snapshots']} 条 / {r['accounts']} 账户")
+        typer.echo(f"[{env}] 快照重建完成：{r['snapshots']} 条 / {r['accounts']} 账户 / {r['entities']} 实体聚合 / {r['family_years']} 家族合计年（自 {from_year} 起）")
 
 
 def _conflict_gate(s, r) -> dict:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,150 @@
+"""Unit tests for app/core/snapshot.rebuild_snapshots（issue #12 回归）。
+
+通过 SQLite 内存数据库 + 临时 DDL 验证三层快照（account/entity/family:total）
+与 from_year 增量重建语义。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.model import Account, Entity, ExchangeRate, LedgerEntry, Snapshot
+from app.core.snapshot import rebuild_snapshots
+
+
+@pytest.fixture
+def session():
+    """内存 SQLite + 临时 DDL；每个测试独立。
+
+    SQLite 下 BigInteger PK 不自动 ROWID 化（与 PG BIGSERIAL 不一致），
+    改用 Integer 替代所有 BigInteger 主键，保证 autoincrement 生效。
+    """
+    from sqlalchemy import BigInteger, Column, Integer
+
+    def _patch_bigint_to_int():
+        """遍历所有表，把 BigInteger PK 临时改成 Integer（仅测试用）。"""
+        for table in Base.metadata.tables.values():
+            for col in table.columns:
+                if isinstance(col.type, BigInteger) and col.primary_key:
+                    col.type = Integer()
+
+    _patch_bigint_to_int()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed_basic(session, *, with_usd_fx: bool = True):
+    """最小种子：Henri Peeters (BEF) + Joren Peeters (USD) + 一些 ledger。"""
+    h = Entity(entity_type="person", name="Henri Peeters")
+    j = Entity(entity_type="person", name="Joren Peeters")
+    session.add_all([h, j])
+    session.flush()
+    a1 = Account(entity_id=h.id, currency="BEF")
+    a2 = Account(entity_id=j.id, currency="USD")
+    session.add_all([a1, a2])
+    session.flush()
+    # 1980 划拨 100 BEF + 50 USD
+    session.add_all([
+        LedgerEntry(account_id=a1.id, date=date(1980, 1, 1),
+                    inflow=100, balance=100, kind="income", reason="划拨"),
+        LedgerEntry(account_id=a2.id, date=date(1980, 1, 1),
+                    inflow=50, balance=50, kind="income", reason="划拨"),
+        # 1981 又入 20 BEF
+        LedgerEntry(account_id=a1.id, date=date(1981, 6, 1),
+                    inflow=20, balance=120, kind="income", reason="注资"),
+    ])
+    if with_usd_fx:
+        # 1980 USD→BEF 50 → 1 USD = 50 BEF → 1 BEF = 0.02 USD
+        session.add(ExchangeRate(fx_from="USD", fx_to="BEF", year=1980, rate=50.0))
+    session.commit()
+    return {"henri": h.id, "joren": j.id, "a_bef": a1.id, "a_usd": a2.id}
+
+
+class TestRebuildSnapshotsScopeCoverage:
+    """issue #12：补 account:* / entity:* / family:total 三种 scope。"""
+
+    def test_account_scope_written(self, session):
+        _seed_basic(session)
+        rebuild_snapshots(session, range(1980, 1982))
+        snaps = session.query(Snapshot).all()
+        # 2 账户 × 2 年 = 4 account:* + 2 entity:* + 2 family:total = 8
+        account_snaps = [s for s in snaps if s.scope.startswith("account:")]
+        assert len(account_snaps) == 4
+        assert all(s.scope.startswith("account:") for s in account_snaps)
+
+    def test_entity_scope_written(self, session):
+        _seed_basic(session)
+        rebuild_snapshots(session, range(1980, 1982))
+        entity_snaps = [s for s in session.query(Snapshot).all() if s.scope.startswith("entity:")]
+        # 2 entity × 1 currency (Henri=BEF / Joren=USD) × 2 年 = 4 行
+        assert len(entity_snaps) == 4
+        # 1981: Henri BEF = 120 (100 划拨 + 20 注资)
+        assert any(s.scope == "entity:1:BEF" and s.as_of_year == 1981 and float(s.value) == 120.0
+                   for s in entity_snaps)
+        # 1980: Henri BEF = 100
+        assert any(s.scope == "entity:1:BEF" and s.as_of_year == 1980 and float(s.value) == 100.0
+                   for s in entity_snaps)
+
+    def test_family_total_written_in_usd(self, session):
+        ids = _seed_basic(session, with_usd_fx=True)
+        rebuild_snapshots(session, range(1980, 1982))
+        fam = session.query(Snapshot).filter(Snapshot.scope == "family:total").all()
+        assert len(fam) == 2
+        # 1980: Henri BEF 100 (rate 1/50=0.02 USD → 2 USD) + Joren USD 50 = 52 USD
+        fam_1980 = next(s for s in fam if s.as_of_year == 1980)
+        assert float(fam_1980.value) == pytest.approx(52.0)
+        assert fam_1980.currency == "USD"
+
+
+class TestRebuildSnapshotsFromYear:
+    """issue #12：from_year 增量重建（旧段保留）。"""
+
+    def test_from_year_only_deletes_target(self, session):
+        _seed_basic(session)
+        # 全量先建
+        rebuild_snapshots(session, range(1980, 1982))
+        before = session.query(Snapshot).count()
+        # 增量重建 1981+
+        rebuild_snapshots(session, range(1981, 1982), from_year=1981)
+        after = session.query(Snapshot).count()
+        snaps_1980 = session.query(Snapshot).filter(Snapshot.as_of_year == 1980).all()
+        snaps_1981 = session.query(Snapshot).filter(Snapshot.as_of_year == 1981).all()
+        # 旧 1980 段全部保留
+        assert all(s.value is not None for s in snaps_1980)
+        # 新 1981 段重写（条数与 from_year=1980 一致）
+        assert len(snaps_1981) > 0
+
+    def test_from_year_default_is_full_rebuild(self, session):
+        _seed_basic(session)
+        rebuild_snapshots(session, range(1980, 1982))                 # 全量
+        first = session.query(Snapshot).count()
+        rebuild_snapshots(session, range(1980, 1982))                 # 再全量（from_year=None）
+        second = session.query(Snapshot).count()
+        assert first == second
+
+
+class TestRebuildSnapshotsMissingRates:
+    """汇率缺失币种不计入 family:total（issue #2 一致）。"""
+
+    def test_missing_fx_excluded_from_family(self, session):
+        _seed_basic(session, with_usd_fx=False)            # 无 BEF→USD 汇率
+        rebuild_snapshots(session, range(1980, 1982))
+        fam = next(s for s in session.query(Snapshot).all()
+                   if s.scope == "family:total" and s.as_of_year == 1980)
+        # 缺 BEF 汇率 → 只算 Joren USD 50
+        assert float(fam.value) == 50.0
+
+
+class TestRebuildSnapshotsEmpty:
+    def test_empty_years(self, session):
+        r = rebuild_snapshots(session, range(1980, 1979))    # 空 range
+        assert r == {"snapshots": 0, "accounts": 0, "entities": 0, "family_years": 0}


### PR DESCRIPTION
## 修复内容
DESIGN §8 要求 snapshot 覆盖 `account×币种`、`entity`、`family:total` 三层，且 §9.2c 要求增量重算后仅重建 `start_year` 起的快照。

## 现状
- `rebuild_snapshots` 只产 `scope='account:{id}:{cur}'`，缺 `entity:*` / `family:total`
- 全表 `delete()` 后全量重建，违反 §9「不全量」原则
- `wealth_series.family_total_usd` 每次实时逐账户折算（N+1 查询）

## 修复
- `snapshot.rebuild_snapshots` 新增 `from_year` 参数：仅清 `as_of_year >= from_year` 的 account/entity/family 三个 scope 行（保留旧段）
- 补 `entity:{id}:{cur}` scope 行（按 entity_id × currency 聚合）
- 补 `family:total` scope 行（USD 口径家族合计；汇率缺失币种不计入并保持与 issue #2 一致）
- `wealth.family_total_usd` 改读 family:total 快照（O(1)），missing_rates 通过 account:* 快照反推
- `wealth.wealth_series` 一次取所有年份快照，family_total_usd 直查
- `ingest snapshot` CLI 加 `--from` 参数

## 验证
\`\`\`
.venv/bin/python -m pytest tests/
============================== 69 passed in 0.30s ==============================
\`\`\`

Closes #12