### PR TITLE
fix(recompute): register_job/notification 全工程接线 + 通知 API (issue #13)

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -17,7 +17,7 @@ from app.core.calendar import snapshot_as_of
 from app.core.health import run_report, summarize
 from app.core.wealth import wealth_series
 from app.model import (Account, Entity, ExchangeRate, IncomeStream, LedgerEntry,
-                       ReturnCurve, Snapshot)
+                       Notification, ReturnCurve, Snapshot)
 
 app = FastAPI(title="Novel Dashboard API", version="0.1")
 
@@ -131,6 +131,34 @@ def fx(fx_from: Optional[str] = None, fx_to: Optional[str] = None, db: Session =
         q = q.where(ExchangeRate.fx_to == fx_to)
     rows = db.execute(q).scalars().all()
     return [{"from": r.fx_from, "to": r.fx_to, "year": r.year, "rate": float(r.rate) if r.rate else None} for r in rows]
+
+
+# ---------------- 通知（非阻断提示；DESIGN §9.3；issue #13） ----------------
+@app.get(API_PREFIX + "/notifications")
+def list_notifications(unread_only: bool = True, limit: int = Query(20, le=200),
+                       db: Session = Depends(get_db)):
+    """非阻断提示列表（重算完成/文件更新等）；默认仅未读，按创建倒序。"""
+    from datetime import datetime, timedelta
+    q = select(Notification)
+    if unread_only:
+        q = q.where(Notification.read_at.is_(None))
+    rows = db.execute(q.order_by(Notification.created_at.desc()).limit(limit)).scalars().all()
+    return [{"id": n.id, "job_id": n.job_id, "kind": n.kind, "title": n.title,
+             "message": n.message, "payload": n.payload,
+             "read": n.read_at is not None, "created_at": n.created_at.isoformat() if n.created_at else None}
+            for n in rows]
+
+
+@app.patch(API_PREFIX + "/notifications/{notif_id}")
+def mark_notification_read(notif_id: int, db: Session = Depends(get_db)):
+    """标记通知已读（DESIGN API 表：PATCH /notifications/{id} → {read_at}）。"""
+    from datetime import datetime
+    n = db.get(Notification, notif_id)
+    if not n:
+        raise HTTPException(status_code=404, detail="notification not found")
+    n.read_at = datetime.now()
+    db.commit()
+    return {"id": n.id, "read": True}
 
 
 # ---------------- 总量概览 ----------------

--- a/app/core/recompute.py
+++ b/app/core/recompute.py
@@ -70,3 +70,26 @@ def register_job(session: Session, start_year: int, reason: str, files: Optional
     session.add(job)
     session.flush()
     return int(job.id)
+
+
+def record_recompute_done(session: Session, start_year: int, reason: str = "manual",
+                          files: Optional[list] = None) -> dict:
+    """DESIGN §9.2 步骤 3-4：写 recompute_job(status=done) → 建 recompute-done Notification。
+
+    供 ingest/recompute 成功路径调用，UI 据此弹「全局重算完成」非阻断横幅（§9.3）。
+    返回 {"job_id": int, "notification_id": int}；session.flush 后由外层 commit。
+    """
+    from app.model import Notification
+    from datetime import datetime
+    job_id = register_job(session, start_year, reason, files)
+    notif = Notification(
+        job_id=job_id,
+        kind="recompute-done",
+        title="全局重算完成",
+        message=f"已在全局重算财富与派生数据（自 {start_year} 起）",
+        payload={"start_year": start_year, "files": files or []},
+        created_at=datetime.now(),
+    )
+    session.add(notif)
+    session.flush()
+    return {"job_id": job_id, "notification_id": int(notif.id)}

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -126,9 +126,17 @@ def ingest(
                 continue
             fx_total += writer.import_fx(s, r.records)["n"]
         closed = writer.close_2002_currency(s)["closed"]
+        # —— DESIGN §9 摄入因果链尾巴：增量重算 + 重建快照 + recompute-done 通知（issue #13）——
+        if not blocked_files:
+            from app.core.recompute import recompute_all, record_recompute_done
+            from app.core.snapshot import rebuild_snapshots as _rebuild
+            recompute_all(s, 1947)
+            _rebuild(s, range(1947, 2026), from_year=1947)
+            job = record_recompute_done(s, 1947, reason="ingest")
         s.flush()
         s.commit()
-        typer.echo(f"[{cfg.env}] 落库完成：人物 {ck}、初始资产 {ia['asset']}、现金 {ia['cash']}、票息 {sec}、租房 {rent}、经营房 {prop}、开店 {shop}、薪资 {sal}、家庭支出 {he}、收益曲线 {rcur}、汇率 {fx_total}、时间线 {tl_n}、银行流水 {bank_n}（seg 跳过 {bank_seg_skip}）、2002关池 {closed}、冲突拦截 {blocked_files}")
+        notif_part = f"；recompute job#{job['job_id']} 通知#{job['notification_id']}" if not blocked_files else ""
+        typer.echo(f"[{cfg.env}] 落库完成：人物 {ck}、初始资产 {ia['asset']}、现金 {ia['cash']}、票息 {sec}、租房 {rent}、经营房 {prop}、开店 {shop}、薪资 {sal}、家庭支出 {he}、收益曲线 {rcur}、汇率 {fx_total}、时间线 {tl_n}、银行流水 {bank_n}（seg 跳过 {bank_seg_skip}）、2002关池 {closed}、冲突拦截 {blocked_files}{notif_part}")
 
 
 @app.command()
@@ -148,13 +156,22 @@ def health(env: str = typer.Option("dev", "--env")):
 
 @app.command()
 def recompute(env: str = typer.Option("dev", "--env"), from_year: int = typer.Option(1947, "--from")):
-    """全库增量重算：从受影响起点年向后滚动账户余额（F-P0-12）。"""
-    from app.core.recompute import recompute_all
+    """全库增量重算：从受影响起点年向后滚动账户余额（F-P0-12）。
+
+    完成后写 recompute_job + recompute-done 通知（DESIGN §9.2 步骤3-4；issue #13）。
+    """
+    from app.core.recompute import recompute_all, record_recompute_done
+    from app.core.snapshot import rebuild_snapshots
     with _session_for(env) as s:
         res = recompute_all(s, from_year)
+        # §9.2c 重算后重建受影响起点起的快照（account/entity/family 三层，增量）
+        rebuild_snapshots(s, range(from_year, 2026), from_year=from_year)
+        # §9.2 步骤3-4：写 job + 通知
+        job = record_recompute_done(s, from_year, reason="recompute")
         s.commit()
         total_updated = sum(r["updated"] for r in res)
-        typer.echo(f"[{env}] 重算 {len(res)} 个账户，更新 {total_updated} 行余额（自 {from_year} 起）")
+        typer.echo(f"[{env}] 重算 {len(res)} 个账户，更新 {total_updated} 行余额（自 {from_year} 起）"
+                   f"；job#{job['job_id']} 通知#{job['notification_id']}")
 
 
 @app.command()

--- a/tests/test_recompute_job.py
+++ b/tests/test_recompute_job.py
@@ -1,0 +1,74 @@
+"""Unit tests for app/core/recompute 的 job/notification 接线（issue #13 回归）。
+
+通过 SQLite 内存 + 临时 DDL 验证：
+- register_job 写 recompute_job(status=done)
+- record_recompute_done 写 job + recompute-done Notification，且字段正确
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.model import RecomputeJob, Notification
+from app.core.recompute import register_job, record_recompute_done
+
+
+@pytest.fixture
+def session():
+    """内存 SQLite + 临时 DDL（BigInteger PK → Integer 兼容 SQLite）。"""
+    from sqlalchemy import BigInteger, Integer
+
+    def _patch():
+        for table in Base.metadata.tables.values():
+            for col in table.columns:
+                if isinstance(col.type, BigInteger) and col.primary_key:
+                    col.type = Integer()
+
+    _patch()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+class TestRegisterJob:
+    def test_writes_job_done(self, session):
+        jid = register_job(session, 1980, reason="test", files=["a.md", "b.md"])
+        session.commit()
+        job = session.get(RecomputeJob, jid)
+        assert job is not None
+        assert job.status == "done"
+        assert job.start_year == 1980
+        assert job.reason == "test"
+        assert {f for f in (job.files or [])} >= {"a.md", "b.md"}
+        assert job.finished_at is not None
+
+
+class TestRecordRecomputeDone:
+    def test_writes_job_and_notification(self, session):
+        res = record_recompute_done(session, 1985, reason="ingest", files=["时间线.md"])
+        session.commit()
+        # job
+        job = session.get(RecomputeJob, res["job_id"])
+        assert job is not None and job.status == "done"
+        # notification
+        notif = session.get(Notification, res["notification_id"])
+        assert notif is not None
+        assert notif.kind == "recompute-done"
+        assert notif.job_id == job.id
+        assert "1985" in (notif.message or "")
+        assert notif.payload.get("start_year") == 1985
+        # 未读
+        assert notif.read_at is None
+
+    def test_default_reason(self, session):
+        res = record_recompute_done(session, 2001)
+        session.commit()
+        notif = session.get(Notification, res["notification_id"])
+        assert notif is not None
+        assert notif.kind == "recompute-done"


### PR DESCRIPTION
## 修复内容
DESIGN §9.2 四步流程只有第 1 步落地：`register_job` 定义后全工程零调用，`Notification` 零写入零读取；UI 用户收不到「全局重算完成」非阻断提示。

## 修复
- `recompute.record_recompute_done(session, start_year, reason, files)`：写 `recompute_job(status=done)` → 建 `Notification(kind='recompute-done')`（§9.2 步骤 3-4）
- `main.py recompute`：重算后增量重建快照（from_year 起）→ `record_recompute_done`
- `main.py ingest`：成功路径（无冲突拦截）→ 增量重算 + 重建快照 + `record_recompute_done`
- `app/api/app.py`：新增 `GET /api/v1/notifications`（默认未读、倒序）+ `PATCH /api/v1/notifications/{id}`（标记已读）

## 验证
\`\`\`
.venv/bin/python -m pytest tests/
============================== 72 passed in 0.37s ==============================
\`\`\`

前端横幅位为 P2 后续（issue 范围聚焦后端时序与 API）。

Closes #13