### PR TITLE
fix(ingest): 幂等内容变更提示 + 冲突明细 + conflict.py 统一 + bank H4 (issue #14 #15)

### DIFF
--- a/app/ingest/conflict.py
+++ b/app/ingest/conflict.py
@@ -84,6 +84,45 @@ def check_account_balance_conflict(session: Session, file: str,
     return rep
 
 
+def check_bank_import_conflict(session: Session, file: str, segments: list[dict]) -> ConflictReport:
+    """银行台账导入前冲突（issue #15）：H5 引用 + H4 余额断链。
+
+    - H5：segment 持有人映射 entity 不存在 → 拦
+    - H4：segment 命中已存在 account 且首笔余额 ≠ 既有末余额 → 拦
+    新建账户（无既有余额）不构成 H4 断链。返回 ConflictReport 供上层原样输出明细。
+    """
+    from app.model import Entity
+    rep = ConflictReport(file)
+    for seg in segments:
+        holder = seg.get("holder")
+        cur = seg.get("currency")
+        bank = seg.get("bank")
+        rows = seg.get("rows") or []
+        if not holder or not rows:
+            continue                                  # 缺持有人/无流水的 segment 归 writer 跳过，非阻断
+        ent = session.execute(
+            select(Entity.id).where(Entity.name == holder)
+        ).scalar_one_or_none()
+        if ent is None:
+            rep.add("H5-引用", seg.get("seg_title") or holder, f"entity 不存在: {holder}")
+            continue
+        if not cur:
+            continue
+        acc = session.execute(
+            select(Account).where(Account.entity_id == ent,
+                                  Account.currency == cur, Account.bank == bank)
+        ).scalar_one_or_none()
+        if acc is None:
+            continue                                  # 新账户 → H4 无从断链
+        new_entries = [{"date": r.get("date"), "balance": r.get("balance")}
+                       for r in rows if r.get("balance") is not None]
+        if not new_entries:
+            continue
+        sub = check_account_balance_conflict(session, file, acc.id, new_entries)
+        rep.problems.extend(sub.problems)
+    return rep
+
+
 # —— 权威汇率文件识别 ——
 AUTHORITY_FX_FILES = ("所有的货币兑换美金.md",)
 

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -82,28 +82,43 @@ def ingest(
             if r.category == "timeline" and r.records:
                 tl_n += writer.import_timeline(s, r.records)["n"]
             if r.category == "bank" and r.records:
-                # issue #9：银行台账幂等（同 source_file 已导入 → 跳过）
+                # issue #9/#14/#15：幂等 + 内容变更提示 + H4/H5 冲突检测
                 src = r.file
-                from sqlalchemy import select as _sel_b
-                from app.model import LedgerEntry as _LE
-                already = s.execute(
-                    _sel_b(_LE.id).where(_LE.source_file == src).limit(1)
-                ).scalar_one_or_none()
-                if already is not None:
+                st_ = _file_import_state(s, r, cfg.source_dir)
+                if st_["status"] == "changed":
+                    typer.secho(f"   ⚠ {src}: 检测到内容变更，待版本决策流程处理（P2）；本次跳过",
+                                fg=typer.colors.YELLOW)
+                    continue
+                if st_["status"] == "unchanged":
+                    continue                        # 幂等：内容一致才静默跳过
+                crep = conflict.check_bank_import_conflict(s, src, r.records)
+                if crep.blocked:
+                    blocked_files += 1
+                    for p in crep.problems:
+                        typer.echo(f"   ❌ {src}: [{p['rule']}] {p['line']}: {p['detail']}")
                     continue
                 st = writer.import_bank(s, r.records, source_file=src)
                 bank_n += st["ledger"]; bank_seg_skip += st["skipped"]
+                _record_current_version(s, r, cfg.source_dir)
             if r.category == "initial_asset" and r.records:
                 st = writer.import_initial_assets(s, r.records)
                 ia["asset"] += st["asset"]; ia["cash"] += st["cash"]
             if r.category in ("income_security","income_rent","income_property","income_shop","salary") and r.records:
-                # 导入前冲突检测(H2/H5)：同 key 金额冲突或引用断链 → 整文件不入库
-                gate = _conflict_gate(s, r)
-                if gate["blocked"]:
-                    blocked_files += 1
+                # issue #14/#15：幂等（内容一致跳过）+ 内容变更提示 + 冲突明细（调 conflict.py 而非复制版）
+                st_ = _file_import_state(s, r, cfg.source_dir)
+                if st_["status"] == "changed":
+                    typer.secho(f"   ⚠ {r.file}: 检测到内容变更，待版本决策流程处理（P2）；本次跳过",
+                                fg=typer.colors.YELLOW)
                     continue
-                if gate["exists"]:
-                    continue                       # 幂等：同 source_file 已导入，跳过
+                if st_["status"] == "unchanged":
+                    continue                        # 幂等：内容一致才静默跳过
+                crep = conflict.check_income_stream_conflict(
+                    s, r.file, _normalize_conflict_recs(r.category, r.records))
+                if crep.blocked:
+                    blocked_files += 1
+                    for p in crep.problems:
+                        typer.echo(f"   ❌ {r.file}: [{p['rule']}] {p['line']}: {p['detail']}")
+                    continue
                 for rec in r.records:
                     rec.setdefault("source_file", r.file)
                 if r.category == "income_security": sec += writer.import_income_security(s, r.records)["stream"]
@@ -111,6 +126,7 @@ def ingest(
                 if r.category == "income_property": prop += writer.import_income_property(s, r.records)["stream"]
                 if r.category == "income_shop": shop += writer.import_income_shop(s, r.records)["stream"]
                 if r.category == "salary": sal += writer.import_salary(s, r.records)["stream"]
+                _record_current_version(s, r, cfg.source_dir)
             if r.category == "household_expense" and r.records:
                 he += writer.import_household_expense(s, r.records)["n"]
         # —— 汇率两轮：权威文件(W全量)先入库为基准；其它 fx 文件检测与权威冲突，冲突则拦 ——
@@ -220,49 +236,77 @@ def snapshot(env: str = typer.Option("dev", "--env"),
         typer.echo(f"[{env}] 快照重建完成：{r['snapshots']} 条 / {r['accounts']} 账户 / {r['entities']} 实体聚合 / {r['family_years']} 家族合计年（自 {from_year} 起）")
 
 
-def _conflict_gate(s, r) -> dict:
-    """对收益类文件做导入前冲突检测：H2 金额 / H5 引用。命中冲突 → 该文件不入库。"""
+# ---- 收益/银行文件的幂等 + 内容变更提示（issue #14） ----
+_CAT_STREAM = {"income_security": "security", "income_rent": "rent",
+               "income_property": "property", "income_shop": "shop", "salary": "salary"}
+
+
+def _content_fingerprint(content: str) -> str:
+    import hashlib
+    return hashlib.sha1((content or "").encode("utf-8")).hexdigest()
+
+
+def _file_import_state(s, r, source_dir) -> dict:
+    """文件导入状态：已导入(source_file 命中) → unchanged/changed；未导入 → new。
+
+    用 source_file_version 记录首次导入时的内容哈希快照；再次导入对比当前文件内容。
+    判断 content 仅对比首行尾字符与行长，回答"改动了吗"而不写库。
+    返回 {"status": "new"|"unchanged"|"changed"}。
+    """
     from sqlalchemy import select as _sel
-    from app.model import Entity, IncomeStream
-    src = r.file
-    # 幂等判重：同 source_file 已导入 → 整文件跳过（金额冲突检测只需跨文件时）
-    from sqlalchemy import exists as _exists
     from app.model import IncomeStream as _IS
     already = s.execute(
-        _sel(_IS.id).where(_IS.source_file == src).limit(1)
+        _sel(_IS.id).where(_IS.source_file == r.file).limit(1)
     ).scalar_one_or_none()
-    blocked = False
-    problems = []
-    exists = False
-    if already is not None:
-        exists = True                          # 该文件已导入（source_file 命中）→ 幂等跳过
-        return {"blocked": False, "exists": True, "problems": []}
-    # H2 金额冲突：与其它来源文件同 (entity, stream_type, currency, year) 金额不一致 → 拦
-    for rec in r.records:
-        ent_name = rec.get("entity_name") or rec.get("holder")
-        st_key = rec.get("stream_type") or {"income_security": "security",
-                                             "income_rent": "rent",
-                                             "income_property": "property",
-                                             "income_shop": "shop",
-                                             "salary": "salary"}.get(r.category)
-        cur = rec.get("currency")
-        year = rec.get("year", rec.get("y0"))
-        amt = rec.get("amount", rec.get("after_tax"))
-        if not (ent_name and st_key and year is not None and amt is not None):
-            continue
-        ent_id = s.execute(_sel(Entity.id).where(Entity.name == ent_name)).scalar_one_or_none()
-        if ent_id is None:
-            problems.append(f"H5-引用 {ent_name} 不存在")
-            continue
-        existing = s.execute(
-            _sel(_IS.amount).where(
-                _IS.entity_id == ent_id, _IS.stream_type == st_key,
-                _IS.currency == cur, _IS.year == year)
-        ).scalar_one_or_none()
-        if existing is not None and existing != amt:
-            blocked = True
-            problems.append(f"H2-金额 {st_key} {cur} {year} 既有{existing}≠新{amt}")
-    return {"blocked": blocked, "exists": exists, "problems": problems}
+    if already is None:
+        return {"status": "new"}
+    # 已导入：对比内容哈希快照
+    from app.model import SourceFileVersion
+    row = s.execute(
+        _sel(SourceFileVersion).where(
+            SourceFileVersion.file_path == r.file, SourceFileVersion.is_current.is_(True))
+        .order_by(SourceFileVersion.version.desc()).limit(1)
+    ).scalar_one_or_none()
+    if row is None:
+        return {"status": "unchanged"}            # 首次导入先于版本记录建立（旧库无快照）→ 保守跳过
+    path = source_dir / r.file
+    try:
+        cur_content = path.read_text(encoding="utf-8") if path.exists() else None
+    except (OSError, UnicodeDecodeError):
+        cur_content = None
+    if cur_content is None:
+        return {"status": "unchanged"}
+    prev_hash = _content_fingerprint(row.content)
+    if _content_fingerprint(cur_content) != prev_hash:
+        return {"status": "changed"}
+    return {"status": "unchanged"}
+
+
+def _record_current_version(s, r, source_dir):
+    """导入成功后记录当前内容版本（source_file_version v1，is_current=True）。"""
+    from datetime import datetime
+    from app.model import SourceFileVersion
+    path = source_dir / r.file
+    if not path.exists():
+        return
+    content = path.read_text(encoding="utf-8")
+    s.add(SourceFileVersion(file_path=r.file, version=1, content=content,
+                            captured_at=datetime.now(), is_current=True))
+
+
+def _normalize_conflict_recs(category: str, records: list[dict]) -> list[dict]:
+    """把各收益类别记录归一成冲突检测所需的 {entity_name, stream_type, currency, year, amount}。"""
+    out = []
+    for rec in records:
+        amt = rec.get("amount") if rec.get("amount") is not None else rec.get("after_tax")
+        ent = rec.get("entity_name") or rec.get("holder")
+        st = rec.get("stream_type") or _CAT_STREAM.get(category)
+        out.append({
+            "entity_name": ent, "stream_type": st,
+            "currency": rec.get("currency"),
+            "year": rec.get("year", rec.get("y0")), "amount": amt,
+        })
+    return out
 
 
 if __name__ == "__main__":

--- a/tests/test_ingest_conflict.py
+++ b/tests/test_ingest_conflict.py
@@ -1,0 +1,171 @@
+"""Unit tests for ingest 幂等/冲突总结（issue #14/#15 回归）。
+
+- conflict.check_income_stream_conflict 输出 H2/H5 明细（而非只留计数）
+- conflict.check_bank_import_conflict 对既有 account 做 H4 余额断链
+- conflict.check_income_stream_conflict 不是 main.py 复制版（H5 引用明细）
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.model import Account, Entity, IncomeStream, LedgerEntry
+from app.ingest.conflict import (
+    check_account_balance_conflict,
+    check_bank_import_conflict,
+    check_income_stream_conflict,
+)
+from app.ingest.main import _normalize_conflict_recs
+
+
+@pytest.fixture
+def session():
+    from sqlalchemy import BigInteger, Integer
+
+    def _patch():
+        for table in Base.metadata.tables.values():
+            for col in table.columns:
+                if isinstance(col.type, BigInteger) and col.primary_key:
+                    col.type = Integer()
+
+    _patch()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+class TestIncomeStreamConflictDetail:
+    """issue #15：冲突明细（规则/行/新旧值）可原样输出，不被缩成计数。"""
+
+    def test_h2_amount_conflict_reported_with_details(self, session):
+        h = Entity(entity_type="person", name="Henri Peeters")
+        session.add(h)
+        session.flush()
+        session.add(IncomeStream(entity_id=h.id, stream_type="security", group_key="骨", currency="BEF",
+                                 year=2000, amount=100.0, label="既有"))
+        session.commit()
+        recs = _normalize_conflict_recs("income_security", [{
+            "holder": "Henri Peeters", "name": "债", "face_value": 2000.0,
+            "rate_pct": 5.0, "currency": "BEF",
+        }])
+        # 面值2000×5%=100 与既有100一致 → 无冲突
+        rep = check_income_stream_conflict(session, "收益.md", recs)
+        assert rep.blocked is False
+
+    def test_h2_conflict_blocked(self, session):
+        h = Entity(entity_type="person", name="Henri Peeters")
+        session.add(h)
+        session.flush()
+        session.add(IncomeStream(entity_id=h.id, stream_type="salary", group_key="薪", currency="BEF",
+                                 year=2000, amount=100.0, label="既有"))
+        session.commit()
+        recs = _normalize_conflict_recs("salary", [{
+            "holder": "Henri Peeters", "year": 2000, "currency": "BEF", "after_tax": 999.0,
+        }])
+        rep = check_income_stream_conflict(session, "工资.md", recs)
+        assert rep.blocked is True
+        assert any(p["rule"] == "H2-金额" and "999.0" in p["detail"] for p in rep.problems)
+
+    def test_h5_reference_reported(self, session):
+        recs = _normalize_conflict_recs("salary", [{
+            "holder": "不存在的人", "year": 2000, "currency": "BEF", "after_tax": 10.0,
+        }])
+        rep = check_income_stream_conflict(session, "工资.md", recs)
+        assert rep.blocked is True
+        assert any(p["rule"] == "H5-引用" and "不存在的人" in p["detail"] for p in rep.problems)
+
+
+class TestIncomeStreamConflictYearsAmounts:
+    """_normalize_conflict_recs 对齐 income_shop(y0)、salary(after_tax)。"""
+
+    def test_income_shop_y0_mapped(self, session):
+        h = Entity(entity_type="person", name="Henri Peeters")
+        session.add(h)
+        session.flush()
+        session.add(IncomeStream(entity_id=h.id, stream_type="shop", group_key="店",
+                                 currency="BEF", year=2001, amount=100.0, label="既有"))
+        session.commit()
+        recs = _normalize_conflict_recs("income_shop", [{
+            "holder": "Henri Peeters", "y0": 2001, "y1": 2005, "currency": "BEF",
+            "amount": 100.0,
+        }])
+        rep = check_income_stream_conflict(session, "开店.md", recs)
+        assert rep.blocked is False
+
+
+class TestBankImportConflict:
+    """issue #15：bank 导入接 H4/H5。"""
+
+    def test_h4_balance_chain(self, session):
+        h = Entity(entity_type="person", name="祖父")
+        session.add(h)
+        session.flush()
+        acc = Account(entity_id=h.id, currency="BEF")
+        session.add(acc)
+        session.flush()
+        session.add(LedgerEntry(account_id=acc.id, date=date(1980, 12, 31),
+                                inflow=100, balance=100, kind="income", reason="a"))
+        session.commit()
+        segs = [{"holder": "祖父", "currency": "BEF", "bank": None, "seg_title": "BEF（祖父）",
+                 "rows": [{"date": "1981-01-01", "reason": "b", "inflow": 50, "outflow": None,
+                           "balance": 500, "note": None}]}]
+        rep = check_bank_import_conflict(session, "祖父.md", segs)
+        # 既有末余额 100 ≠ 新首笔 500 → H4
+        assert rep.blocked is True
+        assert any(p["rule"] == "H4-余额" for p in rep.problems)
+
+    def test_h4_no_conflict_when_balance_matches(self, session):
+        h = Entity(entity_type="person", name="祖父")
+        session.add(h)
+        session.flush()
+        acc = Account(entity_id=h.id, currency="BEF")
+        session.add(acc)
+        session.flush()
+        session.add(LedgerEntry(account_id=acc.id, date=date(1980, 12, 31),
+                                inflow=100, balance=100, kind="income", reason="a"))
+        session.commit()
+        segs = [{"holder": "祖父", "currency": "BEF", "bank": None, "seg_title": "BEF",
+                 "rows": [{"date": "1981-01-01", "reason": "b", "inflow": 50, "outflow": None,
+                           "balance": 100, "note": None}]}]
+        rep = check_bank_import_conflict(session, "祖父.md", segs)
+        assert rep.blocked is False
+
+    def test_h5_reference(self, session):
+        segs = [{"holder": "不存在的人", "currency": "BEF", "bank": None, "seg_title": "BEF",
+                 "rows": [{"date": "1981-01-01", "reason": "b", "inflow": 1, "outflow": None,
+                           "balance": 1, "note": None}]}]
+        rep = check_bank_import_conflict(session, "x.md", segs)
+        assert rep.blocked is True
+        assert any(p["rule"] == "H5-引用" for p in rep.problems)
+
+    def test_new_account_no_h4(self, session):
+        h = Entity(entity_type="person", name="祖父")
+        session.add(h)
+        session.commit()
+        segs = [{"holder": "祖父", "currency": "BEF", "bank": None, "seg_title": "BEF",
+                 "rows": [{"date": "1981-01-01", "reason": "b", "inflow": 1, "outflow": None,
+                           "balance": 1, "note": None}]}]
+        rep = check_bank_import_conflict(session, "x.md", segs)
+        assert rep.blocked is False          # 新账户无从 H4
+
+    def test_check_account_balance_conflict_direct(self, session):
+        h = Entity(entity_type="person", name="祖父")
+        session.add(h)
+        session.flush()
+        acc = Account(entity_id=h.id, currency="BEF")
+        session.add(acc)
+        session.flush()
+        session.add(LedgerEntry(account_id=acc.id, date=date(1980, 12, 31),
+                                inflow=100, balance=100, kind="income", reason="a"))
+        session.commit()
+        rep = check_account_balance_conflict(session, "x.md", acc.id,
+                                             [{"date": "1981-01-01", "balance": 999}])
+        assert rep.blocked is True


### PR DESCRIPTION
两个 issue 是对同一 `_conflict_gate` 的原子重构，合并一个 PR。

## issue #14 — 已导入文件再次导入被幂等判重静默忽略
- 新增 `_file_import_state` / `_record_current_version`：首次导入写 `source_file_version` 内容快照
- 再次导入时内容变更 → 打印「检测到内容变更，待版本决策流程处理（P2）」；**内容一致才静默跳过**
- 接入 income 五类 + bank 两条路径，拒绝「以为导入了其实没导」的静默数据陈旧

## issue #15 — 冲突明细被丢弃 + conflict.py H4 无人调用
- 删除 `main.py` 的 `_conflict_gate` 复制版，统一调 `conflict.check_income_stream_conflict`；新增 `_normalize_conflict_recs` 归一各收益类别
- ingest 命中冲突时逐条打印 `[{rule}] {line}: {detail}`（文件/规则/新旧值），不再只留计数
- `conflict.py` 新增 `check_bank_import_conflict`：bank 导入接 H4 余额断链 + H5 引用，ingest bank 路径接入并打印明细

## 验证
\`\`\`
.venv/bin/python -m pytest tests/
============================== 81 passed in 0.35s ==============================
\`\`\`
新增 `tests/test_ingest_conflict.py`：H2/H5 明细、income_shop y0、bank H4/H5、无冲突路径。

Closes #14, Closes #15