### PR TITLE
fix(ingest): EUR承接分录 + 日历按日累加 (issue #16 #17)

### DIFF
--- a/app/core/calendar.py
+++ b/app/core/calendar.py
@@ -1,7 +1,9 @@
 """全局日历游标（DESIGN §8 / E）：as_of_date → 截至该日状态。
 
-快照按年（as_of_year）预计算，日历游标把所选 as_of_date 归到其所在年，
-返回该年快照。源数据缺粒度由日期规则补全（normalize.resolve_date）。
+快照按年（as_of_year）预计算作默认年视图；日历游标对所选 as_of_date 采用
+「按日即时累加」（issue #17 方案 A′）：截至所选日历日状态 = 固定值 + 累计到该日
+的变更，直接对 ledger(date<=as_of_date) 求和，消除原「年中日期返回年末快照」的前视偏差。
+源数据缺粒度由日期规则补全（normalize.resolve_date）。
 """
 from __future__ import annotations
 
@@ -10,7 +12,8 @@ from datetime import date
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.model import Snapshot
+from app.core.snapshot import _usd_rate, account_balance_at
+from app.model import Account
 
 
 def resolve_as_of_year(as_of_date: date) -> int:
@@ -19,13 +22,37 @@ def resolve_as_of_year(as_of_date: date) -> int:
 
 
 def snapshot_as_of(session: Session, as_of_date: date) -> list[dict]:
-    """截至 as_of_date 的快照（全物种 scope）。"""
-    year = resolve_as_of_year(as_of_date)
-    snaps = session.execute(
-        select(Snapshot).where(Snapshot.as_of_year == year, Snapshot.as_of_date.is_(None))
-    ).scalars().all()
-    return [{"scope": s.scope, "value": float(s.value) if s.value is not None else 0.0,
-             "currency": s.currency, "year": s.as_of_year} for s in snaps]
+    """截至 as_of_date 的快照（account/entity/family 三层，按日累加）。
+
+    口径与 rebuild_snapshots 一致，仅核对到 as_of_date 当日（而非某年年末）：
+    - account  ：逐账户 balance=Σ(inflow−outflow) for date<=as_of_date，scope account:{id}:{cur}
+    - entity   ：按 (entity_id, currency) 聚合，scope entity:{eid}:{cur}
+    - family   ：复用 _usd_rate 折算美元（汇率缺失币种不计入），scope family:total
+    返回 dict 列表（含 year=as_of_date.year），与既有调用方（API /snapshots?as_of=、CLI calendar）兼容。
+    """
+    year = as_of_date.year
+    accs = session.execute(select(Account)).scalars().all()
+    out: list[dict] = []
+    entity_agg: dict[tuple[int, str], float] = {}
+    family_usd = 0.0
+    for a in accs:
+        bal = account_balance_at(session, a.id, as_of_date)
+        # 关池后不双计：closed 账户自关池日起余额清 0（钱已结转进承接 EUR 账户，DESIGN §6.6）
+        if a.status == "closed" and a.closed_on is not None and as_of_date >= a.closed_on:
+            bal = 0.0
+        out.append({"scope": f"account:{a.id}:{a.currency}",
+                    "value": round(bal, 2), "currency": a.currency, "year": year})
+        key = (a.entity_id, a.currency)
+        entity_agg[key] = entity_agg.get(key, 0.0) + bal
+        rate = _usd_rate(session, a.currency, year)
+        if rate is not None:
+            family_usd += bal * rate
+    for (eid, cur), bal in entity_agg.items():
+        out.append({"scope": f"entity:{eid}:{cur}",
+                    "value": round(bal, 2), "currency": cur, "year": year})
+    out.append({"scope": "family:total", "value": round(family_usd, 2),
+                "currency": "USD", "year": year})
+    return out
 
 
 def default_calendar_bounds() -> tuple[int, int]:

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -17,9 +17,34 @@ from sqlalchemy.orm import Session
 from app.model import Account, ExchangeRate, IncomeStream, LedgerEntry, Snapshot
 
 
+def account_balance_at(session: Session, account_id: int, cutoff) -> float:
+    """账户截至 cutoff（date 级）的余额：Σ(inflow) − Σ(outflow) for date <= cutoff。
+
+    与 _account_balance_series 同源口径：在 cutoff=12-30（某年年末）时两者相等，
+    保证日历按日累加与预计算年度快照一致（issue #17 方案 A′）。
+    """
+    tin, tout = session.execute(
+        select(func.coalesce(func.sum(LedgerEntry.inflow), 0),
+               func.coalesce(func.sum(LedgerEntry.outflow), 0))
+        .where(LedgerEntry.account_id == account_id, LedgerEntry.date <= cutoff)
+    ).one()
+    return float(tin) - float(tout)
+
+
+def _close_year_of(acc: Account) -> int | None:
+    """账户关池年：closed 且有关池日 → closed_on.year，否则 None（DESIGN §6.6）。"""
+    if acc.status == "closed" and acc.closed_on is not None:
+        return acc.closed_on.year
+    return None
+
+
 def _account_balance_series(session: Session, account_id: int,
-                            years: range) -> dict[int, float]:
-    """该账户逐年 as-of 余额：初始现金 + 累计 income − 累计 expense。"""
+                            years: range, close_year: int | None = None) -> dict[int, float]:
+    """该账户逐年 as-of 余额：初始现金 + 累计 income − 累计 expense。
+
+    关池（close_year）后不双计：closed 账户自关池年起余额清零——钱已结转进承接币种
+    （EUR）账户，避免与承接分录叠加（DESIGN §6.6）。
+    """
     # ledger 收支（现金进 ledger）
     rows = session.execute(
         select(func.extract("year", LedgerEntry.date),
@@ -38,7 +63,7 @@ def _account_balance_series(session: Session, account_id: int,
     bal = 0.0
     for y in years:
         bal += year_in.get(y, 0.0) - year_out.get(y, 0.0)
-        series[y] = bal
+        series[y] = 0.0 if close_year is not None and y >= close_year else bal
     return series
 
 
@@ -95,7 +120,8 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
     # 2) 先把所有账户余额 series 算好（避免 entity 聚合时再算）
     series_by_acc: dict[int, dict[int, float]] = {}
     for acc in _ownership_accounts(session):
-        series_by_acc[acc.id] = _account_balance_series(session, acc.id, years)
+        series_by_acc[acc.id] = _account_balance_series(
+            session, acc.id, years, close_year=_close_year_of(acc))
 
     # 3) 写 account:* 行
     for acc in _ownership_accounts(session):

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -141,7 +141,8 @@ def ingest(
                 blocked_files += 1
                 continue
             fx_total += writer.import_fx(s, r.records)["n"]
-        closed = writer.close_2002_currency(s)["closed"]
+        cc = writer.close_2002_currency(s)
+        closed = cc["closed"]
         # —— DESIGN §9 摄入因果链尾巴：增量重算 + 重建快照 + recompute-done 通知（issue #13）——
         if not blocked_files:
             from app.core.recompute import recompute_all, record_recompute_done
@@ -152,7 +153,7 @@ def ingest(
         s.flush()
         s.commit()
         notif_part = f"；recompute job#{job['job_id']} 通知#{job['notification_id']}" if not blocked_files else ""
-        typer.echo(f"[{cfg.env}] 落库完成：人物 {ck}、初始资产 {ia['asset']}、现金 {ia['cash']}、票息 {sec}、租房 {rent}、经营房 {prop}、开店 {shop}、薪资 {sal}、家庭支出 {he}、收益曲线 {rcur}、汇率 {fx_total}、时间线 {tl_n}、银行流水 {bank_n}（seg 跳过 {bank_seg_skip}）、2002关池 {closed}、冲突拦截 {blocked_files}{notif_part}")
+        typer.echo(f"[{cfg.env}] 落库完成：人物 {ck}、初始资产 {ia['asset']}、现金 {ia['cash']}、票息 {sec}、租房 {rent}、经营房 {prop}、开店 {shop}、薪资 {sal}、家庭支出 {he}、收益曲线 {rcur}、汇率 {fx_total}、时间线 {tl_n}、银行流水 {bank_n}（seg 跳过 {bank_seg_skip}）、2002关池 {closed}（EUR承接 {cc['migrated']} / 零结转跳过 {cc['skipped_zero']}）、冲突拦截 {blocked_files}{notif_part}")
 
 
 @app.command()

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.model import Account, Entity, ExchangeRate, IncomeStream, InitialAsset, LedgerEntry
@@ -347,19 +347,89 @@ def import_bank(session: Session, segments: list[dict], source_file: str | None 
     return stats
 
 
+# EMU 锁定不变折算率：EUR=X → balance/rate（DESIGN §6.6；BEF 明文，LUF 与 BEF 平比价，NLG 官方锁定）
+_EUR_CONVERSION = {"BEF": 40.3399, "LUF": 40.3399, "NLG": 2.20371}
+
+
 def close_2002_currency(session: Session, currencies=("BEF", "LUF", "NLG"),
                         closed_on="2002-01-01", migrate_to="EUR") -> dict:
-    """2002-01-01 关闭 BEF/LUF/NLG 池 → migrate_to EUR（DESIGN §6.6）。"""
+    """2002-01-01 关闭 BEF/LUF/NLG 池 → migrate_to EUR，并开 EUR 承接分录（DESIGN §6.6）。
+
+    按 entity 聚合：同 entity 的所有被关旧币账户（可多币种/多账户）合并计入该 entity
+    的**一条** EUR 承接分录（DESIGN §6.6「开一条承接分录」）。对每个 entity：
+    1. 置其全部 active 旧币账户为 closed（closed_on/migrate_to_currency）。
+    2. 开/复用同 entity 的 EUR 池（存在多个 EUR 池时归入首个，避免 multi-result）。
+    3. 每条旧币账户取关池日余额 = Σ(inflow) − Σ(outflow) for date ≤ 2002-01-01
+       （不依赖 ledger.balance——重算链可能尚未跑，source/bank 余额不可靠）；余额为 0 计入
+       skipped_zero、不结转。
+    4. 各币种折算后汇总为 EUR，写一条承接 inflow（note 记各原币金额与折算汇率；balance=inflow 作 EUR 池起点）。
+
+    幂等：
+    - 外层按 status='active' 过滤 → 二次运行不再重复关池/承接；
+    - 写前查 EUR 池是否已有 2002-01-01「关池划转」入账，有则跳过（按 entity 一条，天然防重）。
+
+    返回 {"closed": 关池账户数, "migrated": 承接分录(entity)数, "skipped_zero": 零余额未结转账户数}。
+    """
+    from collections import defaultdict
     from datetime import date as _date
     c = _date(2002, 1, 1)
     accs = session.execute(
         select(Account).where(Account.currency.in_(currencies), Account.status == "active")
     ).scalars().all()
+    by_entity: dict[int, list[Account]] = defaultdict(list)
     for a in accs:
-        a.status = "closed"
-        a.closed_on = c
-        a.migrate_to_currency = migrate_to
-    return {"closed": len(accs)}
+        by_entity[a.entity_id].append(a)
+    stats = {"closed": 0, "migrated": 0, "skipped_zero": 0}
+    for eid, alist in by_entity.items():
+        for a in alist:
+            a.status = "closed"
+            a.closed_on = c
+            a.migrate_to_currency = migrate_to
+        stats["closed"] += len(alist)
+        # EUR 承接池：取同 entity 任一 EUR 账户；无则新建（bank=None 统一池）
+        eur_acc = session.execute(
+            select(Account).where(Account.entity_id == eid, Account.currency == migrate_to)
+        ).scalars().first()
+        if eur_acc is None:
+            eur_acc = Account(entity_id=eid, currency=migrate_to, bank=None)
+            session.add(eur_acc)
+            session.flush()
+        # 幂等防重：EUR 池已有关池日承接入账 → 跳过（按 entity 一条）
+        already = session.execute(
+            select(LedgerEntry.id).where(
+                LedgerEntry.account_id == eur_acc.id, LedgerEntry.date == c,
+                LedgerEntry.reason.like("%关池划转%")).limit(1)
+        ).scalar_one_or_none()
+        if already is not None:
+            continue
+        # 各旧币账户折算汇总
+        parts: list[str] = []
+        total_eur = 0.0
+        for a in alist:
+            rate = _EUR_CONVERSION.get(a.currency)
+            if rate is None:
+                continue
+            tin, tout = session.execute(
+                select(func.coalesce(func.sum(LedgerEntry.inflow), 0),
+                       func.coalesce(func.sum(LedgerEntry.outflow), 0))
+                .where(LedgerEntry.account_id == a.id, LedgerEntry.date <= c)
+            ).one()
+            legacy = float(tin) - float(tout)
+            if legacy == 0:
+                stats["skipped_zero"] += 1
+                continue
+            total_eur += legacy / rate
+            parts.append(f"{a.currency} {legacy:,.2f}（折算汇率 1 {migrate_to} = {rate} {a.currency}）")
+        if not parts:
+            continue
+        amount = round(total_eur, 2)
+        note = "承接自 " + "；".join(parts)
+        session.add(LedgerEntry(
+            account_id=eur_acc.id, date=c, reason=f"2002关池划转 ({'/'.join(currencies)}→{migrate_to})",
+            inflow=amount, outflow=None, balance=amount, kind="income", note=note,
+        ))
+        stats["migrated"] += 1
+    return stats
 
 
 def _rent_factor(year: int) -> float:


### PR DESCRIPTION
## 概述
修复两个 P1 账务正确性缺陷，并走 PR→merge→close。

## issue #16 — EUR 承接分录未实现
`close_2002_currency` 原来只置 `status='closed'`，未按 DESIGN §6.6 开 EUR 承接池/生成承接 ledger 分录，导致 2002 后家族本币连续性断裂、曲线断崖。
- 现在按 **entity 聚合**：同 entity 的所有被关旧币账户（可多币种/多账户）合并计入该 entity 的**一条** EUR 承接分录。
- 每条旧币账户取关池日余额 = Σ(inflow)−Σ(outflow) ≤ 2002-01-01（不依赖 ledger.balance，重算未跑也可靠），折算（BEF/LUF=40.3399、NLG=2.20371），汇总写 EUR inflow；`note` 记各原币金额与折算汇率。
- 幂等：外层 `status='active'` 过滤 + 写前查 EUR 池是否已有「关池划转」入账。
- 返回扩充为 `{closed, migrated, skipped_zero}`；ingest 统计文案跟进。

## issue #17 — 日历 as-of 前视偏差
原 `snapshot_as_of` 把任意年中日期映射到该年**年末**年度快照（`1990-06-30` 返回含全年流水）。
- 改按 **方案 A′ 按日即时累加**：`ledger(date<=as_of_date)` 直接求和，复刻三层 scope（account/entity/family:total，USD 折算复用 `snapshot._usd_rate`）。任一日期精确、无前视；磁盘年度快照表保留作默认年视图。

## 一致性（两处一起）
closed 账户自关池日/年起余额清零（钱已结转进承接 EUR 帐，**不再双计**）——否则承接分录 + 旧池历史余额会在 family/entity 聚合里叠加。`_account_balance_series`(`close_year`) 与 `snapshot_as_of` 同时应用。

## 验证（novel_test 环境全量 ingest）
- #16：EUR 承接分录生成、合并多 BEF 账户为一条、note 带原币金额/汇率；再调用幂等（无重复）。
- #17：`1990-01-31/06-30/09-30` 与 `12-30` 不再相等（无前视）；年底 `family:total` 无断崖。
- 2002 边界 annual family 平滑过渡（-3.10M→-3.57M→-2.59M），无双计跳变。

close #16 close #17