### PR TITLE
fix(ingest): 日期统一走 resolve_date 解析链 + date_rule 提示 (issue #19)

### DIFF
--- a/app/ingest/normalize.py
+++ b/app/ingest/normalize.py
@@ -99,6 +99,45 @@ def resolve_date(year: int, month: int | None = None, day: int | None = None,
     return date(year, 12, 30)
 
 
+_DATE_HINT_WORDS = ("年初", "年首", "月初", "上旬", "中旬", "下旬")
+
+
+def _date_hint(s: str) -> str:
+    """从原始日期文本抽提示标注（年初/月初/上中下旬），用于覆盖 resolve_date 默认。"""
+    for w in _DATE_HINT_WORDS:
+        if w in s:
+            return w
+    return ""
+
+
+def parse_date_cell(raw: str) -> tuple[date | None, str | None]:
+    """把表格日期格（timeline/bank 复用）解析为 date + 命中的规则名（DESIGN §6.2(F)）。
+
+    支持：YYYY-MM-DD / YYYY-MM / YYYY（及中文分隔 YYYY年M月D日）与 年初/月初/上中下旬
+    标注 → 统一走 resolve_date 默认规则。命中 → (date, pattern)；超规则无法解析 →
+    (None, None)，由调用方进 ingest_report 提示补 date_rule。
+    """
+    s = (raw or "").strip()
+    if not s:
+        return None, None
+    ym = re.match(r"^(?P<y>[12]\d{3})(?P<rest>.*)$", s)
+    if not ym:
+        return None, None
+    y = int(ym["y"])
+    hint = _date_hint(s)
+    # 年之后抽数值片段：1 段 → 月（year-month）；≥2 段 → 月+日（year-month-day）。
+    # 「年份」单独（rest 无数字）→ 仅年。中文 年/月/日 分隔、'-'、'/'、数字连续均解码。
+    parts = re.findall(r"\d+", ym["rest"])
+    try:
+        if len(parts) >= 2:
+            return resolve_date(y, int(parts[0]), int(parts[1])), "year-month-day"
+        if parts:
+            return resolve_date(y, int(parts[0]), hint=hint), "year-month"
+        return resolve_date(y, hint=hint), "year"
+    except ValueError:
+        return None, None
+
+
 def currency_from(seg_title: str) -> str | None:
     """从分节标题（如 `## 一、BEF（祖父）`）抽币种。"""
     for c in _CURRENCIES:

--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 
-from app.ingest.normalize import parse_number, resolve_date, currency_from
+from app.ingest.normalize import parse_number, resolve_date, currency_from, parse_date_cell
 
 
 class ParseError(Exception):
@@ -260,16 +260,20 @@ def parse_character(path: Path) -> list[dict]:
 
 
 # ---------------- timeline（时间线） ----------------
-def parse_timeline(path: Path) -> list[dict]:
+def parse_timeline(path: Path) -> tuple[list[dict], list[str]]:
     """decade 表 `年份|事件|备注`。
 
-    返回：每条事件记录（含 event_year / event_date / title / note / decade / source_file）。
+    返回：(记录, warnings)。每条事件含 event_year / event_date / title / note /
+    decade / source_file。
 
-    issue #8：parse_timeline 解析后无 writer 落库；这里额外解析 ISO 日期作为 event_date
+    issue #8：parse_timeline 解析后无 writer 落库；这里额外解析日期作 event_date
     （用于 H1 时间线对齐与日历游标快照）。
+    issue #19：日期统一走 normalize.parse_date_cell（内部 resolve_date 默认规则 F）；
+    超规则日期 → 回退当年默认 + warnings 提示补 date_rule。
     """
     lines = _lines(path)
     recs: list[dict] = []
+    warnings: list[str] = []
     decade = None
     for line in lines:
         dm = re.match(r"^#+\s*(19\d0|20\d0)s\s*$", line.strip())
@@ -277,29 +281,25 @@ def parse_timeline(path: Path) -> list[dict]:
             decade = dm.group(1) + "s"
         cells = _split_table_row(line)
         if len(cells) >= 2:
-            y = re.match(r"(\d{4})", cells[0])
+            # 首个表格格任一位置含年份即视为事件行（允许「约1992年」等日期格）
+            y = re.search(r"(?:19|20)\d{2}", cells[0])
             if y and cells[1] and "年份" not in cells[0]:
                 ds = cells[0].strip()
-                # 解析 date_str：优先 YYYY-MM-DD，其次 YYYY-MM，最后 YYYY（→ 12-30）
-                from app.ingest.normalize import resolve_date
-                fm = re.fullmatch(r"(\d{4})-(\d{2})-(\d{2})", ds)
-                fm_m = re.fullmatch(r"(\d{4})-(\d{2})", ds)
-                if fm:
-                    event_date = resolve_date(int(fm.group(1)), int(fm.group(2)), int(fm.group(3)))
-                elif fm_m:
-                    event_date = resolve_date(int(fm_m.group(1)), int(fm_m.group(2)))
-                else:
-                    event_date = resolve_date(int(y.group(1)))
+                d, _rule = parse_date_cell(ds)
+                if d is None:
+                    d = resolve_date(int(y.group(0)))  # 超规则 → 当年默认(12-30)
+                    warnings.append(
+                        f"时间线日期无法按 §6.2 解析「{ds}」，回退 {d.isoformat()}；建议补 date_rule")
                 recs.append({
-                    "event_year": int(y.group(1)),
-                    "event_date": event_date,
+                    "event_year": d.year,
+                    "event_date": d,
                     "date_str": ds,
                     "title": cells[1].strip(),
                     "note": cells[2].strip() if len(cells) > 2 else None,
                     "decade": decade,
                     "source_file": path.name,
                 })
-    return recs
+    return recs, warnings
 
 
 # ---------------- stock_tx（股票台账） ----------------
@@ -597,18 +597,23 @@ def _extract_bank_name_from_header(lines: list[str]) -> str | None:
     return None
 
 
-def parse_bank(path: Path) -> list[dict]:
+def parse_bank(path: Path) -> tuple[list[dict], list[str]]:
     """`## 一、…BEF（祖父）` 分币种节 + 流水表 `日期|理由|收入|支出|余额|备注`。
 
-    返回：每节 dict（含 seg_title / currency / holder / bank / rows）；rows 中每条流水含
-    date / reason / inflow / outflow / balance / note。
+    返回：(segments, warnings)。每节 dict（含 seg_title / currency / holder / bank /
+    rows）；rows 中每条流水含 date(date 对象) / date_raw / reason / inflow / outflow /
+    balance / note。
 
     issue #9：补持有人解析（节标题「BEF（祖父Henri Peeters注入）」→ 祖父；文件 stem
     `祖父.md` → 祖父；最终回退 holder_entity_name）；补开户行从头部注释抽取。
+    issue #19：日期统一走 normalize.parse_date_cell（resolve_date 默认规则 F），非完整
+    年月日（YYYY / YYYY-MM / 月初 / 年初 / 上中下旬）不再被整行丢弃；超规则 → 该行跳过
+    + warnings 提示补 date_rule。
     """
     from app.ingest.holders import holder_entity_name
     lines = _lines(path)
     out: list[dict] = []
+    warnings: list[str] = []
     cur_seg: dict | None = None
     file_holder = holder_entity_name(path.stem)        # 文件名兜底
     bank_name = _extract_bank_name_from_header(lines)
@@ -626,9 +631,17 @@ def parse_bank(path: Path) -> list[dict]:
             out.append(cur_seg)
         else:
             cells = _split_table_row(line)
-            if cur_seg and cells and re.match(r"\d{4}[-/－]", cells[0]):
+            if cur_seg and cells and re.match(r"\d{4}(?:[-/－]|年|$)", cells[0]):
+                d, rule = parse_date_cell(cells[0])
+                if d is None:
+                    warnings.append(
+                        f"银行流水日期无法按 §6.2 解析「{cells[0].strip()}」，该行跳过；建议补 date_rule")
+                    i += 1
+                    continue
                 cur_seg["rows"].append({
-                    "date": cells[0].strip(),
+                    "date": d,
+                    "date_raw": cells[0].strip(),
+                    "date_rule": rule,
                     "reason": cells[1].strip() if len(cells) > 1 else "",
                     "inflow": parse_number(cells[2]) if len(cells) > 2 else None,
                     "outflow": parse_number(cells[3]) if len(cells) > 3 else None,
@@ -636,4 +649,4 @@ def parse_bank(path: Path) -> list[dict]:
                     "note": cells[5].strip() if len(cells) > 5 else None,
                 })
         i += 1
-    return out
+    return out, warnings

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -11,6 +11,7 @@ from datetime import date, datetime
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.ingest.normalize import resolve_date
 from app.model import Account, Entity, ExchangeRate, IncomeStream, InitialAsset, LedgerEntry
 
 
@@ -67,7 +68,7 @@ def import_initial_assets(session: Session, records: list[dict], cash_year: int 
             cur = rec["currency"]
             acc = get_or_create_account(session, ent.id, cur)
             amort = rec["face_value"]
-            session.add(LedgerEntry(account_id=acc.id, date=date(cash_year, 12, 30),
+            session.add(LedgerEntry(account_id=acc.id, date=resolve_date(cash_year),
                                     reason="初始现金", inflow=amort, balance=amort,
                                     kind="income", source_file=rec.get("source_file")))
             stats["cash"] += 1
@@ -267,7 +268,7 @@ def import_household_expense(session: Session, records: list[dict]) -> dict:
         cur = rec.get("currency") or "BEF"
         acc = get_or_create_account(session, ent.id, cur)
         session.add(LedgerEntry(
-            account_id=acc.id, date=date(rec["year"], 12, 30), reason="家庭支出",
+            account_id=acc.id, date=resolve_date(rec["year"]), reason="家庭支出",
             outflow=rec["amount"], balance=None, kind="expense",
             source_file=rec.get("source_file"),
         ))
@@ -331,10 +332,13 @@ def import_bank(session: Session, segments: list[dict], source_file: str | None 
             if inflow is None and outflow is None:
                 continue
             dt = row.get("date")
-            try:
-                d = datetime.fromisoformat((dt or "").replace("/", "-").replace("－", "-"))
-            except (TypeError, ValueError):
-                continue
+            if isinstance(dt, date):
+                d = dt  # parse_bank 已用 parse_date_cell 归一为 date（issue #19）
+            else:
+                try:
+                    d = datetime.fromisoformat((dt or "").replace("/", "-").replace("－", "-")).date()
+                except (TypeError, ValueError):
+                    continue
             kind = _ledger_kind_from_reason(row.get("reason", ""),
                                             is_inflow=(inflow or 0) > 0)
             session.add(LedgerEntry(

--- a/tests/test_bank_parser.py
+++ b/tests/test_bank_parser.py
@@ -67,7 +67,7 @@ class TestParseBankHolderResolution:
             "|------|------|------|------|------|------|\n"
             "| 1982-01-01 | 祖父现金投资划拨 | 348.03 | | 348.03 | |\n"
         ))
-        segs = parse_bank(p)
+        segs, _w = parse_bank(p)
         assert len(segs) == 1
         # 祖父 → 规范名 Henri Peeters
         assert segs[0]["holder"] == "Henri Peeters"
@@ -82,7 +82,7 @@ class TestParseBankHolderResolution:
             "|------|------|------|------|------|------|\n"
             "| 1980-01-01 | 投资划拨 | 100 | | | |\n"
         ))
-        segs = parse_bank(p)
+        segs, _w = parse_bank(p)
         assert segs[0]["holder"] == "Frederik van Oranje"
         assert segs[0]["currency"] == "NLG"
 
@@ -98,7 +98,7 @@ class TestParseBankHolderResolution:
             "|------|------|------|------|------|------|\n"
             "| 1982-01-01 | 划拨 | 50 | | 50 | |\n"
         ))
-        segs = parse_bank(p)
+        segs, _w = parse_bank(p)
         assert len(segs) == 2
         assert segs[0]["currency"] == "BEF"
         assert segs[1]["currency"] == "LUF"
@@ -113,7 +113,7 @@ class TestParseBankHolderResolution:
             "|------|------|------|------|------|------|\n"
             "| 1982-01-01 | 划拨 | 100 | | 100 | |\n"
         ))
-        segs = parse_bank(p)
+        segs, _w = parse_bank(p)
         assert segs[0]["bank"] == "德意志银行"
 
     def test_no_holder_no_currency_segment_kept_but_holder_none(self, tmp_path):
@@ -123,7 +123,7 @@ class TestParseBankHolderResolution:
             "|------|------|------|------|------|------|\n"
             "| 1982-01-01 | 划拨 | 100 | | 100 | |\n"
         ))
-        segs = parse_bank(p)
+        segs, _w = parse_bank(p)
         # holder 解析失败 + 无兜底 → None（writer 会跳）
         assert segs[0]["holder"] is None
 
@@ -155,3 +155,29 @@ class TestLedgerKindFromReason:
 
     def test_property_income(self):
         assert _ledger_kind_from_reason("温泉庄园净值×12月", is_inflow=True) == "investment_income"
+
+class TestParseBankDateRule:
+    """issue #19：银行流水日期统一走 resolve_date 规则；超规则该行跳过 + warning。"""
+
+    def test_hinted_date_resolves(self, tmp_path):
+        p = _write(tmp_path, "祖父.md", (
+            "## 一、BEF（祖父）\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1982年初 | 现金划拨 | 100 | | 100 | |\n"
+        ))
+        segs, _w = parse_bank(p)
+        # 年初 → 1982-01-01（resolve_date 规则 F），不再被整行丢弃
+        from datetime import date as _d
+        assert segs[0]["rows"][0]["date"] == _d(1982, 1, 1)
+
+    def test_out_of_spec_skipped_warns(self, tmp_path):
+        p = _write(tmp_path, "祖父.md", (
+            "## 一、BEF（祖父）\n\n"
+            "| 日期 | 理由 | 收入 | 支出 | 余额 | 备注 |\n"
+            "|------|------|------|------|------|------|\n"
+            "| 1982-13-01 | 非法月 | 100 | | 100 | |\n"
+        ))
+        segs, warnings = parse_bank(p)
+        assert segs[0]["rows"] == []
+        assert warnings and "date_rule" in warnings[0]

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,97 @@
+"""Unit tests for app/ingest/normalize（issue #18 parse_number 万/亿、#19 parse_date_cell 日期规则）。
+
+覆盖：
+- parse_number：千分位 / ≈ / 万 / 亿 乘基数 / 失败回 None
+- parse_amount：单位剥离（含「万美金」长词优先）
+- parse_date_cell：YYYY / YYYY-MM / YYYY-MM-DD / 中文分隔 / 年初·上中下旬 / 超规则回 None
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from app.ingest.normalize import parse_number, parse_amount, parse_date_cell
+
+
+class TestParseNumber:
+    def test_thousands(self):
+        assert parse_number("12,345") == 12345.0
+
+    def test_approx(self):
+        assert parse_number("≈4,047.30") == 4047.3
+
+    def test_wan_units(self):
+        # issue #18：万 乘基数（此前静默回 None）
+        assert parse_number("1.2万") == 12000.0
+        assert parse_number("1万") == 10000.0
+
+    def test_yi_units(self):
+        # issue #18：亿 乘基数
+        assert parse_number("≈1.258亿") == 125800000.0
+        assert parse_number("2亿") == 200000000.0
+
+    def test_scale(self):
+        assert parse_number("100", scale=10.0) == 1000.0
+
+    def test_none_and_dash(self):
+        assert parse_number(None) is None
+        assert parse_number("-") is None
+        assert parse_number("—") is None
+
+    def test_invalid(self):
+        assert parse_number("abc") is None
+        assert parse_number("1.2万亿") is None  # 复合单位未支持 → None
+
+
+class TestParseAmount:
+    def test_strip_currency(self):
+        assert parse_amount("1200USD") == 1200.0
+
+    def test_wan_meijin_long_word(self):
+        # issue #18：「万美金」整词优先剥离，不再残留「美金」
+        assert parse_amount("1.2万美金") == 1.2
+
+    def test_wan_only(self):
+        assert parse_amount("1.2万") == 1.2
+
+
+class TestParseDateCell:
+    def test_iso_full(self):
+        d, p = parse_date_cell("1992-12-31")
+        assert (d, p) == (date(1992, 12, 31), "year-month-day")
+
+    def test_slash_full(self):
+        d, _p = parse_date_cell("1992/01/15")
+        assert d == date(1992, 1, 15)
+
+    def test_cn_full(self):
+        d, p = parse_date_cell("1992年6月30日")
+        assert (d, p) == (date(1992, 6, 30), "year-month-day")
+
+    def test_year_month(self):
+        # 仅年+月 → 该月月底（1992 闰年 → 2 月 29）
+        d, p = parse_date_cell("1992-02")
+        assert (d, p) == (date(1992, 2, 29), "year-month")
+
+    def test_cn_year_month(self):
+        d, p = parse_date_cell("1950年2月")
+        assert (d, p) == (date(1950, 2, 28), "year-month")
+
+    def test_early_mid_late(self):
+        assert parse_date_cell("1992年2月上旬")[0] == date(1992, 2, 1)
+        assert parse_date_cell("1992年2月中旬")[0] == date(1992, 2, 11)
+        assert parse_date_cell("1992年2月下旬")[0] == date(1992, 2, 21)
+
+    def test_beginning_of_year(self):
+        d, p = parse_date_cell("1992年初")
+        assert (d, p) == (date(1992, 1, 1), "year")
+
+    def test_year_only(self):
+        # 仅年 → 12-30（DESIGN §6.2 默认）
+        d, p = parse_date_cell("1992")
+        assert (d, p) == (date(1992, 12, 30), "year")
+
+    def test_out_of_spec(self):
+        assert parse_date_cell("约1992年") == (None, None)
+        assert parse_date_cell("1992-13-01") == (None, None)
+        assert parse_date_cell("1992-02-30") == (None, None)
+        assert parse_date_cell("") == (None, None)

--- a/tests/test_timeline_parser.py
+++ b/tests/test_timeline_parser.py
@@ -25,7 +25,7 @@ class TestParseTimelineBasic:
             "|------|------|------|\n"
             "| 1947 | 祖母去世 | 由祖父继承 |\n"
         ))
-        recs = parse_timeline(p)
+        recs, _w = parse_timeline(p)
         assert len(recs) == 1
         assert recs[0]["event_year"] == 1947
         assert recs[0]["title"] == "祖母去世"
@@ -41,7 +41,7 @@ class TestParseTimelineBasic:
             "|------|------|------|\n"
             "| 1974-01-01 | 主角出生 | - |\n"
         ))
-        recs = parse_timeline(p)
+        recs, _w = parse_timeline(p)
         assert len(recs) == 1
         assert recs[0]["event_year"] == 1974
         assert recs[0]["event_date"] == date(1974, 1, 1)
@@ -61,7 +61,7 @@ class TestParseTimelineMultiple:
             "| 1990 | 事件B | - |\n"
             "| 1992-09-16 | 黑色星期三 | 英镑脱钩ERM |\n"
         ))
-        recs = parse_timeline(p)
+        recs, _w = parse_timeline(p)
         assert len(recs) == 3
         assert [r["event_year"] for r in recs] == [1985, 1990, 1992]
         assert [r["decade"] for r in recs] == ["1980s", "1990s", "1990s"]
@@ -74,7 +74,7 @@ class TestParseTimelineMultiple:
             "|------|------|------|\n"
             "| 2008 | 金融危机 | - |\n"
         ))
-        recs = parse_timeline(p)
+        recs, _w = parse_timeline(p)
         # 表头「年份」不应被当作记录（"年份" in cells[0] → 跳过）
         assert len(recs) == 1
         assert recs[0]["event_year"] == 2008
@@ -86,7 +86,34 @@ class TestParseTimelineMultiple:
             "|------|------|------|\n"
             "| 1995 | 事件 |  |\n"
         ))
-        recs = parse_timeline(p)
+        recs, _w = parse_timeline(p)
         assert len(recs) == 1
         # 备注空白 → None 或空字符串（trim 后存）
         assert recs[0]["note"] in (None, "")
+
+class TestParseTimelineDateRule:
+    """issue #19：日期统一走 resolve_date 规则；超规则进 warnings 提示补 date_rule。"""
+
+    def test_hinted_date(self, tmp_path):
+        p = _write(tmp_path, "时间线.md", (
+            "## 1990s\n\n"
+            "| 年份 | 事件 | 备注 |\n"
+            "|------|------|------|\n"
+            "| 1992年2月上旬 | 某事 | - |\n"
+        ))
+        recs, _w = parse_timeline(p)
+        # 上旬 → 2 月 1 日（DESIGN §6.2 默认规则 F）
+        assert recs[0]["event_date"] == date(1992, 2, 1)
+
+    def test_out_of_spec_warns(self, tmp_path):
+        p = _write(tmp_path, "时间线.md", (
+            "## 1990s\n\n"
+            "| 年份 | 事件 | 备注 |\n"
+            "|------|------|------|\n"
+            "| 约1992年 | 某事 | - |\n"
+        ))
+        recs, warnings = parse_timeline(p)
+        # 超规则 → 回退当年默认(12-30) + 进 ingest_report 提示补 date_rule
+        assert recs[0]["event_date"] == date(1992, 12, 30)
+        assert warnings, "超规则日期应产生 date_rule 提示"
+        assert "date_rule" in warnings[0]


### PR DESCRIPTION
Closes #19

问题：`resolve_date` 已实现 §6.2 日期默认规则，但除 timeline 外零接入；bank 保留原始日期串（writer 手工 `fromisoformat`）、写入端手工拼 `date(year,12,30)` 重复实现规则、部分/标注日期（年初/月初/上中下旬）被静默丢弃、超规则日期无法沉淀 date_rule。

修复：
- **normalize.py** 新增 `parse_date_cell`：把表格日期格统一解析为 date + 匹配规则名（YYYY / YYYY-MM / YYYY-MM-DD / 中文分隔 / 年初·月初·上中下旬），内部走 resolve_date；超规则返回 `(None, None)`。
- **parsers.parse_timeline**：改用 parse_date_cell；超规则日期 → 回退当年默认 + warnings 提示补 date_rule（`运行期`进 ingest_report）。
- **parsers.parse_bank**：日期格不再要求 `YYYY[-/－]`，支持年内部分/标注日期（年初→01-01、上中下旬→1/11/21）；rows 的 `date` 归一为 date 对象；超规则该行跳过 + warnings。
- **writer**：`import_initial_assets`/`import_household_expense` 删手工 `date(year,12,30)` → `resolve_date(year)`（单一事实源）；`import_bank` 直接用解析后的 date 对象。
- **tests**：新增 `tests/test_normalize.py`（parse_number 万/亿 + parse_date_cell 全规则）、timeline/bank 补超规则→ingest_report 提示回归。

验证：`pytest` 104 通过；`.venv/bin/python` 对 Design_Folder 全量 parse 冒烟：435 条银行流水均归一为 date 对象，0 条误报 date_rule。