### PR TITLE
fix(model): finance_entry.entity_kind 加 CHECK 约束 (issue #20)

### DIFF
--- a/app/model/core.py
+++ b/app/model/core.py
@@ -118,6 +118,7 @@ class FinanceEntry(Base):
     __tablename__ = "finance_entry"
     __table_args__ = (
         CheckConstraint("kind IN ('income','expense','investment','investment_income','pool')", name="ck_finance_kind"),
+        CheckConstraint("entity_kind IN ('person','company')", name="ck_finance_entity_kind"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)

--- a/migrations/versions/a1b2c3d4e5f6_finance_entry_entity_kind_check.py
+++ b/migrations/versions/a1b2c3d4e5f6_finance_entry_entity_kind_check.py
@@ -1,0 +1,23 @@
+"""finance_entry.entity_kind 加 CHECK（DESIGN §5.2：仅 person/company）。
+
+Revision ID: a1b2c3d4e5f6
+Revises: 827c44be1b80
+Create Date: 2026-08-23
+"""
+from alembic import op
+
+revision = 'a1b2c3d4e5f6'
+down_revision = '827c44be1b80'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 先清存量脏数据（DESIGN §5.2：entity_kind 仅 person/company）；当前无写路径、表为空 → 通常 no-op
+    op.execute("DELETE FROM finance_entry WHERE entity_kind NOT IN ('person','company')")
+    op.create_check_constraint(
+        "ck_finance_entity_kind", "finance_entry", "entity_kind IN ('person','company')")
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_finance_entity_kind", "finance_entry", type_="check")


### PR DESCRIPTION
Closes #20

问题：DESIGN §5.2 finance_entry DDL 要求 `entity_kind TEXT NOT NULL CHECK (entity_kind IN ('person','company'))`；ORM（`app/model/core.py`）与基础迁移（827c44be1b80）都只有 `ck_finance_kind`（针对 `kind` 列），`entity_kind` 仅有 NOT NULL（注解推断）、取值无约束 → 任意字符串可写入，破坏 F-P1-07「以 person/company 为中心浏览」前提。

修复：
- **ORM** `FinanceEntry.__table_args__` 补 `CheckConstraint("entity_kind IN ('person','company')", name="ck_finance_entity_kind")`。
- **迁移** 新增 `a1b2c3d4e5f6`（down_revision=827c44be1b80）：升级先 `DELETE` 存量脏数据（非 person/company 行）再 `op.create_check_constraint`；降级 `drop_constraint`。

影响：`finance_entry` 当前无写路径（仅模型定义，为 F-P1-07 预留），加约束零风险。三环境 `APP_ENV=dev/test/prod .venv/bin/alembic upgrade head` 各跑一次即可。

验证：`.venv/bin/alembic heads` 单 head；`alembic upgrade a1b2c3d4e5f6 --sql` 生成正确 DDL（DELETE + ADD CONSTRAINT ck_finance_entity_kind CHECK）；ORM `c.sqltext == "entity_kind IN ('person','company')"`；pytest 104 通过。