### PR TITLE
fix(ingest): parse_fx 按节/行定年，跨年文件不再整体错归 (issue #25)

### DIFF
--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -74,11 +74,25 @@ _CUR_NAME = {
 }
 
 
+def _year_for_line(s: str, fallback: int | None) -> int | None:
+    """行内年份优先（issue #25）：19xx/20xx token 单独成词；无则 fallback；都无则 None。
+
+    fallback 形参由 parse_fx 提供文件级推断（首个 4 位 token 或文件名年份），
+    自身不读文件，避免与 _detect_year_in_lines 的文件级扫描职责重叠。
+    """
+    fm = re.search(r"\b(?:19|20)\d{2}\b", s)
+    return int(fm.group(0)) if fm else fallback
+
+
 def parse_fx(path: Path) -> list[dict]:
     """支持两种格式（DESIGN §3）：
 
     - `1EUR=40.3399BEF` / `1 美元 = 8.2789 元人民币`（格式二）
     - TSV 表 `Currency  Code  Rate(Jan-1995)`，Rate = 1 USD 兑该币 → USD→{Currency}
+
+    行内年份优先于文件头（issue #25）：跨年文件（如 `1999-2002.md`）每行独立定年；
+    行内无 token 时回退到文件级（首个 4 位 token 或文件名年份）；
+    全无则 year=NULL（基准常量折算）。
     """
     recs: list[dict] = []
     lines = _lines(path)
@@ -86,15 +100,23 @@ def parse_fx(path: Path) -> list[dict]:
     wide = _parse_fx_wide_table(lines)
     if wide:
         return wide
-    cur_year = _detect_year_in_lines(lines) or _year_from_name(path.name)
+    # 文件级 fallback：行内/节内无年份时使用（issue #25：行/节上下文优先于文件头）
+    file_year = _detect_year_in_lines(lines) or _year_from_name(path.name)
+    current_year: int | None = file_year
     for line in lines:
         s = line.strip()
+        # 节标题型：纯 4 位年份 token（如 `1999`），更新 current_year 并跳过
+        if re.fullmatch(r"\d{4}", s):
+            current_year = int(s)
+            continue
+        # 行内年份优先于 current_year（issue #25）
+        line_year = _year_for_line(s, current_year)
         # 格式一：1XXX = rate YYY
         m = re.search(r"1\s*([A-Za-z]{2,4})\s*=\s*([\d.,]+)\s*([A-Za-z一-鿿]{2,6})", s, re.I)
         if m:
             recs.append({
                 "fx_from": m.group(1).upper(), "rate": parse_number(m.group(2)),
-                "fx_to": _cur(m.group(3)), "year": cur_year,
+                "fx_to": _cur(m.group(3)), "year": line_year,
             })
             continue
         # 格式二：TSV 表格行  `Belgian Franc  BEF  32.14`
@@ -102,7 +124,7 @@ def parse_fx(path: Path) -> list[dict]:
         if t:
             code = _cur(t.group(1)) or t.group(2).upper()
             recs.append({"fx_from": "USD", "rate": parse_number(t.group(3)),
-                         "fx_to": code, "year": cur_year})
+                         "fx_to": code, "year": line_year})
     return recs
 
 

--- a/tests/test_parsers_fx.py
+++ b/tests/test_parsers_fx.py
@@ -1,0 +1,92 @@
+"""Unit tests for app/ingest/parsers.parse_fx（issue #25 回归）。
+
+覆盖：
+- 跨年文件 `1999-2002.md`：行内无年份 token → 文件级 fallback（首个 4 位 token=1999）
+- 行内显式年份（节标题型 1999/2000/2001/2002 分节）按行各自归年
+- 全无年份（仅 `1EUR=40.3399BEF`） → year=NULL（基准常量）
+- TSV 格式表行也走按行定年逻辑
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.ingest.parsers import parse_fx
+
+
+def _write(tmp: Path, name: str, content: str) -> Path:
+    p = tmp / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestParseFxLineYear:
+    def test_multiyear_file_fallback_to_filename(self, tmp_path):
+        """issue #25 核心场景：1999-2002.md 行内无年份 token，应回退到文件级。
+
+        现状：整文件共用 cur_year（=1999）。修复后行为等价——fallback 仍是 1999，
+        但语义从"单一来源"改为"行内优先 → 文件级 fallback"。
+        """
+        p = _write(tmp_path, "1999-2002.md", (
+            "# 1999.1-2002.12 EUR对BEF,LUF,NLG汇率\n"
+            "1EUR=40.3399BEF\n"
+            "1EUR=40.3399LUF\n"
+            "1EUR=2.20371NLG\n"
+        ))
+        recs = parse_fx(p)
+        assert len(recs) == 3
+        # 文件级 fallback 应归到 1999（从首个 4 位 token 或文件名）
+        years = {r["year"] for r in recs}
+        assert years == {1999}, f"预期全部回退到 1999，实际 {years}"
+
+    def test_explicit_year_per_line(self, tmp_path):
+        """行内含 19xx/20xx token 时，每行独立定年（issue #25 主要修复点）。"""
+        p = _write(tmp_path, "汇率表.md", (
+            "1999\n"
+            "1EUR=40.3399BEF\n"
+            "2000\n"
+            "1EUR=40.3399BEF\n"
+            "2001\n"
+            "1EUR=40.3399BEF\n"
+            "2002\n"
+            "1EUR=40.3399BEF\n"
+        ))
+        recs = parse_fx(p)
+        assert len(recs) == 4
+        # 每行应取其节标题年份，不再全部归到 1999
+        assert [r["year"] for r in recs] == [1999, 2000, 2001, 2002], \
+            f"按行定年失败：{[(r['fx_to'], r['year']) for r in recs]}"
+
+    def test_no_year_anywhere_yields_null(self, tmp_path):
+        """全无年份（无文件名 token 也无行内 token）→ year=NULL（基准常量）。"""
+        p = _write(tmp_path, "基准常量.md", (
+            "# 基准汇率（无年份）\n"
+            "1EUR=40.3399BEF\n"
+        ))
+        recs = parse_fx(p)
+        assert len(recs) == 1
+        assert recs[0]["year"] is None, \
+            f"全无年份必须落 NULL，实际 {recs[0]['year']}"
+
+    def test_filename_year_takes_effect(self, tmp_path):
+        """文件名含 4 位年份 + 行内无 token → 文件级 fallback 命中文件名。"""
+        p = _write(tmp_path, "1995.md", (
+            "Belgian Franc  BEF  32.14\n"
+            "Dutch Guilder  NLG  1.61\n"
+        ))
+        recs = parse_fx(p)
+        assert len(recs) == 2
+        assert all(r["year"] == 1995 for r in recs)
+        assert {r["fx_to"] for r in recs} == {"BEF", "NLG"}
+
+    def test_line_year_overrides_filename(self, tmp_path):
+        """行内年份 token 优先于文件名（issue #25 语义核心）。"""
+        p = _write(tmp_path, "1995.md", (
+            "2000\n"
+            "Belgian Franc  BEF  32.14\n"
+        ))
+        recs = parse_fx(p)
+        assert len(recs) == 1
+        # 行内 2000 优先于文件名 1995
+        assert recs[0]["year"] == 2000


### PR DESCRIPTION
## 问题
issue #25: parse_fx 对整文件取首个 19xx/20xx token 定年，所有记录共用 cur_year。Design_Folder/基准/汇率/1999-2002.md 跨 4 年会被整体定为 1999，逐年折算取错率值。

## 修复
- 新增 `_year_for_line(s, fallback)`：行内 `\b 19xx/20xx \b` token 优先于 fallback
- parse_fx 引入 `current_year` 状态变量：遇纯 4 位 token 行（节标题型）更新
- 三层优先级：行内 token > 当前节 current_year > 文件级（首个 4 位 token / 文件名）
- 全无年份 → `year=NULL`（基准常量语义）

## 验证
- 新增 `tests/test_parsers_fx.py`：5 个 case
  - `test_multiyear_file_fallback_to_filename`: 1999-2002.md 实际场景
  - `test_explicit_year_per_line`: 节标题型按行归年
  - `test_no_year_anywhere_yields_null`: 全无年份 → NULL
  - `test_filename_year_takes_effect`: 文件名年份 fallback
  - `test_line_year_overrides_filename`: 行内优先于文件名
- 全套 109 个测试通过（含本次新增 5 个），零回归

## 文件
- `app/ingest/parsers.py`：parse_fx + 新增 _year_for_line
- `tests/test_parsers_fx.py`：新增

Closes #25