### PR TITLE
fix(model): DDL 类型对齐 JSONB/ARRAY(Text)/时间戳 server_default (issue #21)

### DIFF
--- a/app/model/core.py
+++ b/app/model/core.py
@@ -8,10 +8,15 @@ from sqlalchemy import (
     JSON, BigInteger, Boolean, CheckConstraint, Date, ForeignKey, Index,
     Integer, Numeric, String, Text, UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
 from app.model.types import AccountStatus, EntityType, LedgerKind, SourceKind, StreamType
+
+# issue #21：测试在 SQLite 上跑（无 JSONB），生产 Postgres 才用 JSONB。with_variant 是
+# SQLAlchemy 标准 fallback 模式——同一 Python 类型在两个 dialect 都可读写。
+JSONBCompat = JSONB().with_variant(JSON(), "sqlite")
 
 
 class Entity(Base):
@@ -26,7 +31,7 @@ class Entity(Base):
     name: Mapped[str] = mapped_column(String, nullable=False)
     display_name: Mapped[Optional[str]] = mapped_column(String)
     status: Mapped[Optional[str]] = mapped_column(String, comment="公司状态（仅 company；只增不减）")
-    fields: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False, server_default="{}")
+    fields: Mapped[dict] = mapped_column(JSONBCompat, default=dict, nullable=False, server_default="{}")
     source_file: Mapped[Optional[str]] = mapped_column(Text)
     source_line: Mapped[Optional[int]] = mapped_column(Integer)
     source: Mapped[Optional[str]] = mapped_column(String, default=SourceKind.FILE.value)

--- a/app/model/derived.py
+++ b/app/model/derived.py
@@ -1,16 +1,51 @@
 """Derived / reference tables (DESIGN §5.2): return_curve, fx, snapshot, timeline, jobs..."""
 from __future__ import annotations
 
+import json
 from datetime import date, datetime
 from typing import Optional
 
 from sqlalchemy import (
     BigInteger, Boolean, CheckConstraint, Date, DateTime, ForeignKey, Index,
-    Integer, JSON, Numeric, String, Text, UniqueConstraint,
+    Integer, JSON, Numeric, String, Text, UniqueConstraint, func,
 )
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import TypeDecorator
 
 from app.db import Base
+
+
+# issue #21：测试在 SQLite 上跑（无 JSONB / ARRAY），生产 Postgres 才用原生类型。
+# JSONB → JSON：with_variant 标准模式（JSON 文本透明序列化）。
+JSONBCompat = JSONB().with_variant(JSON(), "sqlite")
+
+
+class ArrayTextCompat(TypeDecorator):
+    """ARRAY(Text) 的 SQLite fallback：测试用 JSON 存 list[str]。
+
+    Postgres 直通 ARRAY(Text)；SQLite 用 JSON 存 list 字符串，读回 list。
+    """
+    impl = ARRAY(Text)
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "sqlite":
+            return dialect.type_descriptor(JSON())
+        return dialect.type_descriptor(ARRAY(Text))
+
+    def process_bind_param(self, value, dialect):
+        if dialect.name == "sqlite" and value is not None and not isinstance(value, (str, bytes)):
+            return list(value)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if dialect.name == "sqlite" and isinstance(value, str):
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                return value
+        return value
 
 
 class ReturnCurve(Base):
@@ -89,8 +124,10 @@ class UserDataOverlay(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     section: Mapped[str] = mapped_column(String, nullable=False, comment="'timeline' 等")
     key: Mapped[str] = mapped_column(String, nullable=False)
-    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONBCompat, nullable=False)
+    # issue #21：原实现无 server_default 也无 Python default，INSERT 必炸 NOT NULL
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now())
 
 
 class Snapshot(Base):
@@ -117,7 +154,9 @@ class SourceFileVersion(Base):
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
     version: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    captured_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # issue #21：补 server_default，否则 raw SQL/COPY 插入遇 NOT NULL 失败
+    captured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now())
     is_current: Mapped[Optional[bool]] = mapped_column(Boolean)
 
 
@@ -128,9 +167,12 @@ class RecomputeJob(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     start_year: Mapped[Optional[int]] = mapped_column(Integer)
     reason: Mapped[Optional[str]] = mapped_column(Text)
-    files: Mapped[Optional[list]] = mapped_column(JSON)
+    # issue #21：DESIGN §5.2 DDL 为 TEXT[]，实现误用 JSON；改回 ARRAY(Text) 恢复数组语义
+    files: Mapped[Optional[list[str]]] = mapped_column(ArrayTextCompat())
     status: Mapped[Optional[str]] = mapped_column(String, default="pending")
-    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    # issue #21：补 server_default
+    created_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), server_default=func.now())
     finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
 
 
@@ -142,9 +184,11 @@ class Notification(Base):
     kind: Mapped[Optional[str]] = mapped_column(String)
     title: Mapped[Optional[str]] = mapped_column(String)
     message: Mapped[Optional[str]] = mapped_column(Text)
-    payload: Mapped[Optional[dict]] = mapped_column(JSON)
+    payload: Mapped[Optional[dict]] = mapped_column(JSONBCompat)
     read_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
-    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    # issue #21：补 server_default
+    created_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), server_default=func.now())
 
 
 class Investment(Base):

--- a/migrations/versions/b1c2d3e4f5a6_ddl_jsonb_array_server_defaults.py
+++ b/migrations/versions/b1c2d3e4f5a6_ddl_jsonb_array_server_defaults.py
@@ -1,0 +1,74 @@
+"""DDL 类型对齐（DESIGN §5.2 + issue #21）。
+
+JSONB/ARRAY/时间戳 server_default 落地：
+1. entity.fields:          JSON  → JSONB
+2. user_data_overlay.payload: JSON  → JSONB
+3. notification.payload:   JSON  → JSONB
+4. recompute_job.files:    JSON  → TEXT[]  (DESIGN §5.2 DDL 是 TEXT[])
+5. 时间戳列补 server_default=now()：
+   - source_file_version.captured_at
+   - recompute_job.created_at
+   - user_data_overlay.updated_at  (关键：连 Python default 都没有，INSERT 必炸 NOT NULL)
+   - notification.created_at
+
+downgrade 镜像反向：JSONB → JSON、ARRAY(Text) → JSON、移除 server_default。
+files 字段的 ARRAY↔JSON 转换用 jsonb_array_elements_text 还原数组。
+"""
+from alembic import op
+
+
+revision = 'b1c2d3e4f5a6'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ---- JSON → JSONB ----
+    op.execute("ALTER TABLE entity ALTER COLUMN fields TYPE JSONB USING fields::jsonb")
+    op.execute("ALTER TABLE user_data_overlay ALTER COLUMN payload TYPE JSONB USING payload::jsonb")
+    op.execute("ALTER TABLE notification ALTER COLUMN payload TYPE JSONB USING payload::jsonb")
+
+    # ---- JSON → TEXT[] ----
+    # 现状 files 是 JSON 列，存量数据可能是：
+    # - NULL
+    # - JSON 数组（jsonb_typeof = 'array'）→ ARRAY(SELECT jsonb_array_elements_text(...))
+    # - JSON 标量/对象（理论上不应出现）→ 包成单元素数组，保守不丢数据
+    op.execute("""
+        ALTER TABLE recompute_job ALTER COLUMN files TYPE TEXT[]
+        USING CASE
+            WHEN files IS NULL THEN NULL
+            WHEN jsonb_typeof(files::jsonb) = 'array'
+                THEN ARRAY(SELECT jsonb_array_elements_text(files::jsonb))
+            ELSE ARRAY[files::text]
+        END
+    """)
+
+    # ---- 时间戳列 server_default ----
+    # user_data_overlay.updated_at 必须显式设置（NOT NULL 无 default → INSERT 炸）
+    op.execute("ALTER TABLE user_data_overlay ALTER COLUMN updated_at SET DEFAULT now()")
+    op.execute("ALTER TABLE source_file_version ALTER COLUMN captured_at SET DEFAULT now()")
+    op.execute("ALTER TABLE recompute_job ALTER COLUMN created_at SET DEFAULT now()")
+    op.execute("ALTER TABLE notification ALTER COLUMN created_at SET DEFAULT now()")
+
+
+def downgrade() -> None:
+    # ---- 移除 server_default ----
+    op.execute("ALTER TABLE notification ALTER COLUMN created_at DROP DEFAULT")
+    op.execute("ALTER TABLE recompute_job ALTER COLUMN created_at DROP DEFAULT")
+    op.execute("ALTER TABLE source_file_version ALTER COLUMN captured_at DROP DEFAULT")
+    op.execute("ALTER TABLE user_data_overlay ALTER COLUMN updated_at DROP DEFAULT")
+
+    # ---- TEXT[] → JSON ----
+    op.execute("""
+        ALTER TABLE recompute_job ALTER COLUMN files TYPE JSON
+        USING CASE
+            WHEN files IS NULL THEN NULL
+            ELSE to_jsonb(files)::text::json
+        END
+    """)
+
+    # ---- JSONB → JSON ----
+    op.execute("ALTER TABLE notification ALTER COLUMN payload TYPE JSON USING payload::jsonb")
+    op.execute("ALTER TABLE user_data_overlay ALTER COLUMN payload TYPE JSON USING payload::jsonb")
+    op.execute("ALTER TABLE entity ALTER COLUMN fields TYPE JSON USING fields::jsonb")


### PR DESCRIPTION
## 问题
issue #21: DESIGN §5.2 DDL 与 SQLAlchemy 实现偏差：
- 3 处 JSONB 被实现成 sa.JSON（entity.fields / user_data_overlay.payload / notification.payload）
- recompute_job.files DDL 为 TEXT[]，实现误用 sa.JSON（数组语义被丢成文档）
- 4 处时间戳列无 server_default；其中 user_data_overlay.updated_at 连 Python default 都没有，INSERT 必炸 NOT NULL

## 修复

### 模型（app/model/core.py / app/model/derived.py）
- import `sa.dialects.postgresql.JSONB`
- 3 处 JSON → JSONBCompat（`JSONB().with_variant(JSON(), 'sqlite')`，测试 SQLite 兼容）
- files → ArrayTextCompat（TypeDecorator：Postgres ARRAY(Text)、SQLite fallback JSON list）
- 4 处时间戳加 `server_default=func.now()`

### Alembic 迁移（b1c2d3e4f5a6）
```sql
ALTER TABLE entity ALTER COLUMN fields TYPE JSONB USING fields::jsonb;
ALTER TABLE user_data_overlay ALTER COLUMN payload TYPE JSONB USING payload::jsonb;
ALTER TABLE notification ALTER COLUMN payload TYPE JSONB USING payload::jsonb;

ALTER TABLE recompute_job ALTER COLUMN files TYPE TEXT[]
  USING CASE
    WHEN files IS NULL THEN NULL
    WHEN jsonb_typeof(files::jsonb) = 'array'
      THEN ARRAY(SELECT jsonb_array_elements_text(files::jsonb))
    ELSE ARRAY[files::text]
  END;

ALTER TABLE user_data_overlay ALTER COLUMN updated_at SET DEFAULT now();
ALTER TABLE source_file_version ALTER COLUMN captured_at SET DEFAULT now();
ALTER TABLE recompute_job ALTER COLUMN created_at SET DEFAULT now();
ALTER TABLE notification ALTER COLUMN created_at SET DEFAULT now();
```
downgrade 镜像反向。

## 验证
- 全套 109 测试通过（SQLite 路径走 with_variant/TypeDecorator fallback）
- ⚠ 提交后请本地三库各跑：
  `APP_ENV=dev .venv/bin/alembic upgrade head`（test/prod 同理）

## 影响
- 恢复 JSONB GIN/运算符能力、ARRAY 数组语义
- 修掉 raw SQL/COPY 遇 NOT NULL 失败的隐患
- 0 行为变化（应用层读写 API 不变）

Closes #21