### PR TITLE
fix(health): 补负余额/汇率覆盖检查，H4 首条校验，H3 对称 NULL 回退 (issue #22)

### DIFF
--- a/app/core/health.py
+++ b/app/core/health.py
@@ -61,29 +61,43 @@ def check_h2_amount_consistency(session: Session) -> list[Finding]:
 
 
 def check_h3_fx_closure(session: Session) -> list[Finding]:
-    """H3 汇率链自洽：A→B→C 闭合回 A→C（简化：同 %年 直接 vs 链式差>0.5% 报）。"""
+    """H3 汇率链自洽：A→B→C 闭合回 A→C（简化：同 %年 直接 vs 链式差>0.5% 报）。
+
+    issue #22：direct 侧也回退到常量键 0，与链式两侧对称；任一侧缺值则跳过该年。
+    """
     finds: list[Finding] = []
     rates = session.execute(select(ExchangeRate)).scalars().all()
     by_pair: dict[tuple[str, str], dict[int, float]] = {}
     for r in rates:
         by_pair.setdefault((r.fx_from, r.fx_to), {})[r.year or 0] = r.rate
     pairs = list(by_pair)
+
+    def _val(pair: tuple[str, str], y: int) -> float | None:
+        """统一 NULL 回退：y → 常量键 0；都无则 None（跳过判定）。"""
+        return pair_data.get(y, pair_data.get(0)) if (pair_data := by_pair.get(pair)) else None
+
     for (a, b) in pairs:
         for (c, d) in pairs:
             if not (b == c and (a, d) in by_pair):
                 continue
             for y in by_pair[(a, b)]:
-                v1 = by_pair[(a, b)].get(y, by_pair[(a, b)].get(0))
-                v2 = by_pair[(c, d)].get(y, by_pair[(c, d)].get(0))
-                direct = by_pair[(a, d)].get(y)
-                if v1 and v2 and direct and abs(v1 * v2 - direct) / direct > 0.005:
+                v1 = _val((a, b), y)
+                v2 = _val((c, d), y)
+                direct = _val((a, d), y)
+                if v1 is None or v2 is None or direct is None or direct == 0:
+                    continue
+                if abs(v1 * v2 - direct) / direct > 0.005:
                     finds.append(Finding("H3", "crit", f"{a}→{b}→{d} @{y}",
                                          f"链式 {v1*v2:.4f} ≠ 直接 {direct}"))
     return finds
 
 
 def check_h4_balance_chain(session: Session) -> list[Finding]:
-    """H4 余额连续：ledger 按 account 排序，后一余额 = 前一 + 入 − 出。"""
+    """H4 余额连续：ledger 按 account 排序，后一余额 = 前一 + 入 − 出。
+
+    issue #22：从 i=0 起，首条 prev 视为 0（无前余额），单独校验
+    balance == inflow - outflow（不让首条失核逃逸）。
+    """
     finds: list[Finding] = []
     acct_ids = session.execute(select(func.distinct(LedgerEntry.account_id))).scalars().all()
     for aid in acct_ids:
@@ -91,13 +105,59 @@ def check_h4_balance_chain(session: Session) -> list[Finding]:
             select(LedgerEntry).where(LedgerEntry.account_id == aid)
             .order_by(LedgerEntry.date, LedgerEntry.id)
         ).scalars().all()
-        for i in range(1, len(entries)):
-            prev, cur = entries[i - 1], entries[i]
-            expect = (prev.balance or 0) + (cur.inflow or 0) - (cur.outflow or 0)
-            if cur.balance is not None and abs(cur.balance - expect) > 0.005:
+        for i, cur in enumerate(entries):
+            prev_bal = 0 if i == 0 else (entries[i - 1].balance or 0)
+            if cur.balance is None:
+                continue
+            expect = prev_bal + (cur.inflow or 0) - (cur.outflow or 0)
+            if abs(cur.balance - expect) > 0.005:
                 acc = session.get(Account, aid)
-                finds.append(Finding("H4", "crit", f"account#{aid}({acc.currency if acc else '?'}) {cur.date}",
-                                     f"余额 {cur.balance} ≠ 前{prev.balance}+入{cur.inflow}-出{cur.outflow}={expect:.2f}"))
+                if i == 0:
+                    msg = f"首条余额 {cur.balance} ≠ 入{cur.inflow}-出{cur.outflow}={expect:.2f}"
+                else:
+                    msg = (f"余额 {cur.balance} ≠ 前{prev_bal}+入{cur.inflow}-出{cur.outflow}={expect:.2f}")
+                finds.append(Finding("H4", "crit",
+                                     f"account#{aid}({acc.currency if acc else '?'}) {cur.date}", msg))
+    return finds
+
+
+def check_negative_balance(session: Session) -> list[Finding]:
+    """issue #22：负余额检查。账户余额为负数极可能是计算错误（DESIGN 数值纪律要求
+    账户余额非负；个别场景如短贷可豁免但需 source 注释）。
+
+    仅在 balance 列有非 None 值时检查。报 warn（不阻断重算，便于人工复核）。
+    """
+    finds: list[Finding] = []
+    neg_rows = session.execute(
+        select(LedgerEntry.account_id, LedgerEntry.date, LedgerEntry.balance)
+        .where(LedgerEntry.balance < 0)
+        .order_by(LedgerEntry.account_id, LedgerEntry.date)
+    ).all()
+    for aid, dt, bal in neg_rows:
+        acc = session.get(Account, aid)
+        finds.append(Finding("H4", "warn",
+                             f"account#{aid}({acc.currency if acc else '?'}) {dt}",
+                             f"负余额 {bal}"))
+    return finds
+
+
+def check_fx_coverage(session: Session) -> list[Finding]:
+    """issue #22：汇率表覆盖提示。空表 → warn（USD 折算空转不可见）；
+    有数据但所有行 year=NULL → warn（按基准常量折算，无法逐年）。
+
+    不报具体覆盖率——account/ledger 跨年缺失率留给应用层计算；这里只暴露最
+    显著的两种盲区（完全空 / 全部常量）。
+    """
+    finds: list[Finding] = []
+    total = session.execute(select(func.count()).select_from(ExchangeRate)).scalar() or 0
+    if total == 0:
+        finds.append(Finding("H3", "warn", "exchange_rate", "表为空，USD 折算空转不可见"))
+        return finds
+    null_year = session.execute(
+        select(func.count()).select_from(ExchangeRate).where(ExchangeRate.year.is_(None))
+    ).scalar() or 0
+    if null_year == total:
+        finds.append(Finding("H3", "warn", "exchange_rate", "全部 year=NULL，仅基准常量折算"))
     return finds
 
 
@@ -126,7 +186,9 @@ def run_report(session: Session) -> list[dict]:
     all_finds: list[Finding] = []
     all_finds += check_h1_timeline_alignment(session)
     all_finds += check_h2_amount_consistency(session)
+    all_finds += check_fx_coverage(session)
     all_finds += check_h3_fx_closure(session)
+    all_finds += check_negative_balance(session)
     all_finds += check_h4_balance_chain(session)
     all_finds += check_h5_dangling(session)
     return [f.as_dict() for f in all_finds]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,185 @@
+"""Unit tests for app/core/health（issue #22 回归）。
+
+覆盖：
+- H4 首条校验（i=0 起）：balance != inflow-outflow 应报错
+- H4 链式连续性：i>0 时 prev.balance + in - out 不等报错
+- H3 对称 NULL 回退：direct 缺失时不应误报（issue #22 修复点）
+- 负余额检查：balance < 0 时 warn
+- 汇率表空检查：exchange_rate 为空时 warn
+- 汇率表全 NULL year 检查：仅基准常量折算时 warn
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.health import (
+    check_fx_coverage, check_h3_fx_closure, check_h4_balance_chain,
+    check_negative_balance, run_report,
+)
+from app.db import Base
+from app.model import Account, Entity, ExchangeRate, LedgerEntry
+
+
+@pytest.fixture
+def session():
+    """内存 SQLite + 临时 DDL；BigInteger PK → Integer 兼容 SQLite autoincrement。"""
+    from sqlalchemy import BigInteger, Integer
+
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed_entity(session, name="Henri Peeters") -> Entity:
+    e = Entity(entity_type="person", name=name)
+    session.add(e)
+    session.flush()
+    return e
+
+
+def _seed_account(session, entity: Entity, currency="BEF") -> Account:
+    a = Account(entity_id=entity.id, currency=currency)
+    session.add(a)
+    session.flush()
+    return a
+
+
+class TestH4FirstEntryChecked:
+    def test_first_entry_mismatch_reports(self, session):
+        """issue #22 修复点：i=0 首条 balance != inflow-outflow 必须报错。
+
+        此前因 for i in range(1, ...) 跳过首条，导致首条失核逃逸。
+        """
+        e = _seed_entity(session)
+        a = _seed_account(session, e)
+        # 首条：inflow=100, outflow=20, balance=1000（应等于 80）
+        session.add(LedgerEntry(account_id=a.id, date=date(1990, 1, 1),
+                                inflow=100, outflow=20, balance=1000))
+        session.commit()
+        finds = check_h4_balance_chain(session)
+        crit = [f for f in finds if f.level == "crit"]
+        assert len(crit) == 1, f"首条失核必须报错；got {crit}"
+        assert "首条" in crit[0].detail
+
+    def test_first_entry_consistent_passes(self, session):
+        """首条 balance == inflow - outflow 时不报错。"""
+        e = _seed_entity(session)
+        a = _seed_account(session, e)
+        session.add(LedgerEntry(account_id=a.id, date=date(1990, 1, 1),
+                                inflow=100, outflow=20, balance=80))
+        session.commit()
+        finds = check_h4_balance_chain(session)
+        assert finds == [], f"首条合法应零报错；got {finds}"
+
+    def test_chain_break_after_first(self, session):
+        """链式连续性：第二条开始按 prev.balance + in - out 校验。"""
+        e = _seed_entity(session)
+        a = _seed_account(session, e)
+        session.add_all([
+            LedgerEntry(account_id=a.id, date=date(1990, 1, 1), inflow=100, balance=100),
+            # 第二条：应=100+50-10=140，写成 200 应报错
+            LedgerEntry(account_id=a.id, date=date(1990, 6, 1), inflow=50, outflow=10, balance=200),
+        ])
+        session.commit()
+        finds = check_h4_balance_chain(session)
+        crit = [f for f in finds if "余额" in f.detail]
+        assert any("200" in f.detail and "140" in f.detail for f in crit), \
+            f"链式断链未报错；got {crit}"
+
+
+class TestH3SymmetricNullFallback:
+    def test_direct_missing_no_false_alarm(self, session):
+        """issue #22 修复点：direct 侧缺值时不应误报（H3 链式 vs 直接）。"""
+        # A→B 和 B→C 都有，direct A→C 没有
+        session.add_all([
+            ExchangeRate(fx_from="USD", fx_to="EUR", year=2000, rate=0.9),
+            ExchangeRate(fx_from="EUR", fx_to="BEF", year=2000, rate=40.34),
+            # 故意无 USD→BEF direct
+        ])
+        session.commit()
+        finds = check_h3_fx_closure(session)
+        assert finds == [], f"direct 缺失不应误报；got {finds}"
+
+    def test_three_way_break_reports(self, session):
+        """三向都有但不一致 → crit。"""
+        session.add_all([
+            ExchangeRate(fx_from="USD", fx_to="EUR", year=2000, rate=0.9),
+            ExchangeRate(fx_from="EUR", fx_to="BEF", year=2000, rate=40.0),  # 链式 36.0
+            ExchangeRate(fx_from="USD", fx_to="BEF", year=2000, rate=40.0),  # direct 40.0
+        ])
+        session.commit()
+        finds = check_h3_fx_closure(session)
+        assert any(f.rule == "H3" and f.level == "crit" for f in finds)
+
+
+class TestNegativeBalance:
+    def test_negative_balance_warns(self, session):
+        """issue #22：负余额 warn（H4 级别，但 level=warn 不阻断）。"""
+        e = _seed_entity(session)
+        a = _seed_account(session, e)
+        session.add(LedgerEntry(account_id=a.id, date=date(1990, 1, 1),
+                                inflow=50, outflow=100, balance=-50))
+        session.commit()
+        finds = check_negative_balance(session)
+        assert len(finds) == 1
+        assert finds[0].level == "warn"
+        assert "-50" in finds[0].detail
+
+    def test_positive_balance_no_warn(self, session):
+        session.add(LedgerEntry(account_id=_seed_account(session, _seed_entity(session)).id,
+                                date=date(1990, 1, 1), inflow=100, balance=100))
+        session.commit()
+        assert check_negative_balance(session) == []
+
+
+class TestFxCoverage:
+    def test_empty_table_warns(self, session):
+        """issue #22：exchange_rate 为空 → warn（USD 折算空转不可见）。"""
+        finds = check_fx_coverage(session)
+        assert len(finds) == 1
+        assert finds[0].level == "warn"
+        assert "空" in finds[0].detail
+
+    def test_all_null_year_warns(self, session):
+        """全部 year=NULL → warn（仅基准常量折算，无逐年）。"""
+        session.add(ExchangeRate(fx_from="USD", fx_to="EUR", year=None, rate=0.9))
+        session.commit()
+        finds = check_fx_coverage(session)
+        assert len(finds) == 1
+        assert "常量" in finds[0].detail
+
+    def test_mixed_years_no_warn(self, session):
+        """有 year 不全 NULL → 不报（覆盖足够）。"""
+        session.add_all([
+            ExchangeRate(fx_from="USD", fx_to="EUR", year=2000, rate=0.9),
+            ExchangeRate(fx_from="USD", fx_to="EUR", year=None, rate=0.85),
+        ])
+        session.commit()
+        assert check_fx_coverage(session) == []
+
+
+class TestRunReportIntegration:
+    def test_all_checks_compose(self, session):
+        """run_report 汇总所有 check，无报错时返回空列表。"""
+        e = _seed_entity(session)
+        a = _seed_account(session, e)
+        session.add_all([
+            LedgerEntry(account_id=a.id, date=date(1990, 1, 1), inflow=100, balance=100),
+            ExchangeRate(fx_from="USD", fx_to="EUR", year=2000, rate=0.9),
+        ])
+        session.commit()
+        report = run_report(session)
+        # 期望：H3 覆盖率无 warn、H4 无 crit、负余额无、其余规则无匹配
+        assert report == [], f"干净数据应零发现；got {report}"


### PR DESCRIPTION
## 问题
issue #22: health 校验盲区，最需要暴露的数据异常反而报「健康」：
- 无负余额检查（dev 库主账户 -141M BEF 仍零告警）
- 无汇率表为空/全 NULL year 提示（USD 折算空转不可见）
- H4 循环 range(1, len) 跳过首条 → 首条失核逃逸
- H3 direct 侧不回退常量键 0，与链式两侧不对称漏报

## 修复
### app/core/health.py
1. `check_negative_balance`: ledger.balance < 0 → H4 warn
2. `check_fx_coverage`: 空表 / 全 NULL year → H3 warn（两档盲区显式化）
3. `check_h4_balance_chain`: 改为 `enumerate(entries)`，首条 prev=0 单独校验
4. `check_h3_fx_closure`: 抽 `_val(pair, y)` 统一链式/direct 三侧 NULL 回退
5. `run_report` 接入新两检查

## 验证
- 新增 `tests/test_health.py`：11 个 case
  - TestH4FirstEntryChecked：首条失核报警、首条合法零报、链式断链报警
  - TestH3SymmetricNullFallback：direct 缺失不误报、三向不一致报警
  - TestNegativeBalance：负余额 warn、正常零报
  - TestFxCoverage：空表 warn、全 NULL year warn、混合零报
  - TestRunReportIntegration：run_report 干净数据零发现
- 全套 120 测试通过（含本次新增 11 个），零回归

Closes #22