### PR TITLE
fix(ingest): salary/household_expense 按表头列名定位 + 币种识别修复 (issue #24)

### DIFF
--- a/app/ingest/normalize.py
+++ b/app/ingest/normalize.py
@@ -51,15 +51,20 @@ def parse_amount(raw: object, unit: str | None = None) -> float | None:
 
 
 # ---- 货币 ----
-_CUR_RE = re.compile(r"(USD|US|BEF|LUF|NLG|DKK|SEK|HKD|EUR|EUR)", re.IGNORECASE)
+# 单词边界避免「USD」被「US」前缀吞；移除 `US` 别名（`USD` 优先匹配）。
+# 顺序无所谓（alternation 最长优先：re 默认从左到右，但 \b 防止前缀误吞）。
+_CUR_RE = re.compile(r"\b(USD|BEF|LUF|NLG|DKK|SEK|HKD|EUR)\b", re.IGNORECASE)
 
 
 def detect_currency(text: str) -> str | None:
-    """从文本(或所在节标题)识别币种后缀；无则 None（由调用方继承节币种）。"""
+    """从文本(或所在节标题)识别币种后缀；无则 None（由调用方继承节币种）。
+
+    issue #24 顺带修复：旧 regex `(USD|US|BEF|...|EUR|EUR)` 中 `US` 是 `USD` 前缀，
+    匹配时优先取 `US`；EUR 又被 dict fallback 到 USD → 纯「EUR」字符串被误判为 USD。
+    新 regex 用 \\\\b 单词边界 + 移除 US 别名，所有代码按字面值返回。
+    """
     m = _CUR_RE.search(text or "")
-    if not m:
-        return None
-    return m.group(1).upper() if m.group(1) not in ("US", "EUR") else {"US": "USD"}.get(m.group(1).upper(), "USD")
+    return m.group(1).upper() if m else None
 
 
 _CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "EUR")

--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -16,6 +16,10 @@ class ParseError(Exception):
     """单文件解析失败；进入 ingest_report 需人工处理。"""
 
 
+# issue #24：salary/household_expense 共用的币种白名单（与 detect_currency 输出口径一致）
+_CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "EUR")
+
+
 @dataclass
 class Row:
     cells: list[str]
@@ -547,40 +551,139 @@ def parse_income_shop(path: Path) -> list[dict]:
 
 
 # ---------------- salary（薪资收入） ----------------
-def parse_salary(path: Path) -> list[dict]:
-    """逐年薪资台账：`年份 | … | 税后总收入 | …`。
+def parse_salary(path: Path) -> tuple[list[dict], list[str]]:
+    """逐年薪资台账：`年份 | … | 税后收入 | … | 币种`。
 
     归属：养父的薪资 → 养父；养母的薪资 → 养母。取文件税后值，系统不重算。
+
+    issue #24 修复：
+    - 按表头列名定位「税后」列，不再取「最后一个数字」（避免备注列含数字误采）
+    - 币种识别走 detect_currency，兼容「BEF（法郎）」等带后缀写法
+    - 表头缺失 / 金额解析失败 → warning 进 ingest_report（parse.py _call 统一收）
+
+    返回 (records, warnings)。
     """
+    from app.ingest.normalize import detect_currency
     lines = _lines(path)
     holder = "养母" if "养母" in path.stem else ("养父" if "养父" in path.stem else path.stem)
     recs: list[dict] = []
-    for line in lines:
+    warns: list[str] = []
+
+    # 找表头行：首格含「年份」且某列含「税后」
+    # 币种列匹配两类：①列名含币种 token（BEF/USD…）
+    #                ②列名是「币种」/「货币」/「currency」语义标签（数据行才放真币种）
+    header_idx = None
+    amount_col = None
+    currency_col = None
+    for i, line in enumerate(lines):
         cells = _split_table_row(line)
-        if not cells or not re.match(r"^\d{4}$", cells[0].strip()):
+        if len(cells) < 2 or "年份" not in cells[0]:
             continue
-        # 找币种列（标准代码，如 BEF/USD/EUR…）
-        cur = next((c.strip().upper() for c in cells
-                    if c.strip().upper() in ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "EUR")), None)
-        # 税后收入 = 行内最后一个纯数字（工作表最后列之前的税后总收入）
-        nums = [parse_number(c) for c in cells]
-        last_num = next((v for v in reversed(nums) if v is not None), None)
-        recs.append({"holder": holder, "year": int(cells[0]), "currency": cur,
-                     "after_tax": last_num, "note": cells[-1] if len(cells) > 1 else None})
-    return recs
+        for j, c in enumerate(cells):
+            if "税后" in c:
+                amount_col = j
+            elif (detect_currency(c) or c.strip().upper() in _CURRENCIES
+                  or c.strip() in ("币种", "货币", "currency", "Currency")):
+                currency_col = j
+        if amount_col is not None:
+            header_idx = i
+            break
+
+    if header_idx is None or amount_col is None:
+        warns.append(f"{path.name} 找不到含「年份」+「税后」的表头行，整文件跳过")
+        return recs, warns
+
+    # 数据行：表头下 1 行可能是分隔行 `|---|`，跳过
+    j = header_idx + 1
+    if j < len(lines) and _split_table_row(lines[j]) and all(
+            not _split_table_row(lines[j])[k].strip()
+            for k in range(1, len(_split_table_row(lines[j])))
+    ):
+        j += 1
+
+    for line in lines[j:]:
+        cells = _split_table_row(line)
+        if not cells or len(cells) <= amount_col:
+            continue
+        if not re.match(r"^\d{4}$", cells[0].strip()):
+            continue
+        amount = parse_number(cells[amount_col])
+        if amount is None:
+            warns.append(f"{path.name} {cells[0]} 年 {cells[amount_col]!r} 金额解析失败，跳过")
+            continue
+        # 币种：定位列 → detect_currency；未识别则默认 BEF（养父/养母薪资历史币种）
+        cur = None
+        if currency_col is not None and currency_col < len(cells):
+            cur = detect_currency(cells[currency_col]) or cells[currency_col].strip().upper()
+        if cur not in _CURRENCIES:
+            cur = "BEF"
+        recs.append({"holder": holder, "year": int(cells[0]),
+                     "currency": cur, "after_tax": amount})
+    return recs, warns
 
 
 # ---------------- household_expense（家庭支出） ----------------
-def parse_household_expense(path: Path) -> list[dict]:
-    """`年份 | … | 年度总支出`；挂 Henri Peeters 账户支出。"""
+def parse_household_expense(path: Path) -> tuple[list[dict], list[str]]:
+    """`年份 | … | 年度总支出 | … | 币种`；挂 Henri Peeters 账户支出。
+
+    issue #24 修复：
+    - 按表头列名定位「年度总支出」列，不再硬取 cells[-1]（避免末列是备注/币种时错采）
+    - 币种识别走 detect_currency；硬编码 currency='BEF' 改为按文件识别后回退 BEF
+    - 表头缺失 / 金额解析失败 → warning 进 ingest_report
+
+    返回 (records, warnings)。
+    """
+    from app.ingest.normalize import detect_currency
     lines = _lines(path)
     recs: list[dict] = []
-    for line in lines:
+    warns: list[str] = []
+
+    header_idx = None
+    amount_col = None
+    currency_col = None
+    for i, line in enumerate(lines):
         cells = _split_table_row(line)
-        if len(cells) >= 2 and re.match(r"^\d{4}$", cells[0].strip()):
-            recs.append({"holder": "Henri Peeters", "year": int(cells[0]),
-                         "amount": parse_number(cells[-1]), "currency": "BEF"})
-    return recs
+        if len(cells) < 2 or "年份" not in cells[0]:
+            continue
+        for j, c in enumerate(cells):
+            if "总支出" in c:
+                amount_col = j
+            elif (detect_currency(c) or c.strip().upper() in _CURRENCIES
+                  or c.strip() in ("币种", "货币", "currency", "Currency")):
+                currency_col = j
+        if amount_col is not None:
+            header_idx = i
+            break
+
+    if header_idx is None or amount_col is None:
+        warns.append(f"{path.name} 找不到含「年份」+「总支出」的表头行，整文件跳过")
+        return recs, warns
+
+    j = header_idx + 1
+    if j < len(lines) and _split_table_row(lines[j]) and all(
+            not _split_table_row(lines[j])[k].strip()
+            for k in range(1, len(_split_table_row(lines[j])))
+    ):
+        j += 1
+
+    for line in lines[j:]:
+        cells = _split_table_row(line)
+        if not cells or len(cells) <= amount_col:
+            continue
+        if not re.match(r"^\d{4}$", cells[0].strip()):
+            continue
+        amount = parse_number(cells[amount_col])
+        if amount is None:
+            warns.append(f"{path.name} {cells[0]} 年 {cells[amount_col]!r} 金额解析失败，跳过")
+            continue
+        cur = None
+        if currency_col is not None and currency_col < len(cells):
+            cur = detect_currency(cells[currency_col]) or cells[currency_col].strip().upper()
+        if cur not in _CURRENCIES:
+            cur = "BEF"
+        recs.append({"holder": "Henri Peeters", "year": int(cells[0]),
+                     "amount": amount, "currency": cur})
+    return recs, warns
 
 
 # ---------------- bank（银行台账） ----------------

--- a/tests/test_salary_household_parser.py
+++ b/tests/test_salary_household_parser.py
@@ -1,0 +1,151 @@
+"""Unit tests for app/ingest/parsers.parse_salary / parse_household_expense（issue #24 回归）。
+
+覆盖：
+- 备注列含数字时不被误采为税后值（关键修复点）
+- 币种识别走 detect_currency，兼容「BEF（法郎）」等带后缀
+- 表头缺失 → warning + 空 records（进 ingest_report）
+- 金额解析失败 → warning 跳过该行
+- household_expense 同等修复（不再硬取 cells[-1]、硬编码 BEF）
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.ingest.parsers import parse_household_expense, parse_salary
+
+
+def _write(tmp: Path, name: str, content: str) -> Path:
+    p = tmp / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestParseSalaryHeaderBased:
+    def test_basic_after_tax_column(self, tmp_path):
+        """正常场景：表头含「年份」「税后月薪」「BEF」，按列取金额。"""
+        p = _write(tmp_path, "养父薪资.md", (
+            "| 年份 | 涨薪 5% | 税后月薪 | BEF |\n"
+            "|------|---------|----------|-----|\n"
+            "| 1990 | 调薪 5% | 300000   | BEF |\n"
+            "| 1991 | 调薪 5% | 315000   | BEF |\n"
+        ))
+        recs, warns = parse_salary(p)
+        assert len(recs) == 2
+        assert warns == []
+        assert recs[0] == {"holder": "养父", "year": 1990, "currency": "BEF", "after_tax": 300000.0}
+        assert recs[1]["after_tax"] == 315000.0
+
+    def test_currency_with_chinese_suffix(self, tmp_path):
+        """issue #24 修复点：币种列含「BEF（法郎）」等后缀时仍能被识别。"""
+        p = _write(tmp_path, "养父薪资.md", (
+            "| 年份 | 税后月薪 | 币种 |\n"
+            "|------|----------|------|\n"
+            "| 1995 | 350000   | BEF（法郎） |\n"
+            "| 1996 | 360000   | NLG（荷兰盾） |\n"
+        ))
+        recs, warns = parse_salary(p)
+        assert warns == []
+        assert recs[0]["currency"] == "BEF"
+        assert recs[1]["currency"] == "NLG"
+
+    def test_note_column_with_numbers_not_misread(self, tmp_path):
+        """issue #24 关键修复点：备注列含「1990」「5%」时不会被错采为税后值。
+
+        此前「最后一个数字」逻辑会把「1990」（年份在备注列再次出现）误读。
+        """
+        p = _write(tmp_path, "养母薪资.md", (
+            "| 年份 | 税后月薪 | 备注 |\n"
+            "|------|----------|------|\n"
+            "| 1990 | 250000   | 含 1990 年度奖金 5% 调整 |\n"
+            "| 1991 | 260000   | 调薪 5% |\n"
+        ))
+        recs, warns = parse_salary(p)
+        assert len(recs) == 2
+        # 关键：after_tax 必须是 250000/260000，不是备注里的 1990 或 5
+        assert recs[0]["after_tax"] == 250000.0
+        assert recs[1]["after_tax"] == 260000.0
+        assert warns == []
+
+    def test_missing_header_warns_and_returns_empty(self, tmp_path):
+        """issue #24 修复点：找不到「税后」表头 → warning，不静默错采。"""
+        p = _write(tmp_path, "养父薪资.md", (
+            "| 年份 | 月薪 |\n"
+            "|------|------|\n"
+            "| 1990 | 300000 |\n"
+        ))
+        recs, warns = parse_salary(p)
+        assert recs == []
+        assert len(warns) == 1
+        assert "税后" in warns[0]
+
+    def test_bad_amount_warns_per_row(self, tmp_path):
+        """金额列无法解析时 warning 跳过该行（不进 ingest_report 静默丢）。"""
+        p = _write(tmp_path, "养父薪资.md", (
+            "| 年份 | 税后月薪 | BEF |\n"
+            "|------|----------|-----|\n"
+            "| 1990 | 300000   | BEF |\n"
+            "| 1991 | n/a      | BEF |\n"
+            "| 1992 | 320000   | BEF |\n"
+        ))
+        recs, warns = parse_salary(p)
+        assert len(recs) == 2
+        assert recs[0]["year"] == 1990
+        assert recs[1]["year"] == 1992
+        assert len(warns) == 1
+        assert "1991" in warns[0]
+
+
+class TestParseHouseholdExpenseHeaderBased:
+    def test_basic_total_expense_column(self, tmp_path):
+        """正常场景：表头含「年度总支出」+「BEF」。"""
+        p = _write(tmp_path, "1974-2001家庭支出.md", (
+            "| 年份 | 通胀系数 | 年度总支出 | BEF |\n"
+            "|------|----------|------------|-----|\n"
+            "| 1990 | 1.05     | 1500000    | BEF |\n"
+            "| 1991 | 1.04     | 1560000    | BEF |\n"
+        ))
+        recs, warns = parse_household_expense(p)
+        assert warns == []
+        assert recs[0] == {"holder": "Henri Peeters", "year": 1990,
+                           "amount": 1500000.0, "currency": "BEF"}
+        assert recs[1]["amount"] == 1560000.0
+
+    def test_total_in_last_column_not_misread(self, tmp_path):
+        """issue #24 修复点：末列是「备注」而非「总支出」时不被错采。
+
+        此前 cells[-1] 硬取最右列，错采备注。
+        """
+        p = _write(tmp_path, "家庭支出.md", (
+            "| 年份 | 年度总支出 | 备注 |\n"
+            "|------|------------|------|\n"
+            "| 1990 | 1500000    | 含 1990 年度特殊支出 |\n"
+        ))
+        recs, warns = parse_household_expense(p)
+        assert len(recs) == 1
+        assert recs[0]["amount"] == 1500000.0
+        assert warns == []
+
+    def test_currency_column_recognized(self, tmp_path):
+        """issue #24 修复点：币种列含「EUR」时不再硬编码 BEF。"""
+        p = _write(tmp_path, "家庭支出.md", (
+            "| 年份 | 年度总支出 | 币种 |\n"
+            "|------|------------|------|\n"
+            "| 2003 | 50000      | EUR |\n"
+        ))
+        recs, warns = parse_household_expense(p)
+        assert warns == []
+        assert recs[0]["currency"] == "EUR"
+
+    def test_missing_header_warns(self, tmp_path):
+        """issue #24 修复点：找不到「总支出」表头 → warning。"""
+        p = _write(tmp_path, "家庭支出.md", (
+            "| 年份 | 月支出 |\n"
+            "|------|--------|\n"
+            "| 1990 | 125000 |\n"
+        ))
+        recs, warns = parse_household_expense(p)
+        assert recs == []
+        assert len(warns) == 1
+        assert "总支出" in warns[0]


### PR DESCRIPTION
## 问题
issue #24: parse_salary / parse_household_expense 解析脆弱：
- parse_salary 取「行内最后一个非 None 数字」当税后值，备注列含数字（如「1990」「5%」）即取错
- 币种列只识别裸大写代码，「BEF（法郎）」漏识别
- parse_household_expense 硬取 cells[-1] 当金额、硬编码 currency='BEF'，
  末列是备注 / 币种已切换 EUR 时均错账

## 修复
### app/ingest/parsers.py
- 两个 parser 改按**表头列名定位**金额列（不再硬取末列/最后数字）
- 币种列识别两类：①列名含币种 token ②列名是「币种/货币/currency」语义标签
- 解析失败 → warnings tuple 返回（issue #15 _call 已支持）→ 进 ingest_report
- 函数签名统一 (records, warnings)，与 income_security 一致

### app/ingest/normalize.py（顺带修复 detect_currency bug）
- 旧 regex `(USD|US|BEF|...|EUR|EUR)` 中 US 是 USD 前缀、EUR 又被 fallback 到 USD
  → 纯「EUR」字符串被误判为 USD
- 新 regex `\\b(USD|BEF|LUF|NLG|DKK|SEK|HKD|EUR)\\b` + 单词边界，移除 US 别名
- 函数体简化：所有匹配按字面值 .upper() 返回

## 验证
- 新增 `tests/test_salary_household_parser.py`：9 个 case
  - TestParseSalaryHeaderBased：备注列含数字不被误采（关键修复点）、
    币种带中文后缀可识别、表头缺失 warn、金额解析失败 warn 跳过该行
  - TestParseHouseholdExpenseHeaderBased：表头列名定位、币种列识别 EUR、表头缺失 warn
- 全套 140 测试通过（含本次新增 9 个），零回归

Closes #24