### PR TITLE
fix(ingest): detect 显式映射 CPI + SKIP_P1/SKIP_DOC，单独分组不与 unknown 混淆 (issue #26)

### DIFF
--- a/app/ingest/detect.py
+++ b/app/ingest/detect.py
@@ -1,6 +1,12 @@
 """文件→类别识别（DESIGN §6.1）。
 
 按 `input_dir 下的相对路径` 匹配；`基准/事件/` 为 Phase1 阶段项（跳过，Phase2 启用）。
+
+issue #26 修复：
+- `基准/CPI工资.md` 显式映射为 `cpi_wage`（DESIGN §6.1 类别表；之前落 unknown 报噪音）
+- `基准/公司/用工成本/` P1 范围 → `SKIP_P1`（DESIGN §13；Phase 1 不实现，跳过不报错）
+- `设计文件/` 创作约束笔记 → `SKIP_DOC`（不入库）
+SKIP_* 类别在 parse_one 显式跳过，不计入 unknown 报错。
 """
 from __future__ import annotations
 
@@ -10,6 +16,9 @@ from pathlib import Path
 # (前缀, 类别) —— 顺序敏感：更长/更精确前缀在前
 _PREFIX_RULES: list[tuple[str, str]] = [
     ("基准/事件/", "PHASE2_EVENT"),          # Phase1 跳过
+    ("基准/CPI工资.md", "cpi_wage"),          # issue #26：CPI 与工资增幅基准
+    ("基准/公司/用工成本/", "SKIP_P1"),        # issue #26：P1 §13 范围，Phase1 跳过
+    ("设计文件/", "SKIP_DOC"),                # issue #26：创作约束笔记，不入库
     ("经济/银行/", "bank"),
     ("经济/股票/", "stock_tx"),
     ("基准/收益表/惠民租房.md", "income_rent"),
@@ -25,6 +34,11 @@ _PREFIX_RULES: list[tuple[str, str]] = [
     ("人物/", "character"),
     ("时间线.md", "timeline"),
 ]
+
+
+def is_skip_category(category: str) -> bool:
+    """issue #26：SKIP_* 类别在 parse_one 显式跳过；供调用方判定。"""
+    return category.startswith("SKIP_")
 
 
 @dataclass(frozen=True)

--- a/app/ingest/parse.py
+++ b/app/ingest/parse.py
@@ -47,6 +47,11 @@ class IngestReport:
                 out.append((r.file, w))
         return out
 
+    @property
+    def skipped(self) -> list[ParseResult]:
+        """issue #26：SKIP_* 类别（P1 范围/创作约束）单独分组，不与 unknown 报错混淆。"""
+        return [r for r in self.results if r.category.startswith("SKIP_")]
+
 
 # 解析器签名有两种：(path) -> list 或 (path) -> (list, warnings)。
 # 下面通过 _call 统一处理。
@@ -80,6 +85,10 @@ def parse_one(rel: str, path: Path) -> ParseResult:
     if det.phase2:
         pr.ok = False
         pr.error = "Phase 2 事件，Phase 1 跳过"
+        return pr
+    # issue #26：SKIP_* 类别（P1 范围/创作约束）显式跳过，不算 unknown 报错
+    if det.category.startswith("SKIP_"):
+        pr.ok = True
         return pr
     fn = _PARSERS.get(det.category)
     if fn is None:

--- a/tests/test_detect_cpi_skip.py
+++ b/tests/test_detect_cpi_skip.py
@@ -1,0 +1,105 @@
+"""Unit tests for app/ingest/detect + parse_one SKIP 类别（issue #26 回归）。
+
+覆盖：
+- detect 显式映射 CPI工资.md → cpi_wage（不再落 unknown）
+- detect 显式映射基准/公司/用工成本/ → SKIP_P1
+- detect 显式映射设计文件/ → SKIP_DOC
+- 顺序：更长前缀优先（CPI 工资.md 单独一个，不被 SKIP_P1 之类误吞）
+- is_skip_category 判定
+- parse_one：SKIP 类别 ok=True 不报 unknown error
+- IngestReport.skipped 分组属性
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.ingest.detect import detect, is_skip_category, scan_dir
+from app.ingest.parse import IngestReport, ParseResult, parse_one
+
+
+class TestDetectExplicitMappings:
+    def test_cpi_wage_mapped(self):
+        """issue #26 核心修复：CPI工资.md 不再落 unknown。"""
+        d = detect("基准/CPI工资.md")
+        assert d.category == "cpi_wage", f"应映射为 cpi_wage，实际 {d.category}"
+        assert not d.phase2
+
+    def test_company_labor_cost_skipped(self):
+        """基准/公司/用工成本/ 显式 SKIP_P1（DESIGN §13 P1 范围）。"""
+        d = detect("基准/公司/用工成本/比利时.md")
+        assert d.category == "SKIP_P1"
+        assert d.phase2 is False  # 不是 phase2 event，是 P1 跳过
+
+    def test_design_docs_skipped(self):
+        """设计文件/ 创作约束笔记 → SKIP_DOC（不入库）。"""
+        d = detect("设计文件/学习.md")
+        assert d.category == "SKIP_DOC"
+
+    def test_nested_design_docs_skipped(self):
+        """设计文件/ 子目录也走 SKIP_DOC。"""
+        d = detect("设计文件/子目录/任何文件.md")
+        assert d.category == "SKIP_DOC"
+
+
+class TestIsSkipCategory:
+    def test_skip_prefix_true(self):
+        assert is_skip_category("SKIP_P1") is True
+        assert is_skip_category("SKIP_DOC") is True
+
+    def test_non_skip_false(self):
+        assert is_skip_category("cpi_wage") is False
+        assert is_skip_category("PHASE2_EVENT") is False
+        assert is_skip_category("unknown") is False
+
+
+class TestPrefixOrdering:
+    def test_cpi_specific_before_company_prefix(self):
+        """CPI 工资.md 是精确文件名前缀，应在「基准/」前匹配；这里只需验证 cpi_wage 命中。"""
+        # 即便添加了 SKIP_P1 = "基准/公司/用工成本/" 前缀，CPI 文件路径不冲突
+        d = detect("基准/CPI工资.md")
+        assert d.category == "cpi_wage"
+
+    def test_phase2_event_still_skipped(self):
+        """回归：原有的 PHASE2_EVENT 映射不被破坏。"""
+        d = detect("基准/事件/股票/腾讯.md")
+        assert d.category == "PHASE2_EVENT"
+        assert d.phase2 is True
+
+
+class TestParseOneSkipCategory:
+    def test_skip_p1_ok_no_error(self, tmp_path):
+        """issue #26：SKIP 类别在 parse_one 显式跳过，ok=True 不报 unknown。"""
+        p = tmp_path / "比利时.md"
+        p.write_text("# 标题", encoding="utf-8")
+        pr = parse_one("基准/公司/用工成本/比利时.md", p)
+        assert pr.ok is True
+        assert pr.error is None
+        assert pr.category == "SKIP_P1"
+        assert pr.records == []
+
+    def test_skip_doc_ok_no_error(self, tmp_path):
+        p = tmp_path / "学习.md"
+        p.write_text("# 学习笔记", encoding="utf-8")
+        pr = parse_one("设计文件/学习.md", p)
+        assert pr.ok is True
+        assert pr.category == "SKIP_DOC"
+
+
+class TestIngestReportSkippedGroup:
+    def test_skipped_filters_skip_categories(self):
+        """IngestReport.skipped 单独分组 SKIP_*，不与 unknown 报错混淆。"""
+        report = IngestReport()
+        report.results.append(ParseResult(file="基准/公司/用工成本/X.md",
+                                           category="SKIP_P1", ok=True))
+        report.results.append(ParseResult(file="设计文件/学习.md",
+                                           category="SKIP_DOC", ok=True))
+        report.results.append(ParseResult(file="基准/CPI工资.md",
+                                           category="cpi_wage", ok=True))
+        report.results.append(ParseResult(file="未识别.md",
+                                           category="unknown", ok=False,
+                                           error="解析器未实现（unknown）"))
+        skipped = report.skipped
+        assert len(skipped) == 2
+        assert all(r.category.startswith("SKIP_") for r in skipped)
+        assert len(report.failed) == 1
+        assert report.failed[0].category == "unknown"


### PR DESCRIPTION
## 问题
issue #26: detect 噪音：
- `基准/CPI工资.md` 无映射 → 落 unknown 报"需人工"（DESIGN §6.1 类别表实际含 CPI）
- `基准/公司/用工成本/`（DESIGN §13 P1 范围）与 `设计文件/` 创作约束笔记无显式 skip 标记
- run 报告噪音掩盖真正需要人工的文件

## 修复
### app/ingest/detect.py
- 加 `基准/CPI工资.md` → cpi_wage
- 加 `基准/公司/用工成本/` → SKIP_P1
- 加 `设计文件/` → SKIP_DOC
- 顺序：精确文件名前缀（如 CPI 工资.md）必须在更短目录前缀（SKIP_P1）前
- 新增 is_skip_category() 工具函数

### app/ingest/parse.py
- parse_one 检测 SKIP_ 类别 → ok=True 直接返回，不计 unknown 报错
- IngestReport.skipped 属性单独分组 SKIP_* 结果

## 验证
- 新增 `tests/test_detect_cpi_skip.py`：11 个 case
  - TestDetectExplicitMappings：CPI/P1/DOC 三映射
  - TestIsSkipCategory：前缀判定
  - TestPrefixOrdering：CPI 精确前缀不被吞、PHASE2_EVENT 回归
  - TestParseOneSkipCategory：SKIP 类别 parse_one 不报错
  - TestIngestReportSkippedGroup：skipped 与 failed 分组互不干扰
- 全套 151 测试通过（含本次新增 11 个），零回归

Closes #26