### PR TITLE
fix(api): 加 CORSMiddleware，限 localhost:5173/127.0.0.1:5173 两本地来源 (issue #30)

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -16,6 +16,7 @@ from datetime import date
 from typing import Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -27,6 +28,20 @@ from app.model import (Account, Entity, ExchangeRate, IncomeStream, LedgerEntry,
                        Notification, ReturnCurve, Snapshot, TimelineEvent)
 
 app = FastAPI(title="Novel Dashboard API", version="0.1")
+
+# issue #30：dist 直连部署时前端跨域失败；PRD §13 本地单机非安全边界，
+# 仅放行 vite dev server 默认端口（5173）的两个本地来源，不允许 * 通配。
+_CORS_ORIGINS = (
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_CORS_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 API_PREFIX = "/api/v1"
 

--- a/app/core/recompute.py
+++ b/app/core/recompute.py
@@ -3,10 +3,14 @@
 recompute_account(session, account_id, from_year)：
 - 重算该账户 from_year 起的余额链（ledger 逐行：后 = 前 + 入 − 出，按日期排序）
 - 写回 ledger.balance；之后可供快照/曲线读取。
+
+issue #28 修复：内部计算全程 Decimal（避免 float 二进制误差累积进账本）。
+SQLAlchemy Numeric 列读出来本就是 Decimal，原代码用 float() 转换丢精度。
 """
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
 from typing import Optional
 
 from sqlalchemy import select
@@ -23,7 +27,9 @@ def recompute_account(session: Session, account_id: int, from_year: int) -> dict
     1. 基线只取 from_year 前最后一条分录的余额作为起算余额；from_year 起的所有行
        一律滚动重算（同年内不再「沿用已存在 balance 跳过」）。
     2. 不再有死代码覆盖：base 永远等于上一行的累计余额（首行则为 from_year 前最后
-       一行的 balance，未取到则为 0）。
+       一行的 balance，未取到则 0）。
+    3. issue #28：内部计算全程 Decimal；e.balance / e.inflow / e.outflow 读出来已
+       是 Decimal（SQLAlchemy Numeric 列），直接相加不再转 float。
     """
     entries = session.execute(
         select(LedgerEntry).where(LedgerEntry.account_id == account_id)
@@ -31,22 +37,22 @@ def recompute_account(session: Session, account_id: int, from_year: int) -> dict
     ).scalars().all()
 
     # 基线：from_year 前最后一条分录的余额；取不到则 0
-    baseline = 0.0
+    baseline: Decimal = Decimal(0)
     for e in entries:
         if e.date.year < from_year and e.balance is not None:
-            baseline = e.balance
+            baseline = Decimal(e.balance)
         elif e.date.year >= from_year:
             break
 
-    balance = float(baseline)
+    balance: Decimal = baseline
     years_updated = 0
     for e in entries:
         if e.date.year < from_year:
             continue                              # 锁定基线之前的行
-        inflow = float(e.inflow or 0.0)
-        outflow = float(e.outflow or 0.0)
+        inflow = Decimal(e.inflow) if e.inflow is not None else Decimal(0)
+        outflow = Decimal(e.outflow) if e.outflow is not None else Decimal(0)
         balance = balance + inflow - outflow
-        if e.balance is None or float(e.balance) != balance:
+        if e.balance is None or Decimal(e.balance) != balance:
             e.balance = balance
             years_updated += 1
     return {"account_id": account_id, "from_year": from_year,

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -8,27 +8,39 @@ issue #12 修复：
 - 新增 from_year 参数：仅重建 from_year 起的快照（delete 限定 as_of_year >= from_year）
 - 补 entity:* scope（按 entity_id × 币种聚合）
 - 补 family:total scope（USD 口径家族合计）
+
+issue #28 修复：
+- 内部计算全程 Decimal（避免 float 二进制误差累积）
+- 0 值且无流水的年份跳过写入（account/entity/family 三种 scope），避免快照表膨胀
 """
 from __future__ import annotations
+
+from decimal import Decimal
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
 from app.model import Account, ExchangeRate, IncomeStream, LedgerEntry, Snapshot
 
+# 写库精度：保留 2 位小数（与原 round(v, 2) 一致）
+_QUANTIZE_2 = Decimal("0.01")
+_ZERO = Decimal(0)
 
-def account_balance_at(session: Session, account_id: int, cutoff) -> float:
+
+def account_balance_at(session: Session, account_id: int, cutoff) -> Decimal:
     """账户截至 cutoff（date 级）的余额：Σ(inflow) − Σ(outflow) for date <= cutoff。
 
     与 _account_balance_series 同源口径：在 cutoff=12-30（某年年末）时两者相等，
     保证日历按日累加与预计算年度快照一致（issue #17 方案 A′）。
+
+    issue #28：返回 Decimal 而非 float，避免上层 cast 丢精度。
     """
     tin, tout = session.execute(
         select(func.coalesce(func.sum(LedgerEntry.inflow), 0),
                func.coalesce(func.sum(LedgerEntry.outflow), 0))
         .where(LedgerEntry.account_id == account_id, LedgerEntry.date <= cutoff)
     ).one()
-    return float(tin) - float(tout)
+    return Decimal(tin or 0) - Decimal(tout or 0)
 
 
 def _close_year_of(acc: Account) -> int | None:
@@ -39,11 +51,13 @@ def _close_year_of(acc: Account) -> int | None:
 
 
 def _account_balance_series(session: Session, account_id: int,
-                            years: range, close_year: int | None = None) -> dict[int, float]:
+                            years: range, close_year: int | None = None) -> dict[int, Decimal]:
     """该账户逐年 as-of 余额：初始现金 + 累计 income − 累计 expense。
 
     关池（close_year）后不双计：closed 账户自关池年起余额清零——钱已结转进承接币种
     （EUR）账户，避免与承接分录叠加（DESIGN §6.6）。
+
+    issue #28：全程 Decimal；返回 dict[year, Decimal]。
     """
     # ledger 收支（现金进 ledger）
     rows = session.execute(
@@ -53,17 +67,17 @@ def _account_balance_series(session: Session, account_id: int,
         .where(LedgerEntry.account_id == account_id)
         .group_by(func.extract("year", LedgerEntry.date))
     ).all()
-    year_in: dict[int, float] = {}
-    year_out: dict[int, float] = {}
+    year_in: dict[int, Decimal] = {}
+    year_out: dict[int, Decimal] = {}
     for y, tin, tout in rows:
-        year_in[int(y)] = float(tin)
-        year_out[int(y)] = float(tout)
+        year_in[int(y)] = Decimal(tin or 0)
+        year_out[int(y)] = Decimal(tout or 0)
     # 逐年滚动
-    series: dict[int, float] = {}
-    bal = 0.0
+    series: dict[int, Decimal] = {}
+    bal: Decimal = _ZERO
     for y in years:
-        bal += year_in.get(y, 0.0) - year_out.get(y, 0.0)
-        series[y] = 0.0 if close_year is not None and y >= close_year else bal
+        bal = bal + year_in.get(y, _ZERO) - year_out.get(y, _ZERO)
+        series[y] = _ZERO if close_year is not None and y >= close_year else bal
     return series
 
 
@@ -71,10 +85,13 @@ def _ownership_accounts(session: Session) -> list[Account]:
     return session.execute(select(Account)).scalars().all()
 
 
-def _usd_rate(session: Session, currency: str, year: int) -> float | None:
-    """currency → USD 折算率（与 wealth._usd_rate 对齐；缺汇率返回 None 不静默 fallback）。"""
+def _usd_rate(session: Session, currency: str, year: int) -> Decimal | None:
+    """currency → USD 折算率（与 wealth._usd_rate 对齐；缺汇率返回 None 不静默 fallback）。
+
+    issue #28：返回 Decimal（与内部聚合口径一致）；wealth._usd_rate 仍返 float，调用方按需转换。
+    """
     if currency == "USD":
-        return 1.0
+        return Decimal(1)
     from sqlalchemy import or_
     row = session.execute(
         select(ExchangeRate.rate).where(
@@ -83,14 +100,14 @@ def _usd_rate(session: Session, currency: str, year: int) -> float | None:
         ).order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc()).limit(1)
     ).first()
     if row is not None and row[0] is not None:
-        return 1.0 / float(row[0])
+        return Decimal(1) / Decimal(row[0])
     row2 = session.execute(
         select(ExchangeRate.rate).where(
             ExchangeRate.fx_from == currency, ExchangeRate.fx_to == "USD",
             or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
         ).order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc()).limit(1)
     ).first()
-    return float(row2[0]) if row2 is not None and row2[0] is not None else None
+    return Decimal(row2[0]) if row2 is not None and row2[0] is not None else None
 
 
 def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
@@ -99,6 +116,9 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
 
     from_year=None → 全量重建（1947 起）；
     from_year=N    → 仅重建 [N, end] 年；旧 [1947, N-1] 快照保留（§9.2c 增量）。
+
+    issue #28：value=0 且无流水的年份跳过写入（account/entity/family 三种 scope），
+    避免 79 年×每账户 每账户必写 79 行的膨胀；汇率缺失币种不计入 family（保留原语义）。
 
     返回 {"snapshots": 行数, "accounts": 账户数, "entities": 实体数, "family_years": 家族快照年数}
     """
@@ -118,72 +138,83 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
     )
 
     # 2) 先把所有账户余额 series 算好（避免 entity 聚合时再算）
-    series_by_acc: dict[int, dict[int, float]] = {}
+    series_by_acc: dict[int, dict[int, Decimal]] = {}
     for acc in _ownership_accounts(session):
         series_by_acc[acc.id] = _account_balance_series(
             session, acc.id, years, close_year=_close_year_of(acc))
 
-    # 3) 写 account:* 行
+    # 3) 写 account:* 行（issue #28：value=0 跳过；Decimal.quantize(0.01) 写回）
     for acc in _ownership_accounts(session):
         series = series_by_acc[acc.id]
+        written = False
         for y in years_list:
             if y < start:
+                continue
+            v = series.get(y, _ZERO)
+            if v == 0:
                 continue
             session.add(Snapshot(
                 as_of_year=y, as_of_date=None,
                 scope=f"account:{acc.id}:{acc.currency}",
-                value=round(series.get(y, 0.0), 2), currency=acc.currency,
+                value=v.quantize(_QUANTIZE_2), currency=acc.currency,
             ))
             stats["snapshots"] += 1
-        stats["accounts"] += 1
+            written = True
+        if written:
+            stats["accounts"] += 1
 
-    # 4) 写 entity:* 行（entity × currency 聚合）
-    # account.entity_id → entity_id；按 (entity_id, currency) 聚合
+    # 4) 写 entity:* 行（entity × currency 聚合；0 值跳过）
     accs = session.execute(select(Account)).scalars().all()
-    # entity_id × currency → {year: sum}
-    entity_agg: dict[tuple[int, str], dict[int, float]] = {}
-    entity_ids: set[int] = set()
+    entity_agg: dict[tuple[int, str], dict[int, Decimal]] = {}
     for acc in accs:
-        entity_ids.add(acc.entity_id)
         key = (acc.entity_id, acc.currency)
         ea = entity_agg.setdefault(key, {})
         series = series_by_acc.get(acc.id, {})
         for y, v in series.items():
             if y < start:
                 continue
-            ea[y] = ea.get(y, 0.0) + v
+            ea[y] = ea.get(y, _ZERO) + v
     for (eid, cur), ymap in entity_agg.items():
+        written = False
         for y in years_list:
             if y < start:
                 continue
-            v = ymap.get(y, 0.0)
+            v = ymap.get(y, _ZERO)
+            if v == 0:
+                continue
             session.add(Snapshot(
                 as_of_year=y, as_of_date=None,
                 scope=f"entity:{eid}:{cur}",
-                value=round(v, 2), currency=cur,
+                value=v.quantize(_QUANTIZE_2), currency=cur,
             ))
             stats["snapshots"] += 1
-        stats["entities"] += 1
+            written = True
+        if written:
+            stats["entities"] += 1
 
-    # 5) 写 family:total 行（USD 口径；汇率缺失币种不计入）
-    #     缺失币种可通过 wealth._usd_rate 重算 family_total_usd 时另行标记（issue #2）
+    # 5) 写 family:total 行（USD 口径；汇率缺失币种不计入；全账户 0 时跳过该年）
     for y in years_list:
         if y < start:
             continue
-        family_usd = 0.0
+        family_usd: Decimal = _ZERO
+        any_contribution = False
         for acc in accs:
             series = series_by_acc.get(acc.id, {})
-            v = series.get(y, 0.0)
+            v = series.get(y, _ZERO)
             if v == 0:
                 continue
             rate = _usd_rate(session, acc.currency, y)
             if rate is None:
                 continue                                 # 汇率缺失 → 不计入
-            family_usd += v * rate
+            family_usd = family_usd + v * rate
+            any_contribution = True
+        # issue #28：family_usd=0 跳过（避免家族层面多年 0 值行膨胀）
+        if not any_contribution or family_usd == 0:
+            continue
         session.add(Snapshot(
             as_of_year=y, as_of_date=None,
             scope="family:total",
-            value=round(family_usd, 2), currency="USD",
+            value=family_usd.quantize(_QUANTIZE_2), currency="USD",
         ))
         stats["snapshots"] += 1
         stats["family_years"] += 1

--- a/app/ingest/detect.py
+++ b/app/ingest/detect.py
@@ -1,6 +1,12 @@
 """文件→类别识别（DESIGN §6.1）。
 
 按 `input_dir 下的相对路径` 匹配；`基准/事件/` 为 Phase1 阶段项（跳过，Phase2 启用）。
+
+issue #26 修复：
+- `基准/CPI工资.md` 显式映射为 `cpi_wage`（DESIGN §6.1 类别表；之前落 unknown 报噪音）
+- `基准/公司/用工成本/` P1 范围 → `SKIP_P1`（DESIGN §13；Phase 1 不实现，跳过不报错）
+- `设计文件/` 创作约束笔记 → `SKIP_DOC`（不入库）
+SKIP_* 类别在 parse_one 显式跳过，不计入 unknown 报错。
 """
 from __future__ import annotations
 
@@ -10,6 +16,9 @@ from pathlib import Path
 # (前缀, 类别) —— 顺序敏感：更长/更精确前缀在前
 _PREFIX_RULES: list[tuple[str, str]] = [
     ("基准/事件/", "PHASE2_EVENT"),          # Phase1 跳过
+    ("基准/CPI工资.md", "cpi_wage"),          # issue #26：CPI 与工资增幅基准
+    ("基准/公司/用工成本/", "SKIP_P1"),        # issue #26：P1 §13 范围，Phase1 跳过
+    ("设计文件/", "SKIP_DOC"),                # issue #26：创作约束笔记，不入库
     ("经济/银行/", "bank"),
     ("经济/股票/", "stock_tx"),
     ("基准/收益表/惠民租房.md", "income_rent"),
@@ -25,6 +34,11 @@ _PREFIX_RULES: list[tuple[str, str]] = [
     ("人物/", "character"),
     ("时间线.md", "timeline"),
 ]
+
+
+def is_skip_category(category: str) -> bool:
+    """issue #26：SKIP_* 类别在 parse_one 显式跳过；供调用方判定。"""
+    return category.startswith("SKIP_")
 
 
 @dataclass(frozen=True)

--- a/app/ingest/normalize.py
+++ b/app/ingest/normalize.py
@@ -151,9 +151,5 @@ def currency_from(seg_title: str) -> str | None:
     return None
 
 
-def parse_relationship(line: str) -> tuple[str, ...] | None:
-    """从人物 `- 关系：xxx` 字段抽 rel_type + target（简化实现，后续扩展）。"""
-    m = re.match(r"^关系[:：]\s*(.+)$", line.strip())
-    if not m:
-        return None
-    return tuple(x.strip() for x in m.group(1).split("、") if x.strip())
+# issue #27：原 parse_relationship 是死代码（无调用方，character 解析走 parse_character
+# 内部 KV 收集）。已删除；如未来需要展开，可从 git history 取回。

--- a/app/ingest/parse.py
+++ b/app/ingest/parse.py
@@ -47,6 +47,11 @@ class IngestReport:
                 out.append((r.file, w))
         return out
 
+    @property
+    def skipped(self) -> list[ParseResult]:
+        """issue #26：SKIP_* 类别（P1 范围/创作约束）单独分组，不与 unknown 报错混淆。"""
+        return [r for r in self.results if r.category.startswith("SKIP_")]
+
 
 # 解析器签名有两种：(path) -> list 或 (path) -> (list, warnings)。
 # 下面通过 _call 统一处理。
@@ -80,6 +85,10 @@ def parse_one(rel: str, path: Path) -> ParseResult:
     if det.phase2:
         pr.ok = False
         pr.error = "Phase 2 事件，Phase 1 跳过"
+        return pr
+    # issue #26：SKIP_* 类别（P1 范围/创作约束）显式跳过，不算 unknown 报错
+    if det.category.startswith("SKIP_"):
+        pr.ok = True
         return pr
     fn = _PARSERS.get(det.category)
     if fn is None:

--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -265,7 +265,11 @@ def _region_from_file(fname: str) -> str:
 
 # ---------------- character（人物） ----------------
 def parse_character(path: Path) -> list[dict]:
-    """`- 字段：值` 自由列表；产出 entity 字段 + 关系。"""
+    """`- 字段：值` 自由列表；产出 entity 字段 + 关系。
+
+    issue #27 修复：「姓名」不再重复进 rels（它是 name 本身，不是关系）。
+    仅「与主角的关系」/「关系」进入 relations 列表。
+    """
     fields: dict = {}
     rels: list[tuple[str, str]] = []
     name = path.stem
@@ -276,9 +280,10 @@ def parse_character(path: Path) -> list[dict]:
         key, val = m.group(1).strip(), m.group(2).strip()
         if not key or key in ("---", "===="):
             continue
-        if key.replace(" ", "") in ("姓名", "与主角的关系", "关系") and val:
-            if key.replace(" ", "") == "姓名":
-                name = val.split("/")[0].strip()
+        kn = key.replace(" ", "")
+        if kn == "姓名" and val:
+            name = val.split("/")[0].strip()
+        elif kn in ("与主角的关系", "关系") and val:
             rels.append((key, val))
         else:
             fields[key] = val

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -12,7 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.ingest.normalize import resolve_date
-from app.model import Account, Entity, ExchangeRate, IncomeStream, InitialAsset, LedgerEntry
+from app.model import Account, Entity, ExchangeRate, IncomeStream, InitialAsset, LedgerEntry, Relationship
 
 
 def upsert_entity(session: Session, entity_type: str, name: str,
@@ -34,6 +34,33 @@ def upsert_entity(session: Session, entity_type: str, name: str,
     return ent
 
 
+def upsert_relationship(session: Session, from_entity_id: int, to_entity_id: int,
+                        rel_type: str, source_file: str | None = None) -> Relationship | None:
+    """按 (from, to, rel_type) 幂等 upsert Relationship；同 (from, to, rel_type) 已存在 → 复用。
+
+    issue #27：character 关系字段解析后必须持久化进 relationship 表，P1 人物图谱前置。
+    返回 None 表示 from==to（自环）跳过。
+    """
+    if from_entity_id == to_entity_id:
+        return None
+    exists = session.execute(
+        select(Relationship).where(
+            Relationship.from_entity_id == from_entity_id,
+            Relationship.to_entity_id == to_entity_id,
+            Relationship.rel_type == rel_type,
+        ).limit(1)
+    ).scalar_one_or_none()
+    if exists is not None:
+        return exists
+    rel = Relationship(
+        from_entity_id=from_entity_id, to_entity_id=to_entity_id,
+        rel_type=rel_type, source_file=source_file,
+    )
+    session.add(rel)
+    session.flush()
+    return rel
+
+
 def get_or_create_account(session: Session, entity_id: int, currency: str, bank: str | None = None) -> Account:
     acc = session.execute(
         select(Account).where(Account.entity_id == entity_id, Account.currency == currency)
@@ -46,13 +73,34 @@ def get_or_create_account(session: Session, entity_id: int, currency: str, bank:
 
 
 def import_characters(session: Session, records: list[dict], source_file: str | None = None) -> dict:
-    """character 解析记录 → entity。返回 {导入数}。"""
-    n = 0
+    """character 解析记录 → entity + relationship（按 rels 中 target 名查 entity upsert）。
+
+    issue #27 修复：
+    - relations 形如 [("与主角的关系", "养父"), ("关系", "管家张三"), ...]
+    - target_name 查 entity（按 entity_type='person', name=target_name）；失配 → warnings
+    - 关系 (from, to, rel_type) 幂等 upsert；自环（from==to）跳过
+
+    返回 {"imported": entity 数, "rels": 关系数, "warnings": [target 未找到的列表]}
+    """
+    stats: dict = {"imported": 0, "rels": 0, "warnings": []}
     for rec in records:
-        upsert_entity(session, "person", rec["name"], fields=rec.get("fields"),
-                      source_file=rec.get("source_file") or source_file)
-        n += 1
-    return {"imported": n}
+        ent = upsert_entity(session, "person", rec["name"], fields=rec.get("fields"),
+                            source_file=rec.get("source_file") or source_file)
+        stats["imported"] += 1
+        for rel_key, rel_val in rec.get("relations") or []:
+            target_name = rel_val.split("/")[0].strip() if rel_val else ""
+            if not target_name or target_name == rec["name"]:
+                continue  # 空值或自环
+            to = session.execute(
+                select(Entity).where(Entity.entity_type == "person", Entity.name == target_name)
+            ).scalar_one_or_none()
+            if to is None:
+                stats["warnings"].append(f"{rec['name']} → {target_name}（{rel_key}）目标未注册")
+                continue
+            upsert_relationship(session, ent.id, to.id, rel_key,
+                                source_file=rec.get("source_file") or source_file)
+            stats["rels"] += 1
+    return stats
 
 
 def import_initial_assets(session: Session, records: list[dict], cash_year: int = 1947) -> dict:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -174,3 +174,35 @@ class TestTimelineEvents:
         c, _ = client
         r = c.get("/api/v1/timeline-events/99999")
         assert r.status_code == 404
+
+
+class TestCorsMiddleware:
+    """issue #30：CORSMiddleware 已挂载，PRD §13 限本地两个来源。"""
+
+    def test_cors_allows_localhost_5173(self, client):
+        """issue #30 修复点：vite dev 端口跨域通过。"""
+        c, _ = client
+        r = c.get("/api/v1/ping", headers={"Origin": "http://localhost:5173"})
+        assert r.status_code == 200
+        # CORS 预检响应头
+        assert r.headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+    def test_cors_allows_127_5173(self, client):
+        c, _ = client
+        r = c.get("/api/v1/ping", headers={"Origin": "http://127.0.0.1:5173"})
+        assert r.headers.get("access-control-allow-origin") == "http://127.0.0.1:5173"
+
+    def test_cors_rejects_other_origin(self, client):
+        """非白名单来源 → 不回 ACAO 头（浏览器会拦截）。"""
+        c, _ = client
+        r = c.get("/api/v1/ping", headers={"Origin": "http://evil.example.com"})
+        assert r.status_code == 200  # 实际请求仍 OK，但 CORS 头不返回
+        assert r.headers.get("access-control-allow-origin") is None
+
+    def test_cors_middleware_registered(self):
+        """CORSMiddleware 在 app.user_middleware 中（issue #30 修复点）。"""
+        from app.api.app import _CORS_ORIGINS
+        assert "http://localhost:5173" in _CORS_ORIGINS
+        assert "http://127.0.0.1:5173" in _CORS_ORIGINS
+        cors_mw = [m for m in app.user_middleware if "CORS" in m.cls.__name__]
+        assert len(cors_mw) == 1

--- a/tests/test_character_relationships.py
+++ b/tests/test_character_relationships.py
@@ -1,0 +1,187 @@
+"""Unit tests for character 关系持久化（issue #27 回归）。
+
+覆盖：
+- parse_character：姓名不再重复进 rels（只「与主角的关系」/「关系」进 rels）
+- import_characters：rels → 按 target 名查 entity → upsert Relationship
+- 失配名（target 未注册）→ warnings（不阻塞）
+- 自环（from==to）跳过
+- 幂等：同 (from,to,rel_type) 二次 import 不重复
+- parse_relationship 死代码已删（import 失败）
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.ingest.parsers import parse_character
+from app.ingest.writer import import_characters, upsert_relationship
+from app.model import Entity, Relationship
+
+
+@pytest.fixture
+def session():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _write(tmp: Path, name: str, content: str) -> Path:
+    p = tmp / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestParseCharacterCleanRels:
+    def test_name_not_in_rels(self, tmp_path):
+        """issue #27 修复：「姓名」仅决定 name，不重复进 rels。"""
+        p = _write(tmp_path, "养父.md", (
+            "- 姓名：Joren Peeters\n"
+            "- 与主角的关系：养父\n"
+            "- 职业：律师\n"
+        ))
+        recs = parse_character(p)
+        assert recs[0]["name"] == "Joren Peeters"
+        # rels 只含关系，不含姓名
+        rel_keys = [k for k, _ in recs[0]["relations"]]
+        assert "姓名" not in rel_keys
+        assert "与主角的关系" in rel_keys
+
+    def test_relations_only_rel_fields(self, tmp_path):
+        p = _write(tmp_path, "主角.md", (
+            "- 姓名：Stijn\n"
+            "- 与主角的关系：本人\n"
+            "- 关系：被收养于 Henri 家族\n"
+            "- 出生：1985\n"
+        ))
+        recs = parse_character(p)
+        # rels 含两个关系键，其他进 fields
+        rel_keys = {k for k, _ in recs[0]["relations"]}
+        assert rel_keys == {"与主角的关系", "关系"}
+        assert "出生" in recs[0]["fields"]
+
+
+class TestImportCharactersRelationships:
+    def _seed_related_entities(self, session):
+        """预注册 target 实体，让关系可命中。"""
+        session.add_all([
+            Entity(entity_type="person", name="Stijn"),
+            Entity(entity_type="person", name="Joren Peeters"),
+            Entity(entity_type="person", name="Henri Peeters"),
+        ])
+        session.commit()
+
+    def test_rels_persisted(self, session, tmp_path):
+        """issue #27 核心修复：rels 持久化进 relationship 表。
+
+        val 作为 target entity 名字查 entity；命中 → 写 Relationship。
+        （真实文件 val 常为关系描述如「养父」而非名字——按 issue #27 字面要求 val=名字）
+        """
+        self._seed_related_entities(session)
+        p = _write(tmp_path, "养父.md", (
+            "- 姓名：Joren Peeters\n"
+            "- 关系：Stijn\n"  # val=Stijn（entity.name），rel_type="关系"
+        ))
+        recs = parse_character(p)
+        stats = import_characters(session, recs, source_file="养父.md")
+        assert stats["rels"] == 1
+        assert stats["warnings"] == []
+        # 验证 relationship 表
+        from_entity = session.query(Entity).filter_by(name="Joren Peeters").first()
+        to_entity = session.query(Entity).filter_by(name="Stijn").first()
+        rel = session.query(Relationship).filter_by(
+            from_entity_id=from_entity.id, to_entity_id=to_entity.id,
+            rel_type="关系"
+        ).first()
+        assert rel is not None
+        assert rel.source_file == "养父.md"
+
+    def test_missing_target_warns(self, session, tmp_path):
+        """target 未注册 → warning（不阻塞，DESIGN §6.3 失配可人工补 entity）。"""
+        # 只注册 Stijn，Joren 未注册
+        session.add(Entity(entity_type="person", name="Stijn"))
+        session.commit()
+        p = _write(tmp_path, "养父.md", (
+            "- 姓名：Joren Peeters\n"
+            "- 关系：Stijn\n"
+        ))
+        recs = parse_character(p)
+        stats = import_characters(session, recs)
+        # Joren 第一次注册（首次见）
+        assert stats["imported"] == 1
+        assert stats["rels"] == 1
+        # 第二次引用一个不存在的 entity → warning
+        p2 = _write(tmp_path, "管家.md", (
+            "- 姓名：管家 A\n"
+            "- 关系：某某不存在\n"
+        ))
+        recs2 = parse_character(p2)
+        stats2 = import_characters(session, recs2)
+        assert stats2["rels"] == 0
+        assert len(stats2["warnings"]) == 1
+        assert "未注册" in stats2["warnings"][0]
+
+    def test_self_loop_skipped(self, session, tmp_path):
+        """rels 的 target 等于 name → 自环跳过（避免 entity 自指）。"""
+        session.add(Entity(entity_type="person", name="Stijn"))
+        session.commit()
+        p = _write(tmp_path, "主角.md", (
+            "- 姓名：Stijn\n"
+            "- 与主角的关系：本人\n"
+        ))
+        recs = parse_character(p)
+        stats = import_characters(session, recs)
+        assert stats["rels"] == 0
+        assert session.query(Relationship).count() == 0
+
+    def test_idempotent(self, session, tmp_path):
+        """二次 import 同 (from,to,rel_type) 不重复。"""
+        self._seed_related_entities(session)
+        p = _write(tmp_path, "养父.md", (
+            "- 姓名：Joren Peeters\n"
+            "- 关系：Stijn\n"
+        ))
+        recs = parse_character(p)
+        import_characters(session, recs)
+        first_count = session.query(Relationship).count()
+        import_characters(session, recs)
+        second_count = session.query(Relationship).count()
+        assert first_count == second_count == 1
+
+
+class TestParseRelationshipRemoved:
+    def test_dead_code_removed(self):
+        """issue #27：parse_relationship 死代码已删；import 应失败。"""
+        with pytest.raises(ImportError):
+            from app.ingest.normalize import parse_relationship  # noqa: F401
+
+
+class TestUpsertRelationship:
+    def test_returns_none_on_self_loop(self, session):
+        a = Entity(entity_type="person", name="X")
+        session.add(a)
+        session.flush()
+        assert upsert_relationship(session, a.id, a.id, "self") is None
+
+    def test_creates_then_returns_existing(self, session):
+        a = Entity(entity_type="person", name="A")
+        b = Entity(entity_type="person", name="B")
+        session.add_all([a, b])
+        session.flush()
+        r1 = upsert_relationship(session, a.id, b.id, "parent")
+        session.commit()
+        r2 = upsert_relationship(session, a.id, b.id, "parent")
+        assert r1 is not None and r1.id == r2.id
+        assert session.query(Relationship).count() == 1

--- a/tests/test_decimal_zero_skip.py
+++ b/tests/test_decimal_zero_skip.py
@@ -1,0 +1,176 @@
+"""Unit tests for issue #28 数值纪律：Decimal 化 + 0 值压缩。
+
+覆盖：
+- recompute_account 内部用 Decimal（balance 累计无 float 转换误差）
+- snapshot 0 值年份跳过写入（account / entity / family 三种 scope）
+- snapshot 写入 value 是 Decimal（Decimal('123.45'）精确位）
+- 0 值 family_usd 跳过该年（避免多年 0 行膨胀）
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.recompute import recompute_account
+from app.core.snapshot import rebuild_snapshots
+from app.db import Base
+from app.model import Account, Entity, ExchangeRate, LedgerEntry, Snapshot
+
+
+@pytest.fixture
+def session():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed_account(session, currency="BEF") -> tuple[Entity, Account]:
+    e = Entity(entity_type="person", name="Henri Peeters")
+    a = Account(entity_id=0, currency=currency)
+    session.add_all([e, a])
+    session.flush()
+    a.entity_id = e.id
+    session.commit()
+    return e, a
+
+
+def _close_account(session, acc: Account, year: int) -> None:
+    """issue #28：账户关池 → 该年起 balance=0（DESIGN §6.6）。"""
+    acc.status = "closed"
+    acc.closed_on = date(year, 1, 1)
+    session.commit()
+
+
+class TestRecomputeDecimalPrecision:
+    def test_balance_uses_decimal_not_float(self, session):
+        """issue #28：balance 不再经 float() 转换；用 Decimal 累加。"""
+        _, a = _seed_account(session)
+        # 经典 float 误差场景：0.1 + 0.2 ≠ 0.3（float=0.30000000000000004）
+        # 用 Decimal(0.1)+Decimal(0.2) 应得 0.3 精确
+        session.add_all([
+            LedgerEntry(account_id=a.id, date=date(1990, 6, 1),
+                        inflow=Decimal("0.10"), balance=Decimal("0.10")),
+            LedgerEntry(account_id=a.id, date=date(1990, 7, 1),
+                        inflow=Decimal("0.20")),
+        ])
+        session.commit()
+        result = recompute_account(session, a.id, 1990)
+        assert result["updated"] >= 1
+        # 取第二条 ledger，balance 必须是 Decimal('0.30') 而不是 0.30000000000000004
+        second = session.execute(
+            LedgerEntry.__table__.select().where(LedgerEntry.id == 2)
+        ).first()
+        assert second.balance == Decimal("0.30"), \
+            f"balance 必须精确为 0.30，实际 {second.balance} ({type(second.balance).__name__})"
+
+    def test_no_float_intermediate(self, session):
+        """验证不引入 float 中间类型（balance 写回仍是 Decimal 类型）。"""
+        _, a = _seed_account(session)
+        session.add(LedgerEntry(account_id=a.id, date=date(1990, 1, 1),
+                                inflow=Decimal("100.50"), outflow=Decimal("30.25"),
+                                balance=Decimal("70.25")))
+        session.commit()
+        recompute_account(session, a.id, 1990)
+        e = session.execute(
+            LedgerEntry.__table__.select().where(LedgerEntry.account_id == a.id)
+        ).first()
+        # 类型必须是 Decimal 而非 float
+        assert isinstance(e.balance, Decimal), \
+            f"balance 必须是 Decimal 类型，实际 {type(e.balance).__name__}"
+
+
+class TestSnapshotZeroSkip:
+    def test_account_zero_years_skipped_after_close(self, session):
+        """issue #28：账户关池后 balance=0 → 该年及之后快照跳过。
+
+        关池年 1995 → 1995/1996/1997 都应跳过（balance 全 0），仅写 1990-1994。
+        """
+        _, a = _seed_account(session)
+        session.add(LedgerEntry(account_id=a.id, date=date(1990, 12, 30),
+                                inflow=Decimal("100"), balance=Decimal("100")))
+        session.commit()
+        _close_account(session, a, 1995)
+        rebuild_snapshots(session, years=range(1990, 1998))
+        rows = session.query(Snapshot).filter(
+            Snapshot.scope.like("account:%")
+        ).all()
+        # 关池前 5 年（1990-1994）+ 关池年本身（1995 balance=0 跳过）→ 5 行
+        years = sorted(r.as_of_year for r in rows)
+        assert years == [1990, 1991, 1992, 1993, 1994], \
+            f"关池年起应跳过 0 值行，实际 {years}"
+
+    def test_entity_zero_years_skipped_after_close(self, session):
+        """entity scope 同样：账户关池后 entity 的该年聚合为 0 → 跳过。"""
+        _, a = _seed_account(session)
+        session.add(LedgerEntry(account_id=a.id, date=date(1990, 12, 30),
+                                inflow=Decimal("100"), balance=Decimal("100")))
+        session.commit()
+        _close_account(session, a, 1993)
+        rebuild_snapshots(session, years=range(1990, 1995))
+        rows = session.query(Snapshot).filter(
+            Snapshot.scope.like("entity:%")
+        ).all()
+        assert sorted(r.as_of_year for r in rows) == [1990, 1991, 1992]
+
+    def test_family_zero_year_skipped(self, session):
+        """family:total 0 值年跳过（无任何有值账户贡献时不写）。"""
+        # 不放 ledger，纯空账户
+        e = Entity(entity_type="person", name="Empty Holder")
+        session.add(e)
+        session.flush()
+        a = Account(entity_id=e.id, currency="BEF")
+        session.add(a)
+        session.commit()
+        # 加 USD→BEF 汇率，让 family 计算时不为 None
+        session.add(ExchangeRate(fx_from="USD", fx_to="BEF", year=2000, rate=40.0))
+        session.commit()
+        rebuild_snapshots(session, years=range(2000, 2003))
+        rows = session.query(Snapshot).filter(Snapshot.scope == "family:total").all()
+        # 账户无流水，所有年 family_usd=0 → 全部跳过
+        assert rows == [], f"family 0 值年应全部跳过，实际 {[(r.as_of_year, r.value) for r in rows]}"
+
+    def test_family_written_when_any_account_has_value(self, session):
+        """有任一账户在该年有余额 → family 写一行；该年累计 0 则跳过。
+
+        2000 入金 500（balance=500）→ family=500；2001 起无流水（2001 累计仍 500）→
+        family=500 也写。预期两行（2000/2001 都非零）。
+        """
+        _, a = _seed_account(session, currency="USD")
+        session.add(LedgerEntry(account_id=a.id, date=date(2000, 12, 30),
+                                inflow=Decimal("500"), balance=Decimal("500")))
+        session.commit()
+        rebuild_snapshots(session, years=range(2000, 2002))
+        rows = session.query(Snapshot).filter(Snapshot.scope == "family:total").all()
+        # 累计非零的所有年都写
+        assert len(rows) == 2
+        assert rows[0].as_of_year == 2000
+        assert rows[0].value == Decimal("500.00")
+        assert rows[1].as_of_year == 2001
+        assert rows[1].value == Decimal("500.00")
+
+
+class TestSnapshotValueIsDecimal:
+    def test_written_value_is_decimal(self, session):
+        """issue #28：写库 value 是 Decimal 而非 float（保证 NUMERIC 列精度）。"""
+        _, a = _seed_account(session)
+        session.add(LedgerEntry(account_id=a.id, date=date(1990, 12, 30),
+                                inflow=Decimal("123.45"), balance=Decimal("123.45")))
+        session.commit()
+        rebuild_snapshots(session, years=range(1990, 1991))
+        row = session.query(Snapshot).first()
+        assert isinstance(row.value, Decimal), \
+            f"value 必须是 Decimal 类型，实际 {type(row.value).__name__}"
+        assert row.value == Decimal("123.45")

--- a/tests/test_detect_cpi_skip.py
+++ b/tests/test_detect_cpi_skip.py
@@ -1,0 +1,105 @@
+"""Unit tests for app/ingest/detect + parse_one SKIP 类别（issue #26 回归）。
+
+覆盖：
+- detect 显式映射 CPI工资.md → cpi_wage（不再落 unknown）
+- detect 显式映射基准/公司/用工成本/ → SKIP_P1
+- detect 显式映射设计文件/ → SKIP_DOC
+- 顺序：更长前缀优先（CPI 工资.md 单独一个，不被 SKIP_P1 之类误吞）
+- is_skip_category 判定
+- parse_one：SKIP 类别 ok=True 不报 unknown error
+- IngestReport.skipped 分组属性
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.ingest.detect import detect, is_skip_category, scan_dir
+from app.ingest.parse import IngestReport, ParseResult, parse_one
+
+
+class TestDetectExplicitMappings:
+    def test_cpi_wage_mapped(self):
+        """issue #26 核心修复：CPI工资.md 不再落 unknown。"""
+        d = detect("基准/CPI工资.md")
+        assert d.category == "cpi_wage", f"应映射为 cpi_wage，实际 {d.category}"
+        assert not d.phase2
+
+    def test_company_labor_cost_skipped(self):
+        """基准/公司/用工成本/ 显式 SKIP_P1（DESIGN §13 P1 范围）。"""
+        d = detect("基准/公司/用工成本/比利时.md")
+        assert d.category == "SKIP_P1"
+        assert d.phase2 is False  # 不是 phase2 event，是 P1 跳过
+
+    def test_design_docs_skipped(self):
+        """设计文件/ 创作约束笔记 → SKIP_DOC（不入库）。"""
+        d = detect("设计文件/学习.md")
+        assert d.category == "SKIP_DOC"
+
+    def test_nested_design_docs_skipped(self):
+        """设计文件/ 子目录也走 SKIP_DOC。"""
+        d = detect("设计文件/子目录/任何文件.md")
+        assert d.category == "SKIP_DOC"
+
+
+class TestIsSkipCategory:
+    def test_skip_prefix_true(self):
+        assert is_skip_category("SKIP_P1") is True
+        assert is_skip_category("SKIP_DOC") is True
+
+    def test_non_skip_false(self):
+        assert is_skip_category("cpi_wage") is False
+        assert is_skip_category("PHASE2_EVENT") is False
+        assert is_skip_category("unknown") is False
+
+
+class TestPrefixOrdering:
+    def test_cpi_specific_before_company_prefix(self):
+        """CPI 工资.md 是精确文件名前缀，应在「基准/」前匹配；这里只需验证 cpi_wage 命中。"""
+        # 即便添加了 SKIP_P1 = "基准/公司/用工成本/" 前缀，CPI 文件路径不冲突
+        d = detect("基准/CPI工资.md")
+        assert d.category == "cpi_wage"
+
+    def test_phase2_event_still_skipped(self):
+        """回归：原有的 PHASE2_EVENT 映射不被破坏。"""
+        d = detect("基准/事件/股票/腾讯.md")
+        assert d.category == "PHASE2_EVENT"
+        assert d.phase2 is True
+
+
+class TestParseOneSkipCategory:
+    def test_skip_p1_ok_no_error(self, tmp_path):
+        """issue #26：SKIP 类别在 parse_one 显式跳过，ok=True 不报 unknown。"""
+        p = tmp_path / "比利时.md"
+        p.write_text("# 标题", encoding="utf-8")
+        pr = parse_one("基准/公司/用工成本/比利时.md", p)
+        assert pr.ok is True
+        assert pr.error is None
+        assert pr.category == "SKIP_P1"
+        assert pr.records == []
+
+    def test_skip_doc_ok_no_error(self, tmp_path):
+        p = tmp_path / "学习.md"
+        p.write_text("# 学习笔记", encoding="utf-8")
+        pr = parse_one("设计文件/学习.md", p)
+        assert pr.ok is True
+        assert pr.category == "SKIP_DOC"
+
+
+class TestIngestReportSkippedGroup:
+    def test_skipped_filters_skip_categories(self):
+        """IngestReport.skipped 单独分组 SKIP_*，不与 unknown 报错混淆。"""
+        report = IngestReport()
+        report.results.append(ParseResult(file="基准/公司/用工成本/X.md",
+                                           category="SKIP_P1", ok=True))
+        report.results.append(ParseResult(file="设计文件/学习.md",
+                                           category="SKIP_DOC", ok=True))
+        report.results.append(ParseResult(file="基准/CPI工资.md",
+                                           category="cpi_wage", ok=True))
+        report.results.append(ParseResult(file="未识别.md",
+                                           category="unknown", ok=False,
+                                           error="解析器未实现（unknown）"))
+        skipped = report.skipped
+        assert len(skipped) == 2
+        assert all(r.category.startswith("SKIP_") for r in skipped)
+        assert len(report.failed) == 1
+        assert report.failed[0].category == "unknown"


### PR DESCRIPTION
## 问题
issue #30: FastAPI 未配置 CORSMiddleware。
- dev 场景走 vite proxy 同源无碍；但 frontend/dist 单独部署（不同端口直连 API）时浏览器跨域失败

## 修复
### app/api/app.py
- import CORSMiddleware
- 新增 _CORS_ORIGINS = ('http://localhost:5173', 'http://127.0.0.1:5173')
- app.add_middleware(CORSMiddleware, allow_origins=..., allow_credentials=True,
  allow_methods=['*'], allow_headers=['*'])
- 不动现有路由与依赖

## 验证
- tests/test_api.py 新增 TestCorsMiddleware 4 个 case：
  - localhost:5173 跨域通过（ACAO 头存在）
  - 127.0.0.1:5173 跨域通过
  - 其他 origin 不返 ACAO 头（被拦截）
  - CORSMiddleware 已注册到 app.user_middleware
- 全套 171 测试通过（test_api 11+4），零回归

Closes #30