### PR TITLE
fix(ingest): 清理死代码 _THOUSAND_RE + Row/_rows_between + dataclass 未用导入 (issue #31)

### DIFF
--- a/app/ingest/normalize.py
+++ b/app/ingest/normalize.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 import re
 from datetime import date
 
-# ---- 千分位 / 单位 / 约等 ----
-_THOUSAND_RE = re.compile(r"[,\s]")
+# ---- 单位 / 约等 ----
 _WAN_RE = re.compile(r"(?<=\d)([万亿])(?![a-zA-Z])")
 _APPROX_RE = re.compile(r"[≈~]?\s*")
 
@@ -153,3 +152,4 @@ def currency_from(seg_title: str) -> str | None:
 
 # issue #27：原 parse_relationship 是死代码（无调用方，character 解析走 parse_character
 # 内部 KV 收集）。已删除；如未来需要展开，可从 git history 取回。
+# issue #31：_THOUSAND_RE 定义未用（千分位剥离在 parse_number/parse_amount 内联实现），已清理。

--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -5,7 +5,6 @@ F-P0-02：基础形态解析；收益/初始资产/薪资/支出的细粒度挂�
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 import re
 
@@ -18,11 +17,6 @@ class ParseError(Exception):
 
 # issue #24：salary/household_expense 共用的币种白名单（与 detect_currency 输出口径一致）
 _CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "EUR")
-
-
-@dataclass
-class Row:
-    cells: list[str]
 
 
 def _lines(path: Path) -> list[str]:
@@ -39,31 +33,6 @@ def _split_table_row(line: str) -> list[str]:
         return []
     s = s.strip("|")
     return [c.strip() for c in s.split("|")]
-
-
-def _rows_between(lines: list[str], start: int, header_needs: list[str]) -> tuple[list[Row], int]:
-    """从 line[start] 起找第一个含所有 header_needs 的表格，返回 (数据行, 结束行号)。
-    返回行号供后续指针推进。
-    """
-    i = start
-    while i < len(lines):
-        cells = _split_table_row(lines[i])
-        if len(cells) >= 2 and all(any(h in c for c in cells) for h in header_needs):
-            # 表头下可能是分隔行 `|---|`
-            j = i + 1
-            rows: list[Row] = []
-            while j < len(lines):
-                rc = _split_table_row(lines[j])
-                if not rc:
-                    break
-                if j == i + 1 and rc and all(not c.strip() for c in rc[1:]):
-                    j += 1
-                    continue
-                rows.append(Row(rc))
-                j += 1
-            return rows, j
-        i += 1
-    return [], i
 
 
 # ---------------- fx（汇率） ----------------


### PR DESCRIPTION
闭 #31

- normalize.py 删未用的 _THOUSAND_RE（千分位剥离已内联在 parse_number/parse_amount）
- parsers.py 删无调用方的 Row dataclass 与 _rows_between，及其后不再使用的 dataclass 导入
- _WAN_RE 经核对在用（parse_number 万/亿），parse_relationship 已在 #27 清除，均保留

171 tests passed.