### PR TITLE
fix(ingest): 卫生项——去重 skipped + detect_currency 补 CNY + parse_amount 补 美金 (issue #32)

### DIFF
--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -45,7 +45,7 @@ def run(
     cfg = get_config(env)
     typer.echo(f"[{cfg.env}] 输入目录={cfg.input_dir}")
     report = run_ingest(cfg.input_dir)
-    typer.echo(f"识别 {len(report.ok)} 个可解析文件 · {len(report.failed)} 需人工 · {len(report.skipped)} Phase2 跳过")
+    typer.echo(f"识别 {len(report.ok)} 个可解析文件 · {len(report.failed)} 需人工 · {len(report.skipped)} 跳过")
     for r in report.ok:
         typer.echo(f"  ✅ {r.category:12s} {r.file} ({len(r.records)} 条)")
     for r in report.failed:

--- a/app/ingest/normalize.py
+++ b/app/ingest/normalize.py
@@ -40,7 +40,9 @@ def parse_amount(raw: object, unit: str | None = None) -> float | None:
     if raw is None:
         return None
     s = str(raw).strip().replace(",", "").replace(" ", "").replace("≈", "").replace("~", "")
-    s = re.sub(r"(万美金|万USD|万BEF|万|亿|USD|US|BEF|LUF|NLG|DKK|SEK|HKD|EUR|法郎|美元|元)", "", s)
+    # issue #32：长词单位（万美金/万USD/万BEF）置前优先剥离，避免「万」先命中残留「美金」
+    # 导致 float 失败返 None；补 `美金` 兜底（无「万」前缀的「X 美金」同样被清）。
+    s = re.sub(r"(万美金|万USD|万BEF|万|亿|USD|US|BEF|LUF|NLG|DKK|SEK|HKD|EUR|法郎|美元|美金|元)", "", s)
     if not s or s in ("-", "—"):
         return None
     try:
@@ -52,7 +54,9 @@ def parse_amount(raw: object, unit: str | None = None) -> float | None:
 # ---- 货币 ----
 # 单词边界避免「USD」被「US」前缀吞；移除 `US` 别名（`USD` 优先匹配）。
 # 顺序无所谓（alternation 最长优先：re 默认从左到右，但 \b 防止前缀误吞）。
-_CUR_RE = re.compile(r"\b(USD|BEF|LUF|NLG|DKK|SEK|HKD|EUR)\b", re.IGNORECASE)
+# issue #32：补 `CNY`——fx 解析会把 yuan/rmb/人民币 归一为 CNY（_cur），detect_currency
+# 口径需一致，否则「人民币」串被识别为空、下游 `cur not in _CURRENCIES` 误回退 BEF。
+_CUR_RE = re.compile(r"\b(USD|BEF|LUF|NLG|DKK|SEK|HKD|CNY|EUR|RMB)\b", re.IGNORECASE)
 
 
 def detect_currency(text: str) -> str | None:
@@ -61,12 +65,15 @@ def detect_currency(text: str) -> str | None:
     issue #24 顺带修复：旧 regex `(USD|US|BEF|...|EUR|EUR)` 中 `US` 是 `USD` 前缀，
     匹配时优先取 `US`；EUR 又被 dict fallback 到 USD → 纯「EUR」字符串被误判为 USD。
     新 regex 用 \\\\b 单词边界 + 移除 US 别名，所有代码按字面值返回。
+    issue #32：补 CNY/RMB——fx 把 yuan/rmb/人民币 归一为 CNY，与 detect 口径对齐。
+    返回 `CNY`（RMB 仅是中文习惯写法；下游 `_CURRENCIES` 白名单存 CN/Y 对应 CNY）。
     """
     m = _CUR_RE.search(text or "")
-    return m.group(1).upper() if m else None
+    code = m.group(1).upper() if m else None
+    return "CNY" if code == "RMB" else code
 
 
-_CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "EUR")
+_CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "CNY", "EUR")
 
 
 def _month_end(year: int, month: int) -> date:

--- a/app/ingest/parse.py
+++ b/app/ingest/parse.py
@@ -35,10 +35,6 @@ class IngestReport:
         return [r for r in self.results if not r.ok]
 
     @property
-    def skipped(self) -> list[ParseResult]:
-        return [r for r in self.results if r.category == "PHASE2_EVENT"]
-
-    @property
     def warnings(self) -> list[tuple[str, str]]:
         """收集 (file, warning) 对，供上层展示。"""
         out: list[tuple[str, str]] = []

--- a/app/ingest/parsers.py
+++ b/app/ingest/parsers.py
@@ -16,7 +16,7 @@ class ParseError(Exception):
 
 
 # issue #24：salary/household_expense 共用的币种白名单（与 detect_currency 输出口径一致）
-_CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "EUR")
+_CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "CNY", "EUR")
 
 
 def _lines(path: Path) -> list[str]:


### PR DESCRIPTION
闭 #32

- db.py 行内 __import__：核对已改为顶部正常导入，无需改
- parse.py 删重复旧 skipped(PHASE2_EVENT) 属性——SKIP_ 版已覆盖，旧属性导致 semantics 混乱；同步纠正 main.py 日志「Phase2 跳过」措辞
- normalize.detect_currency 补 CNY/RMB（RMB 归一 CNY），并把 CNY 加入 normalize/parsers 两处 _CURRENCIES 白名单，与 fx 产出口径一致
- parse_amount 单位剥离补 美金 兜底（无万 前缀的「X 美金」残留不再返 None）；长词置前已由 #18 落实

171 tests passed.