### PR TITLE
docs: 修正 CLAUDE.md git 入库范围描述 (issue #34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,5 +109,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 三环境均同源代码，仅 `APP_ENV` + 库名(`novel_*`) + 数据目录不同；`Design_Folder` 为只读源。
 
 **仓库与 git**：
-- `Design_Folder/`（创作素材）已被 `.gitignore` 排除，**不入 git、不提交**；仅 `docs/` + `CLAUDE.md` + `.gitignore` 入版本库。
+- **入库范围**（Dashboard 工程线全部代码入版本库）：`app/`（FastAPI + ingest + 模型）、`frontend/`（React+Vite）、`migrations/` + `alembic.ini`、`tests/`、`requirements.txt`、`docs/`、`CLAUDE.md`、`.gitignore`、`data/*`（仅 `.gitkeep` 占位）。
+- `Design_Folder/`（创作素材）已被 `.gitignore` 排除，**不入 git、不提交**。
 - 远程：`origin` → github.com/LinyunXIA/Novel_Dashboard（private）。


### PR DESCRIPTION
闭 #34

按实际 .gitignore
CLAUDE.md
alembic.ini
app/__init__.py
app/api/__init__.py
app/api/app.py
app/api/deps.py
app/config.py
app/core/__init__.py
app/core/calendar.py
app/core/health.py
app/core/recompute.py
app/core/snapshot.py
app/core/wealth.py
app/db.py
app/ingest/__init__.py
app/ingest/conflict.py
app/ingest/detect.py
app/ingest/holders.py
app/ingest/main.py
app/ingest/normalize.py
app/ingest/parse.py
app/ingest/parsers.py
app/ingest/writer.py
app/model/__init__.py
app/model/core.py
app/model/derived.py
app/model/types.py
data/input-dev/.gitkeep
data/input-test/.gitkeep
data/input/.gitkeep
data/overlay-dev/.gitkeep
data/overlay-test/.gitkeep
data/overlay/.gitkeep
docs/DESIGN-webnovel-dashboard.md
docs/PRD-webnovel-dashboard.md
docs/ui-mockup/index.html
frontend/.env
frontend/index.html
frontend/package-lock.json
frontend/package.json
frontend/src/App.jsx
frontend/src/main.jsx
frontend/src/screens/Dashboard.jsx
frontend/src/styles.css
frontend/vite.config.js
migrations/README
migrations/env.py
migrations/script.py.mako
migrations/versions/020389f690df_init_baseline.py
migrations/versions/827c44be1b80_phase1_p0_full_schema_19_tables.py
migrations/versions/a1b2c3d4e5f6_finance_entry_entity_kind_check.py
migrations/versions/b1c2d3e4f5a6_ddl_jsonb_array_server_defaults.py
requirements.txt
tests/__init__.py
tests/test_api.py
tests/test_bank_parser.py
tests/test_character_relationships.py
tests/test_decimal_zero_skip.py
tests/test_detect_cpi_skip.py
tests/test_health.py
tests/test_holders.py
tests/test_income_security_parser.py
tests/test_ingest_conflict.py
tests/test_normalize.py
tests/test_parsers_fx.py
tests/test_recompute_job.py
tests/test_salary_household_parser.py
tests/test_snapshot.py
tests/test_timeline_parser.py 改写：Dashboard 工程线代码（app/frontend/migrations/tests/requirements/alembic.ini）+ docs + CLAUDE.md + .gitignore + data/.gitkeep 占位均入库； 仍不入库。