### PR TITLE
fix(ingest): cpi_wage SKIP_PARAM + stock_tx 显式 Phase2 跳过 (issue #70)

### DIFF
--- a/app/ingest/detect.py
+++ b/app/ingest/detect.py
@@ -3,10 +3,13 @@
 按 `input_dir 下的相对路径` 匹配；`基准/事件/` 为 Phase1 阶段项（跳过，Phase2 启用）。
 
 issue #26 修复：
-- `基准/CPI工资.md` 显式映射为 `cpi_wage`（DESIGN §6.1 类别表；之前落 unknown 报噪音）
+- `基准/CPI工资.md` 显式映射（不再落 unknown 报噪音）
 - `基准/公司/用工成本/` P1 范围 → `SKIP_P1`（DESIGN §13；Phase 1 不实现，跳过不报错）
 - `设计文件/` 创作约束笔记 → `SKIP_DOC`（不入库）
 SKIP_* 类别在 parse_one 显式跳过，不计入 unknown 报错。
+
+issue #70：CPI工资.md 从 `cpi_wage` 改归 `SKIP_PARAM`——它是折算/展示基准参数，
+当前无任何消费方；原映射导致「有类别无 parser」每轮报 ❌ 解析器未实现。
 """
 from __future__ import annotations
 
@@ -16,7 +19,7 @@ from pathlib import Path
 # (前缀, 类别) —— 顺序敏感：更长/更精确前缀在前
 _PREFIX_RULES: list[tuple[str, str]] = [
     ("基准/事件/", "PHASE2_EVENT"),          # Phase1 跳过
-    ("基准/CPI工资.md", "cpi_wage"),          # issue #26：CPI 与工资增幅基准
+    ("基准/CPI工资.md", "SKIP_PARAM"),        # issue #70：CPI 与工资增幅基准参数，无消费方显式跳过
     ("基准/公司/用工成本/", "SKIP_P1"),        # issue #26：P1 §13 范围，Phase1 跳过
     ("设计文件/", "SKIP_DOC"),                # issue #26：创作约束笔记，不入库
     ("经济/银行/", "bank"),

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -102,6 +102,12 @@ def import_all(session, source_dir, log=None) -> dict:
         key=lambda r: (_ORDER.index(r.category) if r.category in _ORDER else 99, r.file),
     )
     for r in ordered:
+        if r.category == "stock_tx" and r.records:
+            # issue #70：股票台账解析成功但持仓/事件落库属 Phase 2（DESIGN §19.6），显式说明而非静默
+            log(f"   ⏭ {r.file}: 股票台账解析成功（{len(r.records)} 组基本信息/"
+                f"{sum(len(x.get('events') or []) for x in r.records)} 条明细），"
+                f"持仓/事件落库属 Phase 2（§19.6），本次跳过")
+            continue
         if r.category == "character" and r.records:
             ck += writer.import_characters(session, r.records, r.file)["imported"]
         if r.category == "return_table" and r.records:

--- a/tests/test_detect_cpi_skip.py
+++ b/tests/test_detect_cpi_skip.py
@@ -1,7 +1,7 @@
 """Unit tests for app/ingest/detect + parse_one SKIP 类别（issue #26 回归）。
 
 覆盖：
-- detect 显式映射 CPI工资.md → cpi_wage（不再落 unknown）
+- detect 显式映射 CPI工资.md → SKIP_PARAM（issue #70：无消费方的基准参数，显式跳过不报错）
 - detect 显式映射基准/公司/用工成本/ → SKIP_P1
 - detect 显式映射设计文件/ → SKIP_DOC
 - 顺序：更长前缀优先（CPI 工资.md 单独一个，不被 SKIP_P1 之类误吞）
@@ -21,7 +21,7 @@ class TestDetectExplicitMappings:
     def test_cpi_wage_mapped(self):
         """issue #26 核心修复：CPI工资.md 不再落 unknown。"""
         d = detect("基准/CPI工资.md")
-        assert d.category == "cpi_wage", f"应映射为 cpi_wage，实际 {d.category}"
+        assert d.category == "SKIP_PARAM", f"应映射为 SKIP_PARAM，实际 {d.category}"
         assert not d.phase2
 
     def test_company_labor_cost_skipped(self):
@@ -47,17 +47,17 @@ class TestIsSkipCategory:
         assert is_skip_category("SKIP_DOC") is True
 
     def test_non_skip_false(self):
-        assert is_skip_category("cpi_wage") is False
         assert is_skip_category("PHASE2_EVENT") is False
         assert is_skip_category("unknown") is False
 
 
 class TestPrefixOrdering:
     def test_cpi_specific_before_company_prefix(self):
-        """CPI 工资.md 是精确文件名前缀，应在「基准/」前匹配；这里只需验证 cpi_wage 命中。"""
+        """CPI 工资.md 是精确文件名前缀，应在「基准/」前匹配；验证 SKIP_PARAM 命中。"""
         # 即便添加了 SKIP_P1 = "基准/公司/用工成本/" 前缀，CPI 文件路径不冲突
         d = detect("基准/CPI工资.md")
-        assert d.category == "cpi_wage"
+        assert d.category == "SKIP_PARAM"
+        assert is_skip_category("SKIP_PARAM")
 
     def test_phase2_event_still_skipped(self):
         """回归：原有的 PHASE2_EVENT 映射不被破坏。"""
@@ -94,12 +94,12 @@ class TestIngestReportSkippedGroup:
         report.results.append(ParseResult(file="设计文件/学习.md",
                                            category="SKIP_DOC", ok=True))
         report.results.append(ParseResult(file="基准/CPI工资.md",
-                                           category="cpi_wage", ok=True))
+                                           category="SKIP_PARAM", ok=True))
         report.results.append(ParseResult(file="未识别.md",
                                            category="unknown", ok=False,
                                            error="解析器未实现（unknown）"))
         skipped = report.skipped
-        assert len(skipped) == 2
+        assert len(skipped) == 3
         assert all(r.category.startswith("SKIP_") for r in skipped)
         assert len(report.failed) == 1
         assert report.failed[0].category == "unknown"

--- a/tests/test_ingest_noise.py
+++ b/tests/test_ingest_noise.py
@@ -1,0 +1,61 @@
+"""issue #70：ingest 噪音治理回归——SKIP_PARAM 显式跳过、stock_tx 解析后显式说明。"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.ingest.detect import detect, is_skip_category
+from app.ingest.main import import_all
+from app.model import Base
+
+
+@pytest.fixture()
+def session():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+class TestCpiWageSkipParam:
+    def test_detect_maps_skip_param(self):
+        d = detect("基准/CPI工资.md")
+        assert d.category == "SKIP_PARAM"
+        assert is_skip_category(d.category)
+
+    def test_parse_one_ok_not_failed(self, tmp_path):
+        """有类别无 parser 的 ❌ 噪音不再出现：SKIP 类别 ok=True。"""
+        from app.ingest.parse import parse_one
+        p = tmp_path / "CPI工资.md"
+        p.write_text("# CPI 与工资增幅\n", encoding="utf-8")
+        pr = parse_one("基准/CPI工资.md", p)
+        assert pr.ok is True and pr.error is None and pr.records == []
+
+
+class TestStockTxDropped:
+    @pytest.fixture()
+    def source_dir(self, tmp_path):
+        root = tmp_path
+        (root / "经济" / "股票").mkdir(parents=True)
+        (root / "经济" / "股票" / "腾讯.md").write_text(
+            "### 基本信息\n- 公司：腾讯\n- 代码：0700.HK\n\n"
+            "### 年度明细\n"
+            "| 日期 | 代码 | 事件 | 股数 | 单价(USD) | 金额(万美金) | 持股比例 | 备注 |\n"
+            "|---|---|---|---|---|---|---|---|\n"
+            "| 2001-02-01 | 0700 | buy | 100 | 1 | 1 | 5% | 测试 |\n",
+            encoding="utf-8")
+        return root
+
+    def test_stock_tx_logged_as_phase2_skip(self, session, source_dir):
+        logs: list[str] = []
+        st = import_all(session, source_dir, log=logs.append)
+        assert any("股票台账解析成功" in m and "Phase 2" in m for m in logs)
+        assert st["blocked"] == 0


### PR DESCRIPTION
Phase1 P0 审核 · F-P0-02 噪音治理。

- `基准/CPI工资.md`：cpi_wage → **SKIP_PARAM**（无消费方的折算/展示基准参数；原先「有类别无 parser」每轮报 ❌ 解析器未实现）
- stock_tx：解析成功后显式打印「持仓/事件落库属 Phase 2，本次跳过」，不再静默丢弃
- pytest 184 passed