### PR TITLE
refactor(core): core/currency.py 统一 USD 折算权威实现 (issue #71)

### DIFF
--- a/app/core/calendar.py
+++ b/app/core/calendar.py
@@ -12,7 +12,8 @@ from datetime import date
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core.snapshot import _usd_rate, account_balance_at
+from app.core.currency import usd_rate
+from app.core.snapshot import account_balance_at
 from app.model import Account
 
 
@@ -27,7 +28,7 @@ def snapshot_as_of(session: Session, as_of_date: date) -> list[dict]:
     口径与 rebuild_snapshots 一致，仅核对到 as_of_date 当日（而非某年年末）：
     - account  ：逐账户 balance=Σ(inflow−outflow) for date<=as_of_date，scope account:{id}:{cur}
     - entity   ：按 (entity_id, currency) 聚合，scope entity:{eid}:{cur}
-    - family   ：复用 _usd_rate 折算美元（汇率缺失币种不计入），scope family:total
+    - family   ：复用 usd_rate 折算美元（汇率缺失币种不计入），scope family:total
     返回 dict 列表（含 year=as_of_date.year），与既有调用方（API /snapshots?as_of=、CLI calendar）兼容。
     """
     year = as_of_date.year
@@ -44,9 +45,9 @@ def snapshot_as_of(session: Session, as_of_date: date) -> list[dict]:
                     "value": round(bal, 2), "currency": a.currency, "year": year})
         key = (a.entity_id, a.currency)
         entity_agg[key] = entity_agg.get(key, 0.0) + bal
-        rate = _usd_rate(session, a.currency, year)
+        rate = usd_rate(session, a.currency, year)
         if rate is not None:
-            family_usd += bal * rate
+            family_usd += bal * float(rate)
     for (eid, cur), bal in entity_agg.items():
         out.append({"scope": f"entity:{eid}:{cur}",
                     "value": round(bal, 2), "currency": cur, "year": year})

--- a/app/core/currency.py
+++ b/app/core/currency.py
@@ -1,0 +1,48 @@
+"""多币种折算（DESIGN §3 core/currency.py · issue #71 统一权威实现）。
+
+usd_rate() 是全系统唯一的 currency→USD 折算入口（Decimal 口径）：
+- 优先取该年具体汇率；缺则回退基准常量（year IS NULL）；
+- 正向 USD→X 取倒数、反向 X→USD 直取，两分支对称；
+- **缺汇率返回 None**：调用方必须跳过该币种贡献并显式告警，
+  绝不静默 fallback 1.0（issue #2 根因，数值纪律）。
+
+历史背景：snapshot.py / wealth.py 曾各持一份语义相同、精度不同的实现
+（Decimal vs float），存在口径漂移风险；本模块合并后二者仅做薄适配。
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.model import ExchangeRate
+
+
+def usd_rate(session: Session, currency: str, year: int) -> Decimal | None:
+    """1 单位 currency 兑多少 USD；汇率缺失返回 None。"""
+    if currency == "USD":
+        return Decimal(1)
+    # 正向：USD→<currency> 行 rate = 1 USD 兑 X currency → 取倒数
+    row = session.execute(
+        select(ExchangeRate.rate).where(
+            ExchangeRate.fx_from == "USD", ExchangeRate.fx_to == currency,
+            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
+        )
+        .order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc())
+        .limit(1)
+    ).first()
+    if row is not None and row[0] is not None:
+        return Decimal(1) / Decimal(row[0])
+    # 反向：<currency>→USD 行直取（同样按 具体年 > 基准常量 优先）
+    row2 = session.execute(
+        select(ExchangeRate.rate).where(
+            ExchangeRate.fx_from == currency, ExchangeRate.fx_to == "USD",
+            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
+        )
+        .order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc())
+        .limit(1)
+    ).first()
+    if row2 is not None and row2[0] is not None:
+        return Decimal(row2[0])
+    return None

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -20,7 +20,8 @@ from decimal import Decimal
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
-from app.model import Account, ExchangeRate, IncomeStream, LedgerEntry, Snapshot
+from app.core.currency import usd_rate
+from app.model import Account, IncomeStream, LedgerEntry, Snapshot
 
 # 写库精度：保留 2 位小数（与原 round(v, 2) 一致）
 _QUANTIZE_2 = Decimal("0.01")
@@ -86,28 +87,8 @@ def _ownership_accounts(session: Session) -> list[Account]:
 
 
 def _usd_rate(session: Session, currency: str, year: int) -> Decimal | None:
-    """currency → USD 折算率（与 wealth._usd_rate 对齐；缺汇率返回 None 不静默 fallback）。
-
-    issue #28：返回 Decimal（与内部聚合口径一致）；wealth._usd_rate 仍返 float，调用方按需转换。
-    """
-    if currency == "USD":
-        return Decimal(1)
-    from sqlalchemy import or_
-    row = session.execute(
-        select(ExchangeRate.rate).where(
-            ExchangeRate.fx_from == "USD", ExchangeRate.fx_to == currency,
-            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
-        ).order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc()).limit(1)
-    ).first()
-    if row is not None and row[0] is not None:
-        return Decimal(1) / Decimal(row[0])
-    row2 = session.execute(
-        select(ExchangeRate.rate).where(
-            ExchangeRate.fx_from == currency, ExchangeRate.fx_to == "USD",
-            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
-        ).order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc()).limit(1)
-    ).first()
-    return Decimal(row2[0]) if row2 is not None and row2[0] is not None else None
+    """currency → USD 折算率（issue #71：委托 core/currency.py 权威实现）。"""
+    return usd_rate(session, currency, year)
 
 
 def rebuild_snapshots(session: Session, years: range = range(1947, 2026),

--- a/app/core/wealth.py
+++ b/app/core/wealth.py
@@ -14,42 +14,21 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.model import ExchangeRate, Snapshot
+from app.core.currency import usd_rate
+from app.model import Snapshot
 
 
 def _usd_rate(session: Session, currency: str, year: int) -> float | None:
-    """currency → USD 折算率（1 单位 currency = X USD）。
+    """currency → USD 折算率（issue #71：委托 core/currency.py 权威实现，float 适配）。
 
     返回 None 表示汇率缺失；调用方必须 1) 跳过该币种贡献，2) 记入 missing_rates。
     绝不静默返回 1.0 防止 BEF/DKK/NLG/SEK 裸加当美元（issue #2 根因）。
     """
-    if currency == "USD":
-        return 1.0
-    # 正向：USD→<currency> 行，rate 是 1 USD 兑多少 currency；取倒数
-    row = session.execute(
-        select(ExchangeRate.rate).where(
-            ExchangeRate.fx_from == "USD", ExchangeRate.fx_to == currency,
-            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
-        )
-        # 具体年份优先于基准常量（NULL 排后）
-        .order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc())
-        .limit(1)
-    ).first()
-    if row is not None and row[0] is not None:
-        return 1.0 / float(row[0])
-    # 反向：<currency>→USD 行，按基准常量（year IS NULL）回退保持对称
-    row2 = session.execute(
-        select(ExchangeRate.rate).where(
-            ExchangeRate.fx_from == currency, ExchangeRate.fx_to == "USD",
-            or_(ExchangeRate.year == year, ExchangeRate.year.is_(None)),
-        )
-        .order_by(ExchangeRate.year.is_(None), ExchangeRate.year.desc())
-        .limit(1)
-    ).first()
-    return float(row2[0]) if row2 is not None and row2[0] is not None else None
+    d = usd_rate(session, currency, year)
+    return float(d) if d is not None else None
 
 
 def _missing_rates_from_snaps(session: Session, snaps: list[Snapshot], year: int) -> list[str]:

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -1,0 +1,58 @@
+"""issue #71：core/currency.usd_rate 权威折算实现（合并双份 _usd_rate 后的行为钉定）。"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.currency import usd_rate
+from app.model import Base, ExchangeRate
+
+
+@pytest.fixture()
+def session():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _fx(s, f, t, year, rate):
+    s.add(ExchangeRate(fx_from=f, fx_to=t, year=year, rate=rate))
+
+
+class TestUsdRate:
+    def test_usd_identity(self, session):
+        assert usd_rate(session, "USD", 1990) == Decimal(1)
+
+    def test_forward_reciprocal(self, session):
+        """USD→BEF 行 rate=1USD 兑 X → 取倒数。"""
+        _fx(session, "USD", "BEF", 1990, 32)
+        assert usd_rate(session, "BEF", 1990) == Decimal(1) / Decimal(32)
+
+    def test_constant_fallback(self, session):
+        """该年无行 → 回退基准常量（year IS NULL）。"""
+        _fx(session, "USD", "BEF", None, 40.3399)
+        assert usd_rate(session, "BEF", 1990) == Decimal(1) / Decimal("40.3399")
+
+    def test_specific_year_beats_constant(self, session):
+        _fx(session, "USD", "BEF", None, 40)
+        _fx(session, "USD", "BEF", 1991, 38)
+        assert usd_rate(session, "BEF", 1991) == Decimal(1) / Decimal(38)
+
+    def test_reverse_direct(self, session):
+        _fx(session, "BEF", "USD", None, Decimal("0.03"))
+        assert usd_rate(session, "BEF", 1990) == Decimal("0.03")
+
+    def test_missing_returns_none_never_one(self, session):
+        """数值纪律：缺汇率返回 None，绝不静默 fallback 1.0。"""
+        assert usd_rate(session, "SEK", 1990) is None


### PR DESCRIPTION
Phase1 P0 审核 · DESIGN §3 规划的 core/currency.py 缺位补齐。

## 变更
- `app/core/currency.py`：唯一权威 `usd_rate()`（Decimal；具体年 > 基准常量；正反双向对称；缺率返 None）
- `snapshot.py` / `wealth.py` 两份重复实现 → 薄适配委托（float 层仅做转换），行为零变化
- 清理失效导入；新增 6 用例直接钉定语义

## 验证
pytest 190 passed；dev 库 wealth/calendar CLI 输出与合并前一致