### PR TITLE
fix(ingest): conflict 软硬分级对齐 §11.4 + H1/H3 增量预检 (issue #72)

### DIFF
--- a/app/core/recompute.py
+++ b/app/core/recompute.py
@@ -9,7 +9,7 @@ SQLAlchemy Numeric 列读出来本就是 Decimal，原代码用 float() 转换�
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
@@ -69,10 +69,15 @@ def recompute_all(session: Session, from_year: int, reason: str = "manual") -> l
 
 
 def register_job(session: Session, start_year: int, reason: str, files: Optional[list] = None) -> int:
-    """写入 recompute_job（DESIGN §9.3）并返回 job id。"""
+    """写入 recompute_job（DESIGN §9.3）并返回 job id。
+
+    issue #72：created_at/finished_at 用 datetime.now()（列是 timestamptz，
+    原 date.today() 依赖驱动隐式转换）。
+    """
     from app.model import RecomputeJob
+    now = datetime.now()
     job = RecomputeJob(start_year=start_year, reason=reason, files=files or [],
-                       status="done", created_at=date.today(), finished_at=date.today())
+                       status="done", created_at=now, finished_at=now)
     session.add(job)
     session.flush()
     return int(job.id)

--- a/app/ingest/conflict.py
+++ b/app/ingest/conflict.py
@@ -1,11 +1,17 @@
 """导入前冲突检测 hard-block（DESIGN §11.4）。
 
-在写库前比对 新记录 vs DB 既有相关记录：
-- 金额冲突(H2)：同 entity×stream_type×currency×year 已有不同金额 → 拦（不入库）
-- 余额断链(H4)：账户追加流水时，新首笔前值 ≠ 已存在末余额 → 拦
-- 断链/引用(H5)：回引不存在的 entity/account → 拦
+在写库前比对 新记录 vs DB 既有相关记录。严重度两级（issue #72 对齐 §11.4）：
 
-命中冲突：抛 ConflictError，由上层将整文件标为"需人工"、不入库。
+**挡（hard-block，problems）**——该文件不入库：
+- 金额冲突(H2)：同 entity×stream_type×currency×year 已有不同金额
+- 余额断链(H4)：账户追加流水时，新首笔前值 ≠ 已存在末余额
+- 汇率闭合(H3)：新汇率使 A→B→C ≠ A→C（>0.5%）
+
+**标（soft warning，warnings）**——入库但在 ingest_report 高亮：
+- 时间线对齐(H1)：收益年份无任何编年史条目（增量瘦版）
+- 断链/引用(H5)：回引不存在的 entity
+
+命中冲突由上层将整文件标为"需人工"、不入库；软警告随导入输出。
 """
 from __future__ import annotations
 
@@ -27,8 +33,14 @@ class ConflictError(Exception):
 
 @dataclass
 class ConflictReport:
+    """单文件冲突检测报告。
+
+    - problems：硬冲突（§11.4「挡」），任一命中 → 整文件不入库
+    - warnings：软警告（§11.4「标」），入库但需在报告中高亮
+    """
     file: str
     problems: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
 
     @property
     def blocked(self) -> bool:
@@ -36,6 +48,13 @@ class ConflictReport:
 
     def add(self, rule: str, line: object, desc: str):
         self.problems.append({"rule": rule, "line": line, "detail": desc})
+
+    def add_warning(self, rule: str, line: object, desc: str):
+        self.warnings.append({"rule": rule, "line": line, "detail": desc})
+
+    def merge(self, other: "ConflictReport") -> None:
+        self.problems.extend(other.problems)
+        self.warnings.extend(other.warnings)
 
 
 def _resolve_entity_id(session: Session, name: str | None) -> int | None:
@@ -67,13 +86,13 @@ def _resolve_entity_id(session: Session, name: str | None) -> int | None:
 def check_income_stream_conflict(session: Session, file: str, records: list[dict]) -> ConflictReport:
     """income_stream 金额冲突（H2）：同 (entity, stream_type, currency, year) 已存在且金额不同 → 拦。"""
     rep = ConflictReport(file)
-    from app.model import Entity
     for rec in records:
         # issue #68：键存在值为 None 时 .get 的 default 不生效 → 显式 or 回退
         ent_name = rec.get("entity_name") or rec.get("holder")
         ent = _resolve_entity_id(session, ent_name)
         if ent is None:
-            rep.add("H5-引用", rec, f"entity 不存在: {ent_name}")
+            # issue #72：H5 引用失配按 §11.4 定级为「标」（soft）
+            rep.add_warning("H5-引用", rec, f"entity 不存在: {ent_name}")
             continue
         st = rec.get("stream_type")
         cur = rec.get("currency")
@@ -91,6 +110,26 @@ def check_income_stream_conflict(session: Session, file: str, records: list[dict
         ).scalar_one_or_none()
         if existing is not None and existing != amt:
             rep.add("H2-金额", year, f"{st} {cur} {year} 既有 {existing} ≠ 新 {amt}")
+    return rep
+
+
+def check_timeline_alignment(session: Session, file: str, records: list[dict]) -> ConflictReport:
+    """H1 增量瘦版（issue #72）：新收益年份在 timeline_event 无任何条目 → 标。
+
+    §11.4「时间线对齐」的导入侧实现：不比对具体事件，只查年份覆盖盲区；
+    全量跨文件 JOIN 仍归 health.py（导入后汇总视图）。
+    """
+    rep = ConflictReport(file)
+    from app.model import TimelineEvent
+    years = sorted({int(r["year"]) for r in records if r.get("year") is not None})
+    if not years:
+        return rep
+    covered = set(session.execute(
+        select(TimelineEvent.event_year).where(TimelineEvent.event_year.in_(years))
+    ).scalars().all())
+    for y in years:
+        if y not in covered:
+            rep.add_warning("H1-时间线", y, f"{y} 无任何时间线事件（可能缺编年史条目）")
     return rep
 
 
@@ -113,11 +152,10 @@ def check_account_balance_conflict(session: Session, file: str,
 def check_bank_import_conflict(session: Session, file: str, segments: list[dict]) -> ConflictReport:
     """银行台账导入前冲突（issue #15）：H5 引用 + H4 余额断链。
 
-    - H5：segment 持有人映射 entity 不存在 → 拦
+    - H5：segment 持有人映射 entity 不存在 → 标（issue #72：soft，§11.4 定级）
     - H4：segment 命中已存在 account 且首笔余额 ≠ 既有末余额 → 拦
     新建账户（无既有余额）不构成 H4 断链。返回 ConflictReport 供上层原样输出明细。
     """
-    from app.model import Entity
     rep = ConflictReport(file)
     for seg in segments:
         holder = seg.get("holder")
@@ -128,7 +166,8 @@ def check_bank_import_conflict(session: Session, file: str, segments: list[dict]
             continue                                  # 缺持有人/无流水的 segment 归 writer 跳过，非阻断
         ent = _resolve_entity_id(session, holder)
         if ent is None:
-            rep.add("H5-引用", seg.get("seg_title") or holder, f"entity 不存在: {holder}")
+            rep.add_warning("H5-引用", seg.get("seg_title") or holder,
+                            f"entity 不存在: {holder}")
             continue
         if not cur:
             continue
@@ -156,6 +195,62 @@ def is_authority_fx(file: str) -> bool:
     return any(f in file for f in AUTHORITY_FX_FILES)
 
 
+def _rate_map(session: Session, staged: list[dict]) -> dict[tuple[str, str], dict]:
+    """汇率视图：DB ∪ 本批暂存（暂存优先），键 (from,to) → {year_or_0: rate}。"""
+    from app.model import ExchangeRate
+    out: dict[tuple[str, str], dict] = {}
+    for r in session.execute(select(ExchangeRate)).scalars().all():
+        out.setdefault((r.fx_from, r.fx_to), {})[r.year or 0] = float(r.rate)
+    for rec in staged:
+        f, t, y = rec.get("fx_from"), rec.get("fx_to"), rec.get("year")
+        if f and t and rec.get("rate") is not None:
+            out.setdefault((f, t), {})[y or 0] = float(rec["rate"])
+    return out
+
+
+def check_fx_chain_closure(session: Session, file: str, records: list[dict]) -> ConflictReport:
+    """H3 链式闭合增量预检（issue #72）：新汇率参与下 A→B→C ≠ A→C（>0.5%）→ 挡。
+
+    视图 = DB 现有汇率 ∪ 本批暂存；仅评估两跳链 vs 直接汇率，
+    全量闭合校验仍归 health.check_h3_fx_closure（导入后）。
+    """
+    rep = ConflictReport(file)
+    if not records:
+        return rep
+    pairs = _rate_map(session, records)
+
+    def _val(f: str, t: str, y: int | None):
+        d = pairs.get((f, t))
+        if not d:
+            return None
+        return d.get(y or 0, d.get(0))
+
+    seen: set[tuple] = set()
+    for rec in records:
+        a, b, y = rec.get("fx_from"), rec.get("fx_to"), rec.get("year")
+        if not (a and b):
+            continue
+        direct = _val(a, b, y)
+        if direct is None or direct == 0:
+            continue
+        # 遍历所有 a→x→b 两跳链
+        for (p, q), _ in pairs.items():
+            if p != a or q == b or q == a:
+                continue
+            v1 = _val(p, q, y)
+            v2 = _val(q, b, y)
+            if v1 is None or v2 is None or v1 * v2 == 0:
+                continue
+            key = (a, b, q, y)
+            if key in seen:
+                continue
+            seen.add(key)
+            if abs(v1 * v2 - direct) / abs(direct) > 0.005:
+                rep.add("H3-汇率闭合", y,
+                        f"{a}→{q}→{b} 链式 {v1*v2:.4f} ≠ 直接 {direct}（{a}→{b} @{y or '常量'}）")
+    return rep
+
+
 def check_fx_authority_conflict(session: Session, file: str, records: list[dict]) -> ConflictReport:
     """其它汇率文件导入前：同一 (fx_from, fx_to, year) 若权威表已有且值不同 → 冲突(hard-block)。
 
@@ -169,7 +264,6 @@ def check_fx_authority_conflict(session: Session, file: str, records: list[dict]
         f, t, y = rec.get("fx_from"), rec.get("fx_to"), rec.get("year")
         if not (f and t):
             continue
-        # 查权威值（source 来自权威文件——这里用 exchange_rate 里已存在的那一行；权威已入库）
         auth = session.execute(
             select(ExchangeRate.rate).where(
                 ExchangeRate.fx_from == f, ExchangeRate.fx_to == t, ExchangeRate.year == y)

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -89,6 +89,7 @@ def import_all(session, source_dir, log=None) -> dict:
     ck = 0; ia = {"asset": 0, "cash": 0}; sec = 0; rent = 0; prop = 0; shop = 0
     sal = 0; he = 0; rcur = 0; fx_total = 0; tl_n = 0; bank_n = 0; bank_seg_skip = 0
     blocked_files = 0
+    soft_warnings = 0
     job: dict = {}
     fx_files = []
     rep = run_ingest(source_dir)
@@ -126,6 +127,7 @@ def import_all(session, source_dir, log=None) -> dict:
                 for p in crep.problems:
                     log(f"   ❌ {src}: [{p['rule']}] {p['line']}: {p['detail']}")
                 continue
+            soft_warnings += _log_soft(log, src, crep)
             st = writer.import_bank(session, r.records, source_file=src)
             bank_n += st["ledger"]; bank_seg_skip += st["skipped"]
             _record_current_version(session, r, source_dir)
@@ -141,11 +143,15 @@ def import_all(session, source_dir, log=None) -> dict:
                 continue
             crep = conflict.check_income_stream_conflict(
                 session, r.file, _normalize_conflict_recs(r.category, r.records))
+            # issue #72：H1 增量瘦版（收益年份 vs 编年史覆盖）随 H2 一并预检
+            crep.merge(conflict.check_timeline_alignment(
+                session, r.file, _normalize_conflict_recs(r.category, r.records)))
             if crep.blocked:
                 blocked_files += 1
                 for p in crep.problems:
                     log(f"   ❌ {r.file}: [{p['rule']}] {p['line']}: {p['detail']}")
                 continue
+            soft_warnings += _log_soft(log, r.file, crep)
             for rec in r.records:
                 rec.setdefault("source_file", r.file)
             if r.category == "income_security": sec += writer.import_income_security(session, r.records)["stream"]
@@ -166,10 +172,13 @@ def import_all(session, source_dir, log=None) -> dict:
         fx_total += writer.import_fx(session, r.records)["n"]
     for r in others:
         crep = conflict.check_fx_authority_conflict(session, r.file, r.records)
+        # issue #72：H3 链式闭合增量预检（新汇率 ∪ DB 视图，两跳 vs 直接 >0.5% → 挡）
+        crep.merge(conflict.check_fx_chain_closure(session, r.file, r.records))
         if crep.blocked:
             log(f"   ⚠ fx冲突拦截 {r.file}: {len(crep.problems)} 处（以权威表为准）")
             blocked_files += 1
             continue
+        soft_warnings += _log_soft(log, r.file, crep)
         fx_total += writer.import_fx(session, r.records)["n"]
     cc = writer.close_2002_currency(session)
     closed = cc["closed"]
@@ -188,8 +197,9 @@ def import_all(session, source_dir, log=None) -> dict:
         f"（seg 跳过 {bank_seg_skip}）、2002关池 {closed}"
         f"（EUR承接 {cc['migrated']} / 零结转跳过 {cc['skipped_zero']}）、冲突拦截 {blocked_files}"
         + (f"；recompute job#{job['job_id']} 通知#{job['notification_id']}" if job else "")
+        + (f"；软警告 {soft_warnings}" if soft_warnings else "")
     )
-    return {"summary": summary, "blocked": blocked_files,
+    return {"summary": summary, "blocked": blocked_files, "soft_warnings": soft_warnings,
             "characters": ck, "initial_assets": ia["asset"], "cash": ia["cash"],
             "security": sec, "rent": rent, "property": prop, "shop": shop,
             "salary": sal, "household": he, "return_curves": rcur, "fx": fx_total,
@@ -197,6 +207,13 @@ def import_all(session, source_dir, log=None) -> dict:
 
 
 # ---- 收益/银行文件的幂等 + 内容变更提示（issue #14；issue #68 通用化） ----
+
+def _log_soft(log, file: str, crep) -> int:
+    """输出软警告（§11.4「标」：入库但高亮），返回条数（issue #72）。"""
+    for w in crep.warnings:
+        log(f"   ⚠ {file}: [{w['rule']}] {w['line']}: {w['detail']}")
+    return len(crep.warnings)
+
 
 def _content_fingerprint(content: str) -> str:
     import hashlib

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -814,11 +814,11 @@ class Importer(Protocol):
 | 编号 | 模块 | 功能 | 关键章节 | 状态 |
 |---|---|---|---|---|
 | F-P0-01 | **工程骨架** | config 三环境 / db / alembic 迁移 / ingest CLI | §3–§4 | ✅ |
-| F-P0-02 | **Ingest** | detect 类别识别 + 解析器(bank/股票表/汇率/人物/时间线) + normalize | §6 | ✅ |
-| F-P0-03 | **Ingest** | 导入前冲突检测 hard-block（conflict.py，§11.4 + 金额/余额等） | §11.4 | ✅ |
-| F-P0-04 | **Phase1 摄入** | 初始资产建档(initial_asset) + 现金进余额 | §6.5 | ✅ |
-| F-P0-05 | **Phase1 摄入** | 收益文件模块化挂账(income_stream)：租/经营性房/祖产债券/开店（薪资在 F-P0-06） | §6.5/§6.3 | ✅ |
-| F-P0-06 | **Phase1 摄入** | 家庭支出(挂 Henri)/薪资各归各账户；2002 BEF/LUF/NLG 关池转 EUR | §6.5/§6.6 | ✅ |
+| F-P0-02 | **Ingest** | detect 类别识别 + 解析器(bank/股票表/汇率/人物/时间线) + normalize｜cpi_wage→SKIP_PARAM、stock_tx 显式 Phase2 跳过 (#70) | §6 | ✅ |
+| F-P0-03 | **Ingest** | 导入前冲突检测 hard-block（conflict.py，§11.4 + 金额/余额等）｜软硬分级对齐 §11.4：H5/H1=标、H3 链式闭合预检 (#72) | §11.4 | ✅ |
+| F-P0-04 | **Phase1 摄入** | 初始资产建档(initial_asset) + 现金进余额｜幂等已验证：文件指纹+自然键双保险 (#68) | §6.5 | ✅ |
+| F-P0-05 | **Phase1 摄入** | 收益文件模块化挂账(income_stream)：租/经营性房/祖产债券/开店（薪资在 F-P0-06）｜因子外置 core/factors.py，源文件仅基桩值 (#69) | §6.5/§6.3 | ✅ |
+| F-P0-06 | **Phase1 摄入** | 家庭支出(挂 Henri)/薪资各归各账户；2002 BEF/LUF/NLG 关池转 EUR｜家庭支出幂等同 #68 | §6.5/§6.6 | ✅ |
 | F-P0-07 | **DDL** | entity/account(status/closed_on)/ledger_entry/income_stream/initial_asset/snapshot 等 | §5 | ✅ |
 | F-P0-08 | **快照** | 逐年 as-of 快照预计算（snapshot.py）｜三层 scope + from_year 增量已实现，逐年完整覆盖随真实数据联调 | §8 | 🟨 |
 | F-P0-09 | **财富曲线** | 账户/币种/公司/全家族合计 + USD 展示折算（账务本币/展示USD）｜接口已上线，前端曲线仅 Dashboard 单屏可见 | §7/§8 | 🟨 |

--- a/tests/test_conflict_severity.py
+++ b/tests/test_conflict_severity.py
@@ -1,0 +1,112 @@
+"""issue #72：conflict 软硬分级（§11.4「挡/标」）+ H1 增量瘦版 + H3 链式闭合预检。"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.model import Entity, ExchangeRate, TimelineEvent
+from app.ingest.conflict import (
+    check_fx_chain_closure,
+    check_income_stream_conflict,
+    check_timeline_alignment,
+)
+from app.ingest.main import _normalize_conflict_recs as _normalize_recs_for_test
+
+
+@pytest.fixture()
+def session():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+class TestH1TimelineAlignment:
+    def _recs(self, *years):
+        return [{"entity_name": "Henri Peeters", "stream_type": "shop",
+                 "currency": "BEF", "year": y, "amount": 1.0} for y in years]
+
+    def test_missing_year_warns(self, session):
+        rep = check_timeline_alignment(session, "店.md", self._recs(1999))
+        assert not rep.blocked
+        assert any(w["rule"] == "H1-时间线" and w["line"] == 1999 for w in rep.warnings)
+
+    def test_covered_year_clean(self, session):
+        session.add(TimelineEvent(event_year=1999, title="开店"))
+        session.flush()
+        rep = check_timeline_alignment(session, "店.md", self._recs(1999))
+        assert rep.warnings == []
+
+    def test_merged_into_income_report_not_blocking(self, session):
+        """H1 软警告与 H2 硬冲突并存时：H2 拦、H1 不改变拦截判定。"""
+        h = Entity(entity_type="person", name="Henri Peeters")
+        session.add(h)
+        session.flush()
+        recs = _normalize_recs_for_test("income_shop", [{
+            "holder": "Henri Peeters", "y0": 2001, "currency": "BEF", "amount": 999.0}])
+        rep = check_income_stream_conflict(session, "店.md", recs)
+        assert not rep.blocked          # 无既有金额 → 无 H2；H5 亦无（实体存在）
+        # 年份 2001 无时间线 → 若合并 H1 只产生 warnings
+        rep.merge(check_timeline_alignment(session, "店.md", recs))
+        assert not rep.blocked and rep.warnings
+
+
+class TestH3ChainClosure:
+    def test_chain_mismatch_blocks(self, session):
+        """DB 有 USD→EUR=2、EUR→BEF=3；新文件直接给 USD→BEF=7（链式 6≠7 >0.5%）→ 挡。"""
+        session.add(ExchangeRate(fx_from="USD", fx_to="EUR", year=1999, rate=2))
+        session.add(ExchangeRate(fx_from="EUR", fx_to="BEF", year=1999, rate=3))
+        session.flush()
+        staged = [{"fx_from": "USD", "fx_to": "BEF", "year": 1999, "rate": 7}]
+        rep = check_fx_chain_closure(session, "x.md", staged)
+        assert rep.blocked
+        assert any(p["rule"] == "H3-汇率闭合" for p in rep.problems)
+
+    def test_consistent_chain_clean(self, session):
+        session.add(ExchangeRate(fx_from="USD", fx_to="EUR", year=1999, rate=2))
+        session.add(ExchangeRate(fx_from="EUR", fx_to="BEF", year=1999, rate=3))
+        session.flush()
+        staged = [{"fx_from": "USD", "fx_to": "BEF", "year": 1999, "rate": 6}]
+        rep = check_fx_chain_closure(session, "x.md", staged)
+        assert rep.problems == []
+
+    def test_staged_legs_participate(self, session):
+        """两跳腿来自同一批暂存记录也能闭合校验。"""
+        staged = [
+            {"fx_from": "USD", "fx_to": "EUR", "year": 2000, "rate": 2},
+            {"fx_from": "EUR", "fx_to": "BEF", "year": 2000, "rate": 3},
+            {"fx_from": "USD", "fx_to": "BEF", "year": 2000, "rate": 5.5},  # 链式6 ≠ 5.5
+        ]
+        rep = check_fx_chain_closure(session, "x.md", staged)
+        assert rep.blocked
+
+
+class TestSeveritySplit:
+    def test_h5_soft_h2_hard_coexist(self, session):
+        """同文件：H5 软警告 + H2 硬冲突 → 整体 blocked，且 warnings 保留。"""
+        h = Entity(entity_type="person", name="Henri Peeters")
+        session.add(h)
+        session.flush()
+        from app.model import IncomeStream
+        session.add(IncomeStream(entity_id=h.id, stream_type="shop", group_key="店",
+                                 currency="BEF", year=2001, amount=100.0, label="既有"))
+        session.flush()
+        recs = [
+            {"entity_name": "幽灵", "stream_type": "rent", "currency": "BEF",
+             "year": 2005, "amount": 1.0},                       # H5 soft
+            {"entity_name": "Henri Peeters", "stream_type": "shop",
+             "currency": "BEF", "year": 2001, "amount": 555.0},  # H2 hard
+        ]
+        rep = check_income_stream_conflict(session, "混合.md", recs)
+        assert rep.blocked
+        assert any(p["rule"] == "H2-金额" for p in rep.problems)
+        assert any(w["rule"] == "H5-引用" for w in rep.warnings)

--- a/tests/test_ingest_conflict.py
+++ b/tests/test_ingest_conflict.py
@@ -79,8 +79,9 @@ class TestIncomeStreamConflictDetail:
             "holder": "不存在的人", "year": 2000, "currency": "BEF", "after_tax": 10.0,
         }])
         rep = check_income_stream_conflict(session, "工资.md", recs)
-        assert rep.blocked is True
-        assert any(p["rule"] == "H5-引用" and "不存在的人" in p["detail"] for p in rep.problems)
+        # issue #72：H5 按 §11.4 定级为「标」——软警告、不再 hard-block
+        assert rep.blocked is False
+        assert any(w["rule"] == "H5-引用" and "不存在的人" in w["detail"] for w in rep.warnings)
 
 
 class TestIncomeStreamConflictYearsAmounts:
@@ -143,8 +144,9 @@ class TestBankImportConflict:
                  "rows": [{"date": "1981-01-01", "reason": "b", "inflow": 1, "outflow": None,
                            "balance": 1, "note": None}]}]
         rep = check_bank_import_conflict(session, "x.md", segs)
-        assert rep.blocked is True
-        assert any(p["rule"] == "H5-引用" for p in rep.problems)
+        # issue #72：H5 软警告（标），不拦整文件
+        assert rep.blocked is False
+        assert any(w["rule"] == "H5-引用" for w in rep.warnings)
 
     def test_new_account_no_h4(self, session):
         h = Entity(entity_type="person", name="祖父")


### PR DESCRIPTION
Phase1 P0 审核 · F-P0-03 一致性收尾。

## 变更（DESIGN §11.4 严重度对齐）
- **挡**：H2 金额 / H4 余额断链 / **H3 链式闭合**（新增 check_fx_chain_closure，DB∪暂存视图两跳链 vs 直接 >0.5% → 拦）
- **标**：H5 引用失配、**H1 时间线盲区**（新增 check_timeline_alignment 收益年份瘦版）→ 入库但高亮
- register_job created_at/finished_at 改 datetime.now()（timestamptz 列不再靠驱动隐转）
- DESIGN §20 F-P0-02..06 回写实现注记（#68–#72）

## 验证
pytest 197 passed（+7 分级/闭合用例；2 个旧 H5 用例按新语义更新）