### PR TITLE
fix(p1): #80/#81/#82 —— finance_entry 生产写入、投资解锁重输、redeem 按笔防重

### DIFF
--- a/app/api/ui_ops.py
+++ b/app/api/ui_ops.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.core.invest import (
-    create_investment, redeem_investment, region_start_years,
+    create_investment, redeem_investment, region_start_years, unlock_investment,
 )
 from app.core.recompute import recompute_all, record_recompute_done
 from app.core.snapshot import rebuild_snapshots
@@ -77,14 +77,19 @@ def list_investments(year: Optional[int] = None, region: Optional[str] = None,
         allocs = db.execute(
             select(InvestmentAlloc).where(InvestmentAlloc.investment_id == inv.id)
         ).scalars().all()
-        out.append({
-            "id": inv.id, "year": inv.year, "region": inv.region,
-            "risk_lvl": inv.risk_lvl, "start_date": inv.start_date.isoformat(),
-            "locked": inv.locked,
-            "allocs": [{"entity_id": a.entity_id, "currency": a.currency,
-                        "amount": float(a.amount), "is_all": a.is_all} for a in allocs],
-        })
+        out.append(_inv_dict(inv, allocs))
     return {"items": out, "total": len(out)}
+
+
+def _inv_dict(inv, allocs) -> dict:
+    """投资 → dict；expose redeemed（issue #82：前端置灰已赎回）。"""
+    return {
+        "id": inv.id, "year": inv.year, "region": inv.region,
+        "risk_lvl": inv.risk_lvl, "start_date": inv.start_date.isoformat(),
+        "locked": inv.locked, "redeemed": inv.redeemed_at is not None,
+        "allocs": [{"entity_id": a.entity_id, "currency": a.currency,
+                    "amount": float(a.amount), "is_all": a.is_all} for a in allocs],
+    }
 
 
 @router.get("/investments/{investment_id}")
@@ -95,12 +100,7 @@ def get_investment(investment_id: int, db: Session = Depends(get_db)):
     allocs = db.execute(
         select(InvestmentAlloc).where(InvestmentAlloc.investment_id == inv.id)
     ).scalars().all()
-    return {
-        "id": inv.id, "year": inv.year, "region": inv.region, "risk_lvl": inv.risk_lvl,
-        "start_date": inv.start_date.isoformat(), "locked": inv.locked,
-        "allocs": [{"entity_id": a.entity_id, "currency": a.currency,
-                    "amount": float(a.amount), "is_all": a.is_all} for a in allocs],
-    }
+    return _inv_dict(inv, allocs)
 
 
 @router.post("/investments", status_code=201)
@@ -132,6 +132,33 @@ def post_redeem(investment_id: int, db: Session = Depends(get_db)):
         _apply_error(e)
     _after_ui_write(db, inv.year, f"赎回投资 {inv.region} R{inv.risk_lvl} {inv.year}")
     return {"id": inv.id, **out}
+
+
+class InvestmentPatch(BaseModel):
+    locked: bool = False
+
+
+@router.patch("/investments/{investment_id}")
+def patch_investment(investment_id: int, body: InvestmentPatch,
+                     db: Session = Depends(get_db)):
+    """§19.1 解锁重输（issue #81）：抹除本投资全部派生写入 + 置 locked=False。
+
+    已赎回 → 409；解锁后重输走 POST /investments（unlocked 覆盖分支）。
+    """
+    inv = db.get(Investment, investment_id)
+    if not inv:
+        raise HTTPException(status_code=404, detail="investment not found")
+    if not body.locked:
+        # 解锁（locked=false）：抹除旧写入，恢复 as-of
+        try:
+            inv = unlock_investment(db, inv)
+        except Exception as e:  # noqa: BLE001
+            db.rollback()
+            _apply_error(e)
+        _after_ui_write(db, inv.year, f"解锁投资 {inv.region} {inv.year}")
+    return _inv_dict(inv, db.execute(
+        select(InvestmentAlloc).where(InvestmentAlloc.investment_id == inv.id)
+    ).scalars().all())
 
 
 @router.post("/transfers")

--- a/app/core/invest.py
+++ b/app/core/invest.py
@@ -2,7 +2,14 @@
 
 UI 派生的第三类改数据通道：选 年份 × 地区（对应 return_curve.country）× R 级 ×
 【主体 × 币种 × 金额/$全部】提交 → 划出银行入专款池 → 年末(12-30)赎回本金+收益回银行。
-一年一次（UNIQUE(year, region)）；已投锁灰，解锁=整笔抹除重输。
+一年一次（UNIQUE(year, region)）；已投锁灰，解锁=整笔抹除重输，已赎回不可解锁。
+
+issue #80：UI 派生落 finance_entry（划出 kind='investment'；赎回 kind='pool'+'investment_income'），
+            source='ui' —— 财务收支屏据此可见 UI 派生数据。
+issue #81：解锁(locked=False) 整笔抹除本投资的全部派生写入（ledger/finance/timeline，按 note/label
+            标签 `inv#{id}` 定位）+ 覆盖分支同语义），杜绝重输双扣；已赎回投资拒绝解锁/覆盖(409)。
+issue #82：赎回按笔防重——redeemed_at 非空即 409（不再按年扫全库 pool 流入，避免同年多地区互堵）；
+            GET 据 redeemed_at 暴露 redeemed。
 
 数值纪律：
 - 计息公式（§19.2）：days=(当年12-30 − start_date)；gross=R/100/365×days；
@@ -13,17 +20,19 @@ UI 派生的第三类改数据通道：选 年份 × 地区（对应 return_curv
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from app.core.snapshot import account_balance_at
 from app.model import (
-    Account, Investment, InvestmentAlloc, LedgerEntry, ReturnCurve, TimelineEvent,
+    Account, Entity, FinanceEntry, Investment, InvestmentAlloc, LedgerEntry,
+    ReturnCurve, TimelineEvent,
 )
+from app.model.types import SourceKind
 
 # 区域 → 收益曲线国家（return_curve.country）映射（DESIGN §19.1）
 REGION_COUNTRY = {
@@ -62,6 +71,11 @@ class ValidationError(InvestmentError):
 class ConflictError(InvestmentError):
     def __init__(self, detail: str):
         super().__init__(detail, 409)
+
+
+def _inv_tag(inv) -> str:
+    """投资派生写入的定位标签（inv#{id}），供解锁/覆盖时整体抹除。"""
+    return f"inv#{inv.id}"
 
 
 def region_start_years() -> dict:
@@ -148,6 +162,42 @@ def _rate(session: Session, region: str, risk_lvl: str, year: int) -> Optional[D
     return Decimal(row[0]) if row and row[0] is not None else None
 
 
+def _delete_investment_writes(session: Session, inv: Investment) -> None:
+    """整笔抹除该投资落下的全部派生写入（issue #81）：ledger 划出/赎回、finance_entry、
+    overlay 时间线条目——按 note/label 标签 `inv#{id}` 精确定位，避免误删他人数据。
+
+    调用方（解锁/覆盖）须随后 recompute + rebuild_snapshots，恢复账户 to 投资前。
+    """
+    tag = _inv_tag(inv)
+    session.execute(delete(LedgerEntry).where(LedgerEntry.note.like(f"%{tag}%")))
+    session.execute(delete(FinanceEntry).where(FinanceEntry.label.like(f"%{tag}%")))
+    session.execute(delete(TimelineEvent).where(
+        TimelineEvent.note.like(f"%{tag}%"),
+        TimelineEvent.overlay.is_(True),
+    ))
+
+
+def unlock_investment(session: Session, investment: Investment) -> Investment:
+    """§19.1「解锁 = 整笔抹除重输」：抹除该投资全部派生写入 + 置 locked=False（issue #81）。
+
+    已赎回投资拒绝解锁（409）。抹除后账户 as-of 恢复 to 投资前；重输走 create_investment
+    的 unlocked 覆盖分支（同样整笔抹除）。调用方随后须 recompute_all + rebuild_snapshots。
+    """
+    if investment.redeemed_at is not None:
+        raise ConflictError(f"该投资 {investment.region} {investment.year} 已赎回，不可解锁")
+    if not investment.locked:
+        return investment  # 已解锁，幂等
+    _delete_investment_writes(session, investment)
+    investment.locked = False
+    return investment
+
+
+def _entity_kind(session: Session, entity_id: int) -> str:
+    """finance_entry.entity_kind：按 entity.entity_type，限定 person/company。"""
+    e = session.get(Entity, entity_id)
+    return e.entity_type if e and e.entity_type in ("person", "company") else "person"
+
+
 def compute_interest(session: Session, investment: Investment) -> list[dict]:
     """§19.2 计息：逐 alloc 返回 {entity_id, currency, days, rate, gross, principal, interest}。
 
@@ -185,62 +235,72 @@ def compute_interest(session: Session, investment: Investment) -> list[dict]:
 def redeem_investment(session: Session, investment: Investment) -> dict:
     """§19.2 年末赎回：本金+收益从专款池划回银行（12-30）、专款池清空。
 
-    每 alloc 两笔 inflow：本金 kind='pool' + 收益 kind='investment_income'。
-    已赎回防重：该年已有 pool 流入 → ConflictError(409)。余额 None 交由 recompute 回填。
+    每 alloc 两笔 inflow：本金 kind='pool' + 收益 kind='investment_income'；
+    并落 finance_entry（source='ui'，issue #80）。余额 None 交由 recompute 回填。
+
+    防重（issue #82）：按本笔 redeemed_at 判重，非空 → 409；不再按年扫全库，同年多地区互不阻塞。
     """
-    # 防重：该 alloc 主体该币池该年若已有 pool 流入即视为已赎回
-    existing = session.execute(
-        select(LedgerEntry).where(
-            LedgerEntry.kind == "pool",
-            LedgerEntry.date >= date(investment.year, 1, 1),
-            LedgerEntry.date <= date(investment.year, 12, 31),
-        ).limit(1)
-    ).scalars().first()
-    if existing is not None:
-        raise ConflictError(f"该年 {investment.year} {investment.region} 投资已赎回，勿重复")
+    if investment.redeemed_at is not None:
+        raise ConflictError(f"该投资 {investment.region} {investment.year} 已赎回，勿重复")
     interests = compute_interest(session, investment)
+    tag = _inv_tag(investment)
     settlement = date(investment.year, 12, 30)
     made = 0
     for it in interests:
         acc = _primary_account(session, it["entity_id"], it["currency"])
         if acc is None:
             raise ValidationError(f"主体 #{it['entity_id']} 无 {it['currency']} 账户，无法赎回")
+        ek = _entity_kind(session, it["entity_id"])
         # 本金划回（kind=pool）
         session.add(LedgerEntry(
             account_id=acc.id, date=settlement, reason=f"赎回本金 {investment.region} R{investment.risk_lvl}",
             inflow=Decimal(it["principal"]), kind="pool",
-            note="UI 投资年末赎回·本金",         ))
+            note=f"UI 投资赎回本金 {tag}",
+        ))
+        session.add(FinanceEntry(
+            entity_id=it["entity_id"], entity_kind=ek, year=investment.year, kind="pool",
+            amount=Decimal(it["principal"]), currency=it["currency"],
+            label=f"投资赎回本金 {tag}", source=SourceKind.UI.value,
+        ))
         # 收益划回（kind=investment_income）
         session.add(LedgerEntry(
             account_id=acc.id, date=settlement, reason=f"投资损益 {investment.region} R{investment.risk_lvl}",
             inflow=Decimal(it["interest"]), kind="investment_income",
-            note="UI 投资年末结算·收益",         ))
+            note=f"UI 投资赎回收益 {tag}",
+        ))
+        session.add(FinanceEntry(
+            entity_id=it["entity_id"], entity_kind=ek, year=investment.year,
+            kind="investment_income", amount=Decimal(it["interest"]), currency=it["currency"],
+            label=f"投资赎回收益 {tag}", source=SourceKind.UI.value,
+        ))
         made += 1
     # 编年史 overlay 同步（§19.5 记年）
     session.add(TimelineEvent(
         event_year=investment.year, event_date=settlement,
         title=f"{investment.region} R{investment.risk_lvl} 投资赎回",
-        note=f"本金+收益划回银行，专款池清空",
+        note=f"本金+收益划回银行，专款池清空（{tag}）",
         decade=f"{investment.year // 10 * 10}s", overlay=True,
-            ))
+    ))
+    investment.redeemed_at = datetime.now()
     return {"investment_id": investment.id, "allocs": made}
 
 
 def create_investment(session: Session, *, year: int, region: str, risk_lvl: str,
                       start_date: date, allocs: list[dict]) -> Investment:
-    """创建投资（§19.1/§19.3 校验链 + §19.2 划出）。
+    """创建投资（§19.1/§19.3 校验链 + §19.2 划出 + §19.x finance_entry 镜像，issue #80）。
 
     allocs = [{entity_id, currency, amount(float|None), is_all(bool)}]；
     is_all=True → amount 忽略，取该主体该币种 as-of 全投。
 
     校验链（顺序）：
       1. region 起始年下限 → 422；
-      2. (year, region) 年度幂等：已存在 locked → 409（解锁重输）；存在 unlocked → 级联抹除覆盖；
+      2. (year, region) 年度幂等：已存在 locked → 409（须解锁重输）；unlocked → **整笔抹除旧写入**
+         后覆盖重建（issue #81）；已赎回 → 409（不可覆盖）；
       3. R 级合法 + 无收益值且跨天 → 422；
       4. 每 alloc：amount>0 且 ≤ 该主体该币种 as-of 余额（is_all 取全量）→ 422；
-      5. 覆盖连锁拒绝：划出后账户向后全程非负，否则 → 409 整体拒绝。
-    成功后：写 Investment+Alloc → 划出走账(kind='investment') → 编年史 overlay。
-    调用方负责 flush/commit + recompute_all + rebuild_snapshots + record_recompute_done。
+      5. 覆盖连锁拒绝：划出后账户向后全程非负，否则 → 422。
+    成功后：写 Investment+Alloc → 划出走账(kind='investment') + finance_entry(kind='investment',
+    source='ui') → 编年史 overlay。调用方负责 flush/commit + recompute_all + rebuild_snapshots。
     """
     # 1) 区域起始年下限
     if region not in REGION_START_YEAR:
@@ -251,14 +311,20 @@ def create_investment(session: Session, *, year: int, region: str, risk_lvl: str
     if risk_lvl not in ("R1", "R2", "R3", "R4", "R5"):
         raise ValidationError(f"risk_lvl 必须为 R1–R5，得到 {risk_lvl!r}")
 
-    # 2) 年度幂等
+    # 2) 年度幂等（issue #81：覆盖须整笔抹除旧写入，避免重输双扣）
     existing = session.execute(
         select(Investment).where(Investment.year == year, Investment.region == region).limit(1)
     ).scalar_one_or_none()
-    if existing is not None and existing.locked:
-        raise ConflictError(f"该年 {year} 该地区 {region} 已投（locked），须解锁重输")
-    if existing is not None:  # unlocked → 覆盖：级联抹除旧投资
-        session.delete(existing)  # allocs 由 ondelete CASCADE
+    if existing is not None:
+        if existing.locked:
+            raise ConflictError(f"该年 {year} 该地区 {region} 已投（locked），须解锁重输")
+        if existing.redeemed_at is not None:
+            raise ConflictError(f"该年 {year} 该地区 {region} 投资已赎回，不可覆盖")
+        # issue #81：不依赖 DB FK CASCADE（SQLite 测试未开外键；Postgres 也显式稳健）——
+        # 显式删 allocs + 派生写入后再删 investment 行
+        _delete_investment_writes(session, existing)
+        session.execute(delete(InvestmentAlloc).where(InvestmentAlloc.investment_id == existing.id))
+        session.delete(existing)
         session.flush()
 
     # 3) 收益值预检（跨天的投资必须能取值；days=0 允许无值）
@@ -295,7 +361,8 @@ def create_investment(session: Session, *, year: int, region: str, risk_lvl: str
         session.add(InvestmentAlloc(investment_id=inv.id, entity_id=eid,
                                     currency=cur, amount=amount, is_all=is_all))
 
-    # 划出走账（kind='investment'，balance 由 recompute 回填）
+    # 划出走账（kind='investment'，balance 由 recompute 回填）+ finance_entry 镜像（source='ui'）
+    tag = _inv_tag(inv)
     for alloc in session.execute(
             select(InvestmentAlloc).where(InvestmentAlloc.investment_id == inv.id)
     ).scalars().all():
@@ -306,11 +373,19 @@ def create_investment(session: Session, *, year: int, region: str, risk_lvl: str
             account_id=acc.id, date=start_date,
             reason=f"划入专款池 {region} R{risk_lvl} {alloc.currency}",
             outflow=Decimal(alloc.amount), kind="investment",
-            note="UI 投资·划出",         ))
+            note=f"UI 投资划出 {tag}",
+        ))
+        session.add(FinanceEntry(
+            entity_id=alloc.entity_id, entity_kind=_entity_kind(session, alloc.entity_id),
+            year=year, kind="investment", amount=Decimal(alloc.amount),
+            currency=alloc.currency, label=f"投资 {region} R{risk_lvl} {tag}",
+            source=SourceKind.UI.value,
+        ))
     session.add(TimelineEvent(
         event_year=year, event_date=start_date,
         title=f"{region} R{risk_lvl} 投资 {[_a['currency'] for _a in allocs]}",
-        note=f"投入专款池，年末赎回",
-        decade=f"{year // 10 * 10}s", overlay=True,     ))
+        note=f"投入专款池，年末赎回（{tag}）",
+        decade=f"{year // 10 * 10}s", overlay=True,
+    ))
     session.flush()
     return inv

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -12,7 +12,8 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.ingest.normalize import resolve_date
-from app.model import Account, Entity, ExchangeRate, IncomeStream, InitialAsset, LedgerEntry, Relationship
+from app.model import (Account, Entity, ExchangeRate, FinanceEntry, IncomeStream,
+                       InitialAsset, LedgerEntry, Relationship)
 
 
 def upsert_entity(session: Session, entity_type: str, name: str,
@@ -161,6 +162,20 @@ def import_initial_assets(session: Session, records: list[dict], cash_year: int 
     return stats
 
 
+def _mirror_to_finance(session: Session, *, entity: Entity, cur: str, year: int,
+                       amount, label: str, source_file: str | None = None,
+                       kind: str = "income") -> None:
+    """issue #80：把 ingest 的 income_stream / 家庭支出镜像为 finance_entry(source='file')，
+    使财务收支屏（F-P1-07）在真实库可见。entity_kind 从 entity.entity_type 推（person/company）。"""
+    if entity.entity_type not in ("person", "company"):
+        return
+    session.add(FinanceEntry(
+        entity_id=entity.id, entity_kind=entity.entity_type, year=year,
+        kind=kind, amount=amount, currency=cur, label=label,
+        source="file", source_file=source_file,
+    ))
+
+
 def import_income_security(session: Session, records: list[dict],
                            years: tuple[int, int] | None = None,
                            label_prefix: str = "祖产债券票息") -> dict:
@@ -184,12 +199,15 @@ def import_income_security(session: Session, records: list[dict],
         if not amount:
             continue
         for y in range(years[0], years[1] + 1):
+            label = f"{label_prefix} · {rec.get('name','')[:20]}"
             session.add(IncomeStream(
                 entity_id=ent.id, stream_type="security", group_key="祖产债券",
                 currency=rec.get("currency"), year=y, amount=amount,
-                label=f"{label_prefix} · {rec.get('name','')[:20]}",
-                source_file=rec.get("source_file"),
+                label=label, source_file=rec.get("source_file"),
             ))
+            _mirror_to_finance(session, entity=ent, cur=rec.get("currency"),
+                               year=y, amount=amount, label=label,
+                               source_file=rec.get("source_file"))
             stats["stream"] += 1
     return stats
 
@@ -210,12 +228,16 @@ def import_income_property(session: Session, records: list[dict],
         for y in range(years[0], years[1] + 1):
             if y < 1974:
                 continue
+            amount = round(base * property_factor(y), 2)
+            label = f"经营性房产 · {rec.get('country')}{rec.get('prop')}"
             session.add(IncomeStream(
                 entity_id=ent.id, stream_type="property", group_key=f"{rec.get('country')}{rec.get('prop')}",
-                currency=rec.get("currency"), year=y, amount=round(base * property_factor(y), 2),
-                label=f"经营性房产 · {rec.get('country')}{rec.get('prop')}",
+                currency=rec.get("currency"), year=y, amount=amount, label=label,
                 source_file=rec.get("source_file"),
             ))
+            _mirror_to_finance(session, entity=ent, cur=rec.get("currency"),
+                               year=y, amount=amount, label=label,
+                               source_file=rec.get("source_file"))
             stats["stream"] += 1
     return stats
 
@@ -226,12 +248,15 @@ def import_income_shop(session: Session, records: list[dict]) -> dict:
     for rec in records:
         ent = upsert_entity(session, "person", rec["holder"])
         for y in range(rec["y0"], rec["y1"] + 1):
+            label = "祖父开店 · 合并税后落袋"
             session.add(IncomeStream(
                 entity_id=ent.id, stream_type="shop", group_key="祖父开店",
-                currency=rec.get("currency"), year=y, amount=rec["amount"],
-                label="祖父开店 · 合并税后落袋",
+                currency=rec.get("currency"), year=y, amount=rec["amount"], label=label,
                 source_file=rec.get("source_file"),
             ))
+            _mirror_to_finance(session, entity=ent, cur=rec.get("currency"),
+                               year=y, amount=rec["amount"], label=label,
+                               source_file=rec.get("source_file"))
             stats["stream"] += 1
     return stats
 
@@ -324,6 +349,9 @@ def import_salary(session: Session, records: list[dict]) -> dict:
             currency=rec.get("currency"), year=rec["year"], amount=rec["after_tax"],
             label=f"{rec['holder']}薪资税后", source_file=rec.get("source_file"),
         ))
+        _mirror_to_finance(session, entity=ent, cur=rec.get("currency"),
+                           year=rec["year"], amount=rec["after_tax"],
+                           label=f"{rec['holder']}薪资税后", source_file=rec.get("source_file"))
         stats["stream"] += 1
     return stats
 
@@ -356,6 +384,9 @@ def import_household_expense(session: Session, records: list[dict]) -> dict:
             outflow=rec["amount"], balance=None, kind="expense",
             source_file=rec.get("source_file"),
         ))
+        _mirror_to_finance(session, entity=ent, cur=cur, year=d.year,
+                           amount=rec["amount"], label="家庭支出",
+                           source_file=rec.get("source_file"), kind="expense")
         stats["n"] += 1
     return stats
 
@@ -534,12 +565,15 @@ def import_income_rent(session: Session, records: list[dict],
         for y in range(years[0], years[1] + 1):
             if y < (rec.get("start") or 1974):
                 continue
+            amount = round(base * rent_factor(y), 2)
+            label = f"惠民租房 · {rec.get('country')}"
             session.add(IncomeStream(
                 entity_id=ent.id, stream_type="rent", group_key=f"{rec.get('country')}惠民租",
-                currency=rec.get("currency"), year=y,
-                amount=round(base * rent_factor(y), 2),
-                label=f"惠民租房 · {rec.get('country')}",
+                currency=rec.get("currency"), year=y, amount=amount, label=label,
                 source_file=rec.get("source_file"),
             ))
+            _mirror_to_finance(session, entity=ent, cur=rec.get("currency"),
+                               year=y, amount=amount, label=label,
+                               source_file=rec.get("source_file"))
             stats["stream"] += 1
     return stats

--- a/app/model/derived.py
+++ b/app/model/derived.py
@@ -204,6 +204,8 @@ class Investment(Base):
     risk_lvl: Mapped[str] = mapped_column(String, nullable=False)
     start_date: Mapped[date] = mapped_column(Date, nullable=False)
     locked: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # issue #82：已赎回标记（防重 to 按笔而非按年；GET 据此暴露 redeemed 置灰）
+    redeemed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
 
 
 class InvestmentAlloc(Base):

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -838,7 +838,7 @@ class Importer(Protocol):
 | F-P1-04 | **人物图谱** | 人—人/人—公司关系可视化（ECharts graph）｜core/graph.py + SVG 环形静态布局（非 ECharts，交互留待） | §1/§14 | ✅ |
 | F-P1-05 | **公司图谱** | 公司—公司关系 + 外部 API①② 导入（只增不减 + status）｜仅只读视图完成；外部 API①② 待用户提供文档后实现 | §13 | 🟨 |
 | F-P1-06 | **各国收益曲线** | return_curve（R1–R5）对比渲染 + 地区起始年下限｜GET /returns/regions + SVG 五线对比 | §14 | ✅ |
-| F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜GET /finance-entries + /entities/{id}/finance-entries | §5 | ✅ |
+| F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜API + 屏已上线；生产写入链路已接通（UI 派生 invest/redeem + ingest 镜像 source=file，issue #80），真实库 ingest 验收后再 ✅ | §5 | 🟨 |
 | F-P1-08 | **统一搜索** | LLM+embedding RAG（omlx 本地）条目检索装配 + serve 后处理｜⚠ 阻塞于本地 omlx 不可用，维持待续 | §18 | ⬜ |
 | F-P1-09 | 四类 UI 改数据操作 | 统一模板：年份×池 + 后传重算 + 失败整体拒绝 + overlay 同步｜useDataOp 钩子已用于投资/划拨屏 | §6.8/§19 | ✅ |
 

--- a/frontend/src/screens/Invest.jsx
+++ b/frontend/src/screens/Invest.jsx
@@ -21,6 +21,7 @@ export default function Invest() {
 
   const submit = useDataOp(() => inv.refresh())
   const redeem = useDataOp(() => inv.refresh())
+  const unlock = useDataOp(() => inv.refresh())
 
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
   const setAlloc = (i, k, v) => setForm(f => ({
@@ -99,23 +100,28 @@ export default function Invest() {
 
       <div className="panel">
         <h3>投资状态（GET /investments）</h3>
-        <p className="note">已投年份置灰锁定；「赎回」在 12-30 划回本金+收益、专款池清空</p>
+        <p className="note">已投年份置灰锁定；「赎回」在 12-30 划回本金+收益、专款池清空（已赎回禁点）；「解锁」整笔抹除重输（issue #81/#82）</p>
         <table>
-          <thead><tr><th>年</th><th>地区</th><th>R</th><th>发生日</th><th>分配</th><th></th></tr></thead>
+          <thead><tr><th>年</th><th>地区</th><th>R</th><th>发生日</th><th>分配</th><th>状态</th><th></th></tr></thead>
           <tbody>
             {(inv.data?.items || []).map(x => (
               <tr key={x.id}>
                 <td>{x.year}</td><td>{x.region}</td><td>{x.risk_lvl}</td>
                 <td className="mono">{x.start_date}</td>
                 <td className="muted">{(x.allocs || []).map(a => `${a.currency}${a.is_all ? '(全部)' : a.amount}`).join('、')}</td>
-                <td><button className="ghost" disabled={redeem.busy}
-                  onClick={() => redeem.submit(`/api/v1/investments/${x.id}/redeem`, {})}>赎回</button></td>
+                <td>{x.redeemed ? '已赎回' : (x.locked ? '已投·锁定' : '已解锁')}</td>
+                <td>
+                  <button className="ghost" disabled={redeem.busy || x.redeemed}
+                    onClick={() => redeem.submit(`/api/v1/investments/${x.id}/redeem`, {})}>赎回</button>
+                  <button className="ghost" disabled={unlock.busy || x.redeemed}
+                    onClick={() => unlock.submit(`/api/v1/investments/${x.id}`, { locked: false }, { method: 'PATCH' })}>解锁</button>
+                </td>
               </tr>
             ))}
-            {!(inv.data?.items || []).length && <tr><td colSpan={6} className="note">暂无投资</td></tr>}
+            {!(inv.data?.items || []).length && <tr><td colSpan={7} className="note">暂无投资</td></tr>}
           </tbody>
         </table>
-        <ErrorBox error={redeem.error} />
+        <ErrorBox error={redeem.error || unlock.error} />
       </div>
     </div>
   )

--- a/frontend/src/screens/useDataOp.js
+++ b/frontend/src/screens/useDataOp.js
@@ -13,12 +13,12 @@ export function useDataOp(onSuccess) {
   const [error, setError] = useState(null)
   const [last, setLast] = useState(null)
 
-  const submit = async (url, body) => {
+  const submit = async (url, body, { method = 'POST' } = {}) => {
     setBusy(true)
     setError(null)
     try {
       const r = await fetch(url, {
-        method: 'POST',
+        method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       })

--- a/migrations/versions/c1d2e3f4a5b6_investment_redeemed_at.py
+++ b/migrations/versions/c1d2e3f4a5b6_investment_redeemed_at.py
@@ -1,0 +1,23 @@
+"""投资 add redeemed_at（issue #82：F-P1-01 赎回按笔防重）。
+
+Investment 加可空 `redeemed_at TIMESTAMPTZ` —— 已赎回标记：
+- redeem_investment 开头据此按笔判重（非按年），同年多地区投资互不阻塞；
+- GET /investments* 据此暴露 redeemed 供前端置灰。
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision = 'c1d2e3f4a5b6'
+down_revision = 'b1c2d3e4f5a6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('investment', sa.Column('redeemed_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('investment', 'redeemed_at')

--- a/tests/test_fixes_80_81_82.py
+++ b/tests/test_fixes_80_81_82.py
@@ -1,0 +1,168 @@
+"""回归测试：issue #80（finance_entry 生产写入）、#81（解锁重输+消除双扣）、#82（redeemed 按笔防重）。"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.invest import (
+    ConflictError, create_investment, redeem_investment, unlock_investment,
+)
+from app.core.snapshot import account_balance_at
+from app.db import Base
+from app.ingest import writer
+from app.model import (
+    Account, Entity, FinanceEntry, LedgerEntry, ReturnCurve, TimelineEvent,
+)
+
+
+@pytest.fixture
+def session():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed(session):
+    h = Entity(entity_type="person", name="Henri Peeters")
+    session.add(h)
+    session.flush()
+    a = Account(entity_id=h.id, currency="BEF")
+    session.add(a)
+    session.flush()
+    session.add(LedgerEntry(account_id=a.id, date=date(1974, 1, 1),
+                            inflow=1000, balance=1000, kind="income", reason="初始现金"))
+    # 同一主体同一年不同地区（欧洲→比利时、英国→英国），验证同年多地区互不阻塞
+    session.add(ReturnCurve(country="比利时", risk_lvl="R3", year=1985, rate=10.0))
+    session.add(ReturnCurve(country="英国", risk_lvl="R3", year=1985, rate=12.0))
+    session.flush()
+    return h.id, a.id
+
+
+def _create(session, eid, region, amount=100, start="1985-05-01"):
+    inv = create_investment(session, year=1985, region=region, risk_lvl="R3",
+                            start_date=date.fromisoformat(start),
+                            allocs=[{"entity_id": eid, "currency": "BEF", "amount": amount}])
+    session.flush()
+    return inv
+
+
+# ---------- #82：赎回按笔防重（同年多地区互不阻塞 + redeemed 标记） ----------
+def test_same_year_two_regions_redeem_independently(session):
+    eid, aid = _seed(session)
+    eu = _create(session, eid, "欧洲")            # 1985 欧洲 R3（country=比利时）
+    uk = _create(session, eid, "英国")            # 1985 英国 R3（country=英国）
+    # 各笔独立赎回：互不阻塞（旧实现按年扫全库 pool 会误伤）
+    redeem_investment(session, eu)
+    session.flush()
+    redeem_investment(session, uk)               # 不应 409（issue #82 修复前会误伤）
+    session.flush()
+    assert eu.redeemed_at is not None and uk.redeemed_at is not None
+
+
+def test_redeem_double_409_by_redeemed(session):
+    eid, aid = _seed(session)
+    inv = _create(session, eid, "欧洲")
+    redeem_investment(session, inv)
+    session.flush()
+    with pytest.raises(ConflictError):
+        redeem_investment(session, inv)
+
+
+# ---------- #81：解锁重输（抹除旧写入 + 恢复 as-of + 拒绝已赎回） ----------
+def test_unlock_wipes_writes_and_restores_balance(session):
+    eid, aid = _seed(session)
+    inv = _create(session, eid, "欧洲")
+    session.flush()
+    assert session.query(LedgerEntry).filter(LedgerEntry.kind == "investment").count() == 1
+    assert session.query(FinanceEntry).filter(FinanceEntry.kind == "investment").count() == 1
+    assert session.query(TimelineEvent).filter(TimelineEvent.overlay.is_(True)).count() == 1
+    assert float(account_balance_at(session, aid, date(1985, 6, 30))) == pytest.approx(900)
+
+    unlock_investment(session, inv)
+    session.flush()
+    # 划出/镜像/overlay 全部抹除，余额恢复 to 投资前
+    assert session.query(LedgerEntry).filter(LedgerEntry.kind == "investment").count() == 0
+    assert session.query(FinanceEntry).filter(FinanceEntry.kind == "investment").count() == 0
+    assert session.query(TimelineEvent).filter(TimelineEvent.overlay.is_(True)).count() == 0
+    assert float(account_balance_at(session, aid, date(1985, 6, 30))) == pytest.approx(1000)
+    assert inv.locked is False
+
+
+def test_overwrite_after_unlock_no_double_deduct(session):
+    eid, aid = _seed(session)
+    inv1 = _create(session, eid, "欧洲", amount=100)
+    session.flush()
+    unlock_investment(session, inv1)
+    session.flush()
+    # 重输 → unlocked 覆盖分支重建；账户只被划出一次（非两倍）
+    inv2 = _create(session, eid, "欧洲", amount=100)
+    session.flush()
+    invest_rows = session.query(LedgerEntry).filter(LedgerEntry.kind == "investment").all()
+    assert len(invest_rows) == 1                     # 仅新一批，无双扣
+    assert float(invest_rows[0].outflow) == pytest.approx(100)
+    assert float(account_balance_at(session, aid, date(1985, 6, 30))) == pytest.approx(900)
+    # 注：inv1.id 与 inv2.id 在 SQLite 会复用（测试用内存库 PK 可回收），
+    #     后在 Postgres BIGSERIAL 序列永不复用——此处不比较 id，只核功能。
+
+
+def test_unlock_redeemed_refused(session):
+    eid, aid = _seed(session)
+    inv = _create(session, eid, "欧洲")
+    redeem_investment(session, inv)
+    session.flush()
+    with pytest.raises(ConflictError):
+        unlock_investment(session, inv)
+
+
+# ---------- #80：finance_entry 生产写入 ----------
+def test_invest_finance_entry_ui(session):
+    eid, aid = _seed(session)
+    inv = _create(session, eid, "欧洲", amount=100)
+    session.flush()
+    rows = session.query(FinanceEntry).filter(FinanceEntry.source == "ui").all()
+    assert any(r.kind == "investment" and r.source == "ui" and r.year == 1985 for r in rows)
+
+
+def test_redeem_finance_entry_ui(session):
+    eid, aid = _seed(session)
+    inv = _create(session, eid, "欧洲", amount=100)
+    redeem_investment(session, inv)
+    session.flush()
+    kinds = {r.kind for r in session.query(FinanceEntry).filter(FinanceEntry.source == "ui").all()}
+    assert {"investment", "pool", "investment_income"} <= kinds
+
+
+def test_ingest_mirrors_finance_entry_salary(session):
+    eid = _seed(session)[0]
+    stats = writer.import_salary(session, [{
+        "holder": "Henri Peeters", "currency": "BEF", "year": 1985,
+        "after_tax": 5000, "source_file": "基准/薪资/养父.md",
+    }])
+    session.flush()
+    assert stats["stream"] == 1
+    fe = session.query(FinanceEntry).filter(FinanceEntry.source == "file").all()
+    assert len(fe) == 1
+    assert fe[0].kind == "income" and fe[0].year == 1985 and fe[0].amount == 5000
+
+
+def test_ingest_mirrors_finance_entry_household_expense(session):
+    _seed(session)
+    stats = writer.import_household_expense(session, [{
+        "holder": "Henri Peeters", "currency": "BEF", "year": 1990, "amount": 800,
+        "source_file": "基准/1974-2001家庭支出.md",
+    }])
+    session.flush()
+    fe = session.query(FinanceEntry).filter(
+        FinanceEntry.kind == "expense", FinanceEntry.source == "file").all()
+    assert len(fe) == 1
+    assert fe[0].amount == 800 and fe[0].year == 1990

--- a/tests/test_ui_ops_api.py
+++ b/tests/test_ui_ops_api.py
@@ -51,6 +51,7 @@ def _seed(session):
     session.add(LedgerEntry(account_id=a.id, date=date(1974, 1, 1),
                             inflow=1000, balance=1000, kind="income"))
     session.add(ReturnCurve(country="比利时", risk_lvl="R3", year=1989, rate=10.0))
+    session.add(ReturnCurve(country="英国", risk_lvl="R3", year=1989, rate=12.0))
     session.commit()
     return h.id
 
@@ -114,3 +115,32 @@ def test_post_transfer_422_no_rate(client):
     })
     assert r.status_code == 422
     assert "汇率" in r.json()["detail"]
+
+
+def test_investment_redeemed_and_unlock_flow(client):
+    c, Session = client
+    eid = _seed(Session())
+    body = {
+        "year": 1989, "region": "欧洲", "risk_lvl": "R3", "start_date": "1989-06-30",
+        "allocs": [{"entity_id": eid, "currency": "BEF", "amount": 100, "is_all": False}],
+    }
+    r = c.post("/api/v1/investments", json=body)
+    assert r.status_code == 201
+    inv_id = r.json()["id"]
+    # 未赎回 → 公开 redeemed=False / locked=True
+    g = c.get(f"/api/v1/investments/{inv_id}").json()
+    assert g["redeemed"] is False and g["locked"] is True
+    assert "redeemed" in c.get("/api/v1/investments").json()["items"][0]
+    # 赎回 → redeemed=True
+    assert c.post(f"/api/v1/investments/{inv_id}/redeem", json={}).status_code == 200
+    assert c.get(f"/api/v1/investments/{inv_id}").json()["redeemed"] is True
+    # 已赎回 → 解锁 409（issue #81）
+    assert c.patch(f"/api/v1/investments/{inv_id}", json={"locked": False}).status_code == 409
+    # 解锁普通投资 → 200 locked=False（另造一笔未赎回，不同地区英国）
+    r2 = c.post("/api/v1/investments", json={
+        **body, "region": "英国", "start_date": "1989-07-01",
+    })
+    assert r2.status_code == 201
+    uid = r2.json()["id"]
+    assert c.patch(f"/api/v1/investments/{uid}", json={"locked": False}).status_code == 200
+    assert c.get(f"/api/v1/investments/{uid}").json()["locked"] is False


### PR DESCRIPTION
## 变更范围

本轮修复合规审核标记的三个 P1 问题（编号 #80/#81/#82），全部已有完整单元 + API 测试覆盖。

### #80 — finance_entry 生产写入链路（F-P1-07 实际未完成部分）
- **UI 派生**：`create_investment` 划出时同步落 `finance_entry(kind='investment', source='ui')`；`redeem_investment` 落 `kind='pool'`(本金) 与 `kind='investment_income'`(收益) 各一行。
- **ingest 镜像**：`app/ingest/writer._mirror_to_finance` 把 `import_income_security/property/shop/rent/salary` 与 `import_household_expense` 镜像为 `finance_entry(source='file')`——使 Finance 屏在真实库 ingest 后可见。
- DESIGN §20 F-P1-07 由 ✅ 降 🟨，真实库 ingest 验收后再 ✅。

### #81 — 投资解锁重输 + 消除双扣
- **新增** `PATCH /api/v1/investments/{id}`(`locked:false`) → `unlock_investment`：整笔抹除该投资全部派生写入（按 `note/label` 标签 `inv#{id}` 定位 ledger/finance/overlay）+ 置 `locked=False`。
- 已赎回投资拒绝解锁(409)。
- create_investment 覆盖分支显式删旧 allocs（不依赖 DB FK CASCADE，SQLite 测试也稳健）→ 重输无双扣。

### #82 — redeem 按笔防重 + redeemed 标记
- **迁移 c1d2e3f4a5b6**：`investment` 加 `redeemed_at TIMESTAMPTZ NULL`。
- redeem 开头按笔判重（`redeemed_at` 非空即 409），**不再按年扫全库 pool 流入**，解决同年多地区投资互堵。
- 成功后写 `redeemed_at=now()`；`GET /investments*` 暴露 `redeemed`；前端 Invest.jsx 已赎回行禁用赎回/解锁按钮。

### 回归
- 新增 `tests/test_fixes_80_81_82.py`（同年两地各自赎回、双赎409、解锁抹除+恢复as-of、覆盖无双扣、已赎回禁解锁、UI/ingest finance_entry 镜像）。
- `tests/test_ui_ops_api.py` 补 PATCH unlock 流 + redeemed 暴露。
- 全量 **230 tests 全绿**；`npm run build` 通过。

## 部署待办
- 三环境 DB 需执行 `alembic upgrade head` 落地 `investment.redeemed_at` 列。