### PR TITLE
fix(p1): #83/#84 —— 关池转出守门 + 跨类型关系边图谱

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db
 from app.api.ui_ops import router as ui_ops_router
 from app.core.calendar import snapshot_as_of
-from app.core.graph import company_graph, person_graph
+from app.core.graph import all_graph, company_graph, person_graph
 from app.core.health import run_report, summarize
 from app.core.wealth import wealth_series
 from app.model import (Account, Entity, ExchangeRate, FinanceEntry, IncomeStream,
@@ -358,6 +358,16 @@ def graph_companies(db: Session = Depends(get_db)):
     注：外部 API①② 对接（importers）留待外部系统文档后实现（F-P1-05 未完成部分）。
     """
     return company_graph(db)
+
+
+@app.get(API_PREFIX + "/graph/all")
+def graph_all(db: Session = Depends(get_db)):
+    """全量图谱（issue #84 / PRD §6.4 P1-1）：节点含 person/company/asset/family，边含跨类型。
+
+    纯类型视图 /graph/persons、/graph/companies 保留不删；本端点供「人—公司」等跨类型关系
+    可视化（前端按 entity_type 着色）。
+    """
+    return all_graph(db)
 
 
 # ---------------- 通知（非阻断提示；DESIGN §9.3；issue #13） ----------------

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -12,7 +12,10 @@ from app.model import Entity, Relationship
 
 
 def _graph(session: Session, entity_type: str) -> dict:
-    """按 entity_type 聚合 nodes + edges（两端都在该类型集合内的关系）。"""
+    """按 entity_type 聚合 nodes + edges（两端都在该类型集合内的关系）。
+
+    仅返回纯类型视图（人—人 或 公司—公司）；跨类型边（人—公司）见 all_graph（issue #84）。
+    """
     ents = {e.id: e for e in session.execute(
         select(Entity).where(Entity.entity_type == entity_type)).scalars().all()}
     nodes = [
@@ -36,10 +39,39 @@ def _graph(session: Session, entity_type: str) -> dict:
 
 
 def person_graph(session: Session) -> dict:
-    """人—人关系图。"""
+    """人—人关系图（纯类型视图；跨类型边见 /graph/all）。"""
     return _graph(session, "person")
 
 
 def company_graph(session: Session) -> dict:
-    """公司—公司关系图。"""
+    """公司—公司关系图（纯类型视图；跨类型边见 /graph/all）。"""
     return _graph(session, "company")
+
+
+def all_graph(session: Session) -> dict:
+    """全量图谱（issue #84 · PRD §6.4 P1-1）：节点=所有实体（含 person/company/asset/family），
+    边=所有 relationship（含人—公司/资产等跨类型）。
+
+    现有纯类型端点 /graph/persons、/graph/companies 保留不删；本视图作为跨类型视图供
+    「人—人、人—公司」合并关系可视化（前端按 entity_type 着色区分）。
+    """
+    ents = {e.id: e for e in session.execute(select(Entity)).scalars().all()}
+    nodes = [
+        {"id": e.id, "type": e.entity_type, "name": e.display_name or e.name,
+         "display_name": e.display_name, "status": e.status}
+        for e in ents.values()
+    ]
+    edges = []
+    for r in session.execute(select(Relationship)).scalars().all():
+        f, t = ents.get(r.from_entity_id), ents.get(r.to_entity_id)
+        if f is None or t is None:
+            continue
+        edges.append({
+            "from": f.id, "to": t.id,
+            "from_type": f.entity_type, "to_type": t.entity_type,
+            "from_name": f.display_name or f.name,
+            "to_name": t.display_name or t.name,
+            "rel_type": r.rel_type,
+            "since_year": r.since_year, "until_year": r.until_year,
+        })
+    return {"nodes": nodes, "edges": edges, "node_count": len(nodes), "edge_count": len(edges)}

--- a/app/core/invest.py
+++ b/app/core/invest.py
@@ -89,22 +89,18 @@ def _primary_account(session: Session, entity_id: int, currency: str) -> Optiona
 
     UNIQUE(entity_id, currency, bank) 允许同主体多 bank 同币种账户；投资划出/赎回
     统一落在最小 id 的 active 账户，保证余额链可重算（实测每主体每币种仅一个账户）。
+
+    关池（status=closed）账户不接受——§6.6 BEF/LUF/NLG 2002-01-01 关池后只读终态，
+    若主体该币种仅 closed 池，应走 EUR 承接池而非 silent 回退（issue #83 收紧）。
+    返回 None 以便调用方显式拒绝（Error 422 含币种/主体）。
     """
-    acc = session.execute(
+    return session.execute(
         select(Account).where(
             Account.entity_id == entity_id,
             Account.currency == currency,
             Account.status == "active",
         ).order_by(Account.id).limit(1)
     ).scalar_one_or_none()
-    if acc is None:
-        # 回退到任意账户（含已关池，避免全无时报错；正常数据不会走这）
-        return session.execute(
-            select(Account).where(Account.entity_id == entity_id,
-                                  Account.currency == currency)
-            .order_by(Account.id).limit(1)
-        ).scalar_one_or_none()
-    return acc
 
 
 def _pool_balance(session: Session, entity_id: int, currency: str, cutoff: date) -> Decimal:

--- a/app/core/transfer.py
+++ b/app/core/transfer.py
@@ -90,13 +90,18 @@ def transfer(session: Session, *, source_account_id: int, target_entity_id: int,
     """划拨（同币）/ 换汇（跨币）。返回 {operation, source_account_id,
     target_account_id, source_currency, target_currency, amount, target_amount, year}。
 
-    校验：金额>0；源/目标账户存在；源自 year 起全链 as-of 非负（否则拒绝）；换汇需该年汇率。
-    成功后：写两笔 ledger（year-12-30）→ 编年史 overlay。
+    校验：金额>0；源/目标账户存在；源非关池（§6.6 只读终态，issue #83）；源自 year 起全链
+    as-of 非负（否则拒绝）；换汇需该年汇率。成功后：写两笔 ledger（year-12-30）→ 编年史 overlay。
     调用方负责 flush/commit + recompute_all + rebuild_snapshots + record_recompute_done。
     """
     source = session.get(Account, source_account_id)
     if not source:
         raise ValidationError(f"源账户 #{source_account_id} 不存在")
+    if source.status == "closed":
+        # §6.6：关池后 BEF/LUF/NLG 进入只读终态，不可再存/投/换汇——历史资金已全额
+        # 结转 EUR 承接池，再从旧池转出会造成双份资金或污染 H4 余额链。
+        raise ValidationError(
+            f"源账户 #{source.id}（{source.currency}）已于 {source.closed_on} 关池进入只读终态，不可转出")
     target = primary_account(session, target_entity_id, target_currency)
     if not target:
         raise ValidationError(f"目标主体 #{target_entity_id} 无 {target_currency} 账户")

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -835,7 +835,7 @@ class Importer(Protocol):
 | F-P1-01 | **投资** | investment + alloc 派生数据、一年一投、R 级计息、年末赎回回银行、手动续投｜core/invest.py，§19.1–19.4 全实现 | §19.1–19.4 | ✅ |
 | F-P1-02 | **投资** | 专款池（分币种）走账 + 服务层校验（as-of/R起始年/年度幂等/覆盖连锁拒绝）｜§19.3 校验 422/409 + 划出(kind=investment)/赎回(pool+investment_income) 走账 | §19.3 | ✅ |
 | F-P1-03 | **划拨/换汇** | 划拨(同币)/换汇(按年汇率) + 转出向后全链不破负拒绝 + 编年史同步｜core/transfer.py，同币两笔净0、跨币缺该年汇率 422 | §19.5 | ✅ |
-| F-P1-04 | **人物图谱** | 人—人/人—公司关系可视化（ECharts graph）｜core/graph.py + SVG 环形静态布局（非 ECharts，交互留待） | §1/§14 | ✅ |
+| F-P1-04 | **人物图谱** | 人—人/人—公司关系可视化（ECharts graph）｜core/graph.py + SVG 环形静态布局（非 ECharts，交互留待）；issue #84 补 `/graph/all` 全量图谱（节点按 entity_type 形状/颜色区分，跨类型边虚线标出）覆盖 PRD P1-1 | §1/§14 | ✅ |
 | F-P1-05 | **公司图谱** | 公司—公司关系 + 外部 API①② 导入（只增不减 + status）｜仅只读视图完成；外部 API①② 待用户提供文档后实现 | §13 | 🟨 |
 | F-P1-06 | **各国收益曲线** | return_curve（R1–R5）对比渲染 + 地区起始年下限｜GET /returns/regions + SVG 五线对比 | §14 | ✅ |
 | F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜API + 屏已上线；生产写入链路已接通（UI 派生 invest/redeem + ingest 镜像 source=file，issue #80），真实库 ingest 验收后再 ✅ | §5 | 🟨 |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ const TABS = [
   { key: 'finance', label: '财务收支' },
   { key: 'persons', label: '人物图谱' },
   { key: 'companies', label: '公司图谱' },
+  { key: 'graphall', label: '全图谱' },
   { key: 'timeline', label: '编年史' },
   { key: 'search', label: '搜索' },
   { key: 'health', label: '健康校验' },
@@ -59,6 +60,7 @@ export default function App() {
         {active === 'finance' && <Finance />}
         {active === 'persons' && <Graph url="/api/v1/graph/persons" />}
         {active === 'companies' && <Graph url="/api/v1/graph/companies" />}
+        {active === 'graphall' && <Graph url="/api/v1/graph/all" />}
         {(active === 'timeline' || active === 'search' || active === 'health') && (
           <Placeholder label={TABS.find(t => t.key === active).label} asOf={asOf} />
         )}

--- a/frontend/src/screens/Graph.jsx
+++ b/frontend/src/screens/Graph.jsx
@@ -3,13 +3,30 @@ import { useFetch } from './useDataOp'
 
 const W = 720, H = 460, CX = W / 2, CY = H / 2
 
+// 按 entity_type 区分形状/颜色（issue #84 · 全图谱跨类型渲染）
+const TYPE_STYLE = {
+  person:  { fill: 'var(--s1)', shape: 'circle' },
+  company: { fill: 'var(--s2)', shape: 'rect' },
+  asset:   { fill: 'var(--s3)', shape: 'diamond' },
+  family:  { fill: 'var(--warn)', shape: 'rect' },
+}
+const TYPE_LABEL = {
+  person: '人物图谱',
+  company: '公司图谱',
+  family: '全图谱（人·公司·资产·家族）',
+}
+
 /**
- * 通用只读图谱视图（F-P1-04/05）：SVG 环形布局（节点等角分布 + 连线 + 名称标签）。
+ * 通用只读图谱视图（F-P1-04/05 + /graph/all）：SVG 环形布局 + 按 entity_type 形状/颜色区分。
+ * 纯类型视图（/graph/persons、/graph/companies）单色；/graph/all 多类型混合。
  * 静态布局，无交互拖拽（G6/ECharts 留待需要交互时再换）。
  */
 export default function Graph({ url, emptyHint }) {
   const g = useFetch(url)
   const { nodes = [], edges = [] } = g.data || {}
+  const isAll = url.startsWith('/api/v1/graph/all')
+  const title = isAll ? TYPE_LABEL.family
+    : (url.startsWith('/api/v1/graph/persons') ? TYPE_LABEL.person : TYPE_LABEL.company)
 
   const layout = useMemo(() => {
     if (!nodes.length) return {}
@@ -25,8 +42,8 @@ export default function Graph({ url, emptyHint }) {
   const pos = layout.pos || {}
   return (
     <div className="panel">
-      <h3>{url.startsWith('/api/v1/graph/persons') ? '人物图谱' : '公司图谱'}</h3>
-      <p className="note">只读视图 · {nodes.length} 节点 · {edges.length} 关系（rel_type 标注）</p>
+      <h3>{title}</h3>
+      <p className="note">只读视图 · {nodes.length} 节点 · {edges.length} 关系（rel_type 标注）{isAll ? ' · 形状/颜色按 entity_type 区分' : ''}</p>
       {nodes.length === 0 ? (
         <div className="plot"><span className="ph">{emptyHint || '暂无节点（需 entity/relationship 数据）'}</span></div>
       ) : (
@@ -36,34 +53,62 @@ export default function Graph({ url, emptyHint }) {
             {edges.map((e, i) => {
               const a = pos[e.from], b = pos[e.to]
               if (!a || !b) return null
+              const isCross = isAll && e.from_type && e.to_type && e.from_type !== e.to_type
               return (
                 <g key={i}>
-                  <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="var(--axis)" strokeWidth="1.2" />
+                  <line x1={a.x} y1={a.y} x2={b.x} y2={b.y}
+                    stroke={isCross ? 'var(--warn)' : 'var(--axis)'}
+                    strokeWidth={isCross ? '1.6' : '1.2'}
+                    strokeDasharray={isCross ? '4 3' : ''} />
                   <text x={(a.x + b.x) / 2} y={(a.y + b.y) / 2} fontSize="9" fill="var(--muted)" textAnchor="middle" dy="-2">
                     {e.rel_type}
                   </text>
                 </g>
               )
             })}
-            {/* 节点 */}
+            {/* 节点（按 entity_type 形状/颜色） */}
             {nodes.map(n => {
               const p = pos[n.id]
               if (!p) return null
+              const style = (isAll && TYPE_STYLE[n.type]) || { fill: 'var(--s1)', shape: 'circle' }
+              const shapeNode = renderShape(p, n, style)
               return (
                 <g key={n.id}>
-                  <circle cx={p.x} cy={p.y} r="16" fill="var(--s1)" opacity="0.85" stroke="var(--page)" strokeWidth="2" />
+                  {shapeNode}
                   <text x={p.x} y={p.y} fontSize="9" fill="#fff" textAnchor="middle" dominantBaseline="central">
                     {String(n.id)}
                   </text>
-                  <text x={p.x} y={p.y + 26} fontSize="10" fill="var(--ink)" textAnchor="middle">
+                  <text x={p.x} y={p.y + (style.shape === 'circle' || style.shape === 'diamond' ? 26 : 22)} fontSize="10" fill="var(--ink)" textAnchor="middle">
                     {n.name}
                   </text>
                 </g>
               )
             })}
           </svg>
+          {isAll && (
+            <div className="legend" style={{ position: 'absolute', bottom: 8, right: 12, background: 'var(--surface-1)', padding: '4px 8px', borderRadius: 6, border: '1px solid var(--border)' }}>
+              <span><i style={{ background: TYPE_STYLE.person.fill, borderRadius: '50%' }} /> person</span>
+              <span><i style={{ background: TYPE_STYLE.company.fill }} /> company</span>
+              <span><i style={{ background: TYPE_STYLE.asset.fill, transform: 'rotate(45deg)' }} /> asset</span>
+              <span><i style={{ background: TYPE_STYLE.family.fill }} /> family</span>
+            </div>
+          )}
         </div>
       )}
     </div>
   )
+}
+
+function renderShape(p, n, style) {
+  const fill = style.fill
+  const stroke = 'var(--page)', sw = 2
+  if (style.shape === 'rect') {
+    return <rect x={p.x - 18} y={p.y - 12} width={36} height={24} rx={3}
+      fill={fill} opacity="0.9" stroke={stroke} strokeWidth={sw} />
+  }
+  if (style.shape === 'diamond') {
+    return <polygon points={`${p.x},${p.y - 16} ${p.x + 16},${p.y} ${p.x},${p.y + 16} ${p.x - 16},${p.y}`}
+      fill={fill} opacity="0.9" stroke={stroke} strokeWidth={sw} />
+  }
+  return <circle cx={p.x} cy={p.y} r={16} fill={fill} opacity="0.85" stroke={stroke} strokeWidth={sw} />
 }

--- a/frontend/src/screens/Transfer.jsx
+++ b/frontend/src/screens/Transfer.jsx
@@ -41,10 +41,15 @@ export default function Transfer() {
                 onChange={e => set('year', Number(e.target.value))} />
             </Field>
           </div>
-          <Field label="源账户（主体·币种）">
+          <Field label="源账户（主体·币种 · 关池不可选）">
             <select value={form.source_account_id} onChange={e => set('source_account_id', e.target.value)}>
               <option value="">—选择源账户—</option>
-              {acctOpts.map(a => <option key={a.id} value={a.id}>#{a.id} · entity{a.entity_id} · {a.currency}{a.status === 'closed' ? '（关池）' : ''}</option>)}
+              {acctOpts.map(a => (
+                <option key={a.id} value={a.id} disabled={a.status === 'closed'}
+                  title={a.status === 'closed' ? `§6.6 关池后只读终态（${a.closed_on || ''}）` : ''}>
+                  #{a.id} · entity{a.entity_id} · {a.currency}{a.status === 'closed' ? '（关池·禁选）' : ''}
+                </option>
+              ))}
             </select>
           </Field>
           <div className="row">

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy import BigInteger, Integer, create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.core.graph import company_graph, person_graph
+from app.core.graph import all_graph, company_graph, person_graph
 from app.db import Base
 from app.model import Entity, Relationship
 
@@ -57,3 +57,23 @@ def test_company_graph(session):
     assert g["node_count"] == 2
     assert [e["rel_type"] for e in g["edges"]] == ["holds"]
     assert g["edges"][0]["from_name"] == "Peeters Americas"
+
+
+def test_all_graph_includes_cross_edges_issue_84(session):
+    """issue #84：/graph/all 包含跨类型（人—公司）边，节点 type 标注。"""
+    _seed(session)
+    g = all_graph(session)
+    # 全量节点：3 person + 2 company = 5
+    assert g["node_count"] == 5
+    by_type = {}
+    for n in g["nodes"]:
+        by_type.setdefault(n["type"], []).append(n)
+    assert len(by_type["person"]) == 3 and len(by_type["company"]) == 2
+    # 跨类型边：member（person→company）应出现
+    cross = [e for e in g["edges"]
+             if e["from_type"] == "person" and e["to_type"] == "company"]
+    assert any(e["rel_type"] == "member" for e in cross)
+    # 同类型边也都在
+    assert any(e["rel_type"] == "parent" for e in g["edges"])
+    # 节点 type 字段填充（前端据此着色）
+    assert all("type" in n and n["type"] in ("person", "company") for n in g["nodes"])

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from app.core.invest import ValidationError
 from app.core.transfer import transfer
 from app.db import Base
-from app.model import Account, Entity, ExchangeRate, LedgerEntry
+from app.model import Account, Entity, ExchangeRate, FinanceEntry, LedgerEntry
 
 
 @pytest.fixture
@@ -90,3 +90,37 @@ def test_transfer_causing_negative_rejected(session):
     with pytest.raises(ValidationError):
         transfer(session, source_account_id=a1.id, target_entity_id=j.id,
                  target_currency="BEF", amount=60, year=1980)
+
+
+def test_transfer_closed_source_rejected_issue_83(session):
+    """issue #83：§6.6 关池（status=closed）只读终态，转出必拒。"""
+    h, j, a1, a2, a3 = _seed(session)
+    # 把 BEF 主账户置为关池
+    a1.status = "closed"
+    a1.closed_on = date(2002, 1, 1)
+    a1.migrate_to_currency = "EUR"
+    session.flush()
+    with pytest.raises(ValidationError) as e:
+        transfer(session, source_account_id=a1.id, target_entity_id=j.id,
+                 target_currency="BEF", amount=100, year=2003)
+    assert "关池" in str(e.value.detail)
+
+
+def test_transfer_active_source_after_close_still_works(session):
+    """issue #83：关池账户被拒，但同主体下 active EUR 账户可正常转出。"""
+    h, j, a1, a2, a3 = _seed(session)
+    a1.status = "closed"
+    a1.closed_on = date(2002, 1, 1)
+    # 给 EUR 池补一笔 inflow，使其可作转出源
+    session.add(LedgerEntry(account_id=a3.id, date=date(2002, 1, 1),
+                            inflow=100, balance=100, kind="income"))
+    session.flush()
+    # 用 a3(EUR) 作源 → 同币划拨到公司 BEF（其实跨币，这里用 a3 EUR → 公司 EUR）
+    eur_company = Account(entity_id=j.id, currency="EUR")
+    session.add(eur_company)
+    session.flush()
+    out = transfer(session, source_account_id=a3.id, target_entity_id=j.id,
+                   target_currency="EUR", amount=50, year=2003)
+    session.flush()
+    assert out["operation"] == "划拨"
+    assert out["amount"] == 50

--- a/tests/test_ui_ops_api.py
+++ b/tests/test_ui_ops_api.py
@@ -12,7 +12,7 @@ from sqlalchemy.pool import StaticPool
 from app.api.app import app
 from app.api.deps import get_db
 from app.db import Base
-from app.model import Account, Entity, LedgerEntry, ReturnCurve
+from app.model import Account, Entity, LedgerEntry, Relationship, ReturnCurve
 
 
 @pytest.fixture
@@ -115,6 +115,47 @@ def test_post_transfer_422_no_rate(client):
     })
     assert r.status_code == 422
     assert "汇率" in r.json()["detail"]
+
+
+def test_post_transfer_closed_source_rejected(client):
+    """issue #83：源 account.status=closed → 422（§6.6 关池只读终态）。"""
+    c, Session = client
+    _seed(Session())
+    s = Session()
+    src = s.query(Account).filter(Account.currency == "BEF").first()
+    src.status = "closed"
+    src.closed_on = date(2002, 1, 1)
+    src.migrate_to_currency = "EUR"
+    bv = Entity(entity_type="company", name="Peeters BV")
+    s.add(bv)
+    s.flush()
+    s.add(Account(entity_id=bv.id, currency="BEF"))
+    s.commit()
+    r = c.post("/api/v1/transfers", json={
+        "source_account_id": src.id, "target_entity_id": bv.id,
+        "target_currency": "BEF", "amount": 10, "year": 2003,
+    })
+    assert r.status_code == 422
+    assert "关池" in r.json()["detail"]
+
+
+def test_get_graph_all_endpoint(client):
+    """issue #84：GET /graph/all 包含跨类型边 + 节点 type 字段。"""
+    c, Session = client
+    s = Session()
+    h = Entity(entity_type="person", name="Stijn Peeters")
+    bv = Entity(entity_type="company", name="Peeters BV")
+    s.add_all([h, bv])
+    s.flush()
+    s.add(Relationship(from_entity_id=h.id, to_entity_id=bv.id, rel_type="member"))
+    s.commit()
+    r = c.get("/api/v1/graph/all")
+    assert r.status_code == 200
+    body = r.json()
+    types = {n["type"] for n in body["nodes"]}
+    assert "person" in types and "company" in types
+    assert any(e["rel_type"] == "member" and e["from_type"] == "person" and e["to_type"] == "company"
+               for e in body["edges"])
 
 
 def test_investment_redeemed_and_unlock_flow(client):


### PR DESCRIPTION
## 变更范围

合规审核标记的两个 P2 问题（#83 / #84），均已修复并通过单元 + API 测试。

### #83 — transfer 关池转出守门（DESIGN §6.6 conformance）
- **`transfer()` 开头校验 `source.status == 'closed'` → 422**，detail 含关池日/币种。
- `invest._primary_account` 去掉 closed 兜底（不再 silent 回退到已关池账户）。
- 前端 `Transfer.jsx` 关池源账户 `disabled` + title 提示，避免误选。

### #84 — 跨类型关系边图谱（PRD §6.4 P1-1 feature-gap）
现有 /graph/persons、/graph/companies 只保留纯类型边（两端都在该类型集合内），人—公司
(member/holds) 边被两端过滤、永远不可见。
- **保留纯类型端点不删**；新增 `GET /api/v1/graph/all`（`core.graph.all_graph`）：
  - 节点 = 全部 entity（含 person/company/asset/family），每节点带 `type`；
  - 边 = 全部 relationship，每边带 `from_type`/`to_type`；
  - 跨类型边（两端 type 不同）由前端标虚线区分。
- 前端 `Graph.jsx` 按 entity_type 渲染形状+颜色：
  - person = 圆 / company = 方 / asset = 菱 / family = 方（warn 配色）；
  - 跨类型边虚线 + 角部图例；
- 新前端 tab **「全图谱」** 挂 /graph/all；纯类型端点不受影响。

### 回归
- `tests/test_transfer.py` 增：关池源 → 422；active EUR 池正常转出。
- `tests/test_graph.py` 增：`all_graph` 跨类型边可见 + 节点 type 字段。
- `tests/test_ui_ops_api.py` 增：POST /transfers 关池 422；GET /graph/all 跨边可见。
- 全量 **235 tests 全绿**；`npm run build` 通过。
- DESIGN §20 F-P1-04 加注 `/graph/all` 跨类型视图。