### PR TITLE
fix(p1): #85/#86/#87 —— 专款池在途净值口径 + DESIGN回写 + P3 hygiene

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -191,6 +191,16 @@ def wealth(year_from: int = 1947, year_to: int = 2025, db: Session = Depends(get
 
 
 # ---------------- 收益曲线 ----------------
+@app.get(API_PREFIX + "/returns/countries")
+def returns_countries(db: Session = Depends(get_db)):
+    """收益曲线在库国家列表（issue #87-3：前端动态渲染，不再硬编码 9 国）。"""
+    rows = db.execute(
+        select(ReturnCurve.country).where(ReturnCurve.country.isnot(None))
+        .distinct().order_by(ReturnCurve.country)
+    ).scalars().all()
+    return {"countries": rows}
+
+
 @app.get(API_PREFIX + "/returns")
 def returns(
     country: Optional[str] = None,
@@ -223,16 +233,19 @@ def returns(
 def fx(
     fx_from: Optional[str] = None,
     fx_to: Optional[str] = None,
+    year: Optional[int] = None,                       # issue #87-1：按年筛可用方向
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
 ):
-    """issue #23：补分页。"""
+    """issue #23：补分页；issue #87-1：补 year 筛选（前端换汇目标币种可用方向）。"""
     q = select(ExchangeRate)
     if fx_from:
         q = q.where(ExchangeRate.fx_from == fx_from)
     if fx_to:
         q = q.where(ExchangeRate.fx_to == fx_to)
+    if year:
+        q = q.where(ExchangeRate.year == year)
     total = db.execute(select(func.count()).select_from(q.subquery())).scalar() or 0
     rows = db.execute(q.order_by(ExchangeRate.fx_from, ExchangeRate.fx_to, ExchangeRate.year)
                       .offset((page - 1) * page_size).limit(page_size)).scalars().all()

--- a/app/core/calendar.py
+++ b/app/core/calendar.py
@@ -8,12 +8,13 @@
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.currency import usd_rate
-from app.core.snapshot import account_balance_at
+from app.core.snapshot import account_balance_at, pool_in_transit
 from app.model import Account
 
 
@@ -37,17 +38,26 @@ def snapshot_as_of(session: Session, as_of_date: date) -> list[dict]:
     entity_agg: dict[tuple[int, str], float] = {}
     family_usd = 0.0
     for a in accs:
-        bal = account_balance_at(session, a.id, as_of_date)
+        bal = account_balance_at(session, a.id, as_of_date)      # Decimal（issue #28）
         # 关池后不双计：closed 账户自关池日起余额清 0（钱已结转进承接 EUR 账户，DESIGN §6.6）
         if a.status == "closed" and a.closed_on is not None and as_of_date >= a.closed_on:
-            bal = 0.0
+            bal = Decimal(0)
         out.append({"scope": f"account:{a.id}:{a.currency}",
-                    "value": round(bal, 2), "currency": a.currency, "year": year})
+                    "value": round(float(bal), 2), "currency": a.currency, "year": year})
         key = (a.entity_id, a.currency)
-        entity_agg[key] = entity_agg.get(key, 0.0) + bal
+        entity_agg[key] = entity_agg.get(key, 0.0) + float(bal)
         rate = usd_rate(session, a.currency, year)
         if rate is not None:
-            family_usd += bal * float(rate)
+            family_usd += float(bal) * float(rate)
+    # §19.4（issue #85）：净值 = 银行 + 专款池合计。在途资金不凹陷——投资划出后、赎回前，
+    # 该币种本金仍在池中，应在 entity/family 聚合时加回，使投资期间总净值不变。
+    # account scope 保留纯银行余额（专款池是"在途仓"，区别于银行现金）。
+    pool = pool_in_transit(session, as_of_date)
+    for (eid, cur), amt in pool.items():
+        entity_agg[(eid, cur)] = entity_agg.get((eid, cur), 0.0) + float(amt)
+        rate = usd_rate(session, cur, year)
+        if rate is not None:
+            family_usd += float(amt) * float(rate)
     for (eid, cur), bal in entity_agg.items():
         out.append({"scope": f"entity:{eid}:{cur}",
                     "value": round(bal, 2), "currency": cur, "year": year})

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -12,9 +12,15 @@ issue #12 修复：
 issue #28 修复：
 - 内部计算全程 Decimal（避免 float 二进制误差累积）
 - 0 值且无流水的年份跳过写入（account/entity/family 三种 scope），避免快照表膨胀
+
+issue #85 修复：
+- 净值口径对齐 §19.4：净值 = 银行 + 专款池合计。投资在途（划出后~赎回前）本金不使
+  family/entity 净值凹陷——entity/family 聚合时经 `pool_in_transit` 加回在途本金；
+  account scope 仍为纯银行余额。
 """
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 
 from sqlalchemy import delete, func, select
@@ -49,6 +55,39 @@ def _close_year_of(acc: Account) -> int | None:
     if acc.status == "closed" and acc.closed_on is not None:
         return acc.closed_on.year
     return None
+
+
+def pool_in_transit(session: Session, as_of: date) -> dict[tuple[int, str], Decimal]:
+    """各 (entity_id, currency) 截至 as_of 的在途专款池本金（DESIGN §19.4 / issue #85）。
+
+    口径：净值 = 银行 + 专款池合计。投资本金在 `start_date` 划出银行入池（kind='investment'
+    ledger 支出）、至该投资年 12-30 划回（kind='pool' 流入）；**在途期间该笔资金归入专款池
+    而非令净值凹陷**。本实现走 ledger 累计：在途本金 = Σ(kind='investment' 支出) −
+    Σ(kind='pool' 流入)，截止 as_of——按日期天然与银行账目一致，且不依赖 redeemed_at
+    （那只作防重标记，非结算日）。
+
+    返回 {(entity_id, currency): 在途本金}；无在途资金返回空 dict。供
+    - calendar.snapshot_as_of（日级 as-of）与
+    - rebuild_snapshots #5/#4（年）在聚合 family:total / entity:* 时加回，
+    保持「投资期间总净值不变」。
+    """
+    rows = session.execute(
+        select(
+            Account.entity_id,
+            Account.currency,
+            func.coalesce(func.sum(func.coalesce(LedgerEntry.outflow, 0)), 0),
+            func.coalesce(func.sum(func.coalesce(LedgerEntry.inflow, 0)), 0),
+        )
+        .join(Account, Account.id == LedgerEntry.account_id)
+        .where(LedgerEntry.date <= as_of, LedgerEntry.kind.in_(["investment", "pool"]))
+        .group_by(Account.entity_id, Account.currency)
+    ).all()
+    out: dict[tuple[int, str], Decimal] = {}
+    for eid, cur, o, i in rows:
+        net = Decimal(o or 0) - Decimal(i or 0)       # 划出(投资) − 划回(pool本金)
+        if net != 0:
+            out[(int(eid), cur)] = net
+    return out
 
 
 def _account_balance_series(session: Session, account_id: int,
@@ -109,6 +148,14 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
         return stats
     start = from_year if from_year is not None else years_list[0]
 
+    # 0) 专款池在途（issue #85 §19.4）：逐年 12-30 在途本金，供 entity/family 聚合时加回，
+    #    保证年度净值口径 = 银行 + 专款池合计（投资在途不凹陷）。
+    pool_by_year: dict[int, dict[tuple[int, str], Decimal]] = {}
+    for y in years_list:
+        if y < start:
+            continue
+        pool_by_year[y] = pool_in_transit(session, date(y, 12, 30))
+
     # 1) 清旧：仅清 from_year 起（含）的 account/entity/family 三种 scope 行
     scope_prefixes = ("account:", "entity:", "family:")
     session.execute(
@@ -160,7 +207,8 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
         for y in years_list:
             if y < start:
                 continue
-            v = ymap.get(y, _ZERO)
+            # §19.4：净值 = 银行 + 专款池在途；entity 口径把该年 12-30 在途本金加回（issue #85）
+            v = ymap.get(y, _ZERO) + pool_by_year[y].get((eid, cur), _ZERO)
             if v == 0:
                 continue
             session.add(Snapshot(
@@ -188,6 +236,14 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
             if rate is None:
                 continue                                 # 汇率缺失 → 不计入
             family_usd = family_usd + v * rate
+            any_contribution = True
+        # §19.4：净值 = 银行 + 专款池在途；family:total 补回该年 12-30 在途本金（issue #85）。
+        # 在途本金按主体×币种记（account 银行余额已含划出凹陷，这里加回对冲）。
+        for (eid, cur), amt in pool_by_year[y].items():
+            rate = _usd_rate(session, cur, y)
+            if rate is None:
+                continue                                 # 汇率缺失 → 不计入
+            family_usd = family_usd + amt * rate
             any_contribution = True
         # issue #28：family_usd=0 跳过（避免家族层面多年 0 值行膨胀）
         if not any_contribution or family_usd == 0:

--- a/app/core/transfer.py
+++ b/app/core/transfer.py
@@ -39,7 +39,9 @@ def primary_account(session: Session, entity_id: int, currency: str) -> Optional
 def _fx_rate(session: Session, fx_from: str, fx_to: str, year: int) -> Optional[Decimal]:
     """该年直接货币对汇率（§19.5：换汇命中该年汇率才可换，不做全时段穷举）。
 
-    只取该年具体行（year==year，不含 year IS NULL 基准常量）——缺失即无该年汇率。
+    只取该年具体行（year==year，不含 year IS NULL 基准常量）。
+    issue #87-1：缺正向方向时取反向行（fx_to→fx_from）取倒数——来源币向通常只存单向，
+    EUR↔BEF 应可双向成交（倒数是精确的数学逆）。
     """
     row = session.execute(
         select(ExchangeRate.rate).where(
@@ -48,7 +50,28 @@ def _fx_rate(session: Session, fx_from: str, fx_to: str, year: int) -> Optional[
             ExchangeRate.year == year,
         ).limit(1)
     ).first()
-    return Decimal(row[0]) if row and row[0] is not None else None
+    if row is not None and row[0] is not None:
+        return Decimal(str(row[0]))
+    rrow = session.execute(
+        select(ExchangeRate.rate).where(
+            ExchangeRate.fx_from == fx_to,
+            ExchangeRate.fx_to == fx_from,
+            ExchangeRate.year == year,
+        ).limit(1)
+    ).first()
+    if rrow is not None and rrow[0] is not None and Decimal(str(rrow[0])) != 0:
+        return Decimal(1) / Decimal(str(rrow[0]))
+    return None
+
+
+def available_fx_pairs(session: Session, year: int) -> list[tuple[str, str]]:
+    """该年在库的直接货币对方向（issue #87-1：供错误提示/前端可用方向下拉）。"""
+    return session.execute(
+        select(ExchangeRate.fx_from, ExchangeRate.fx_to)
+        .where(ExchangeRate.year == year, ExchangeRate.rate.isnot(None))
+        .order_by(ExchangeRate.fx_from, ExchangeRate.fx_to)
+        .distinct()
+    ).all()
 
 
 def _simulate_annual_asof_nonneg(session: Session, account_id: int,
@@ -125,8 +148,11 @@ def transfer(session: Session, *, source_account_id: int, target_entity_id: int,
     else:
         rate = _fx_rate(session, source.currency, target.currency, year)
         if rate is None:
+            pairs = available_fx_pairs(session, year)
+            hint = ("；该年可用方向：" + "、".join(f"{f}→{t}" for f, t in pairs)
+                    ) if pairs else "；该年无任何汇率行（缺 year-12-30 单，请数据调整员先导入）"
             raise ValidationError(
-                f"缺 {year} 年 {source.currency}→{target.currency} 汇率，无法换汇；请数据调整员先导入该年汇率")
+                f"缺 {year} 年 {source.currency}→{target.currency} 汇率，无法换汇{hint}")
         target_amount = (amt * rate).quantize(Decimal("0.01"))
         op = "换汇"
         reason_src = f"换汇 {amt} {source.currency} → {target.currency} @{year}"

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -608,6 +608,9 @@ class Importer(Protocol):
 - **视图资源**（多资源聚合）以 `/api/v1/overview`、`/api/v1/graph/{kind}`、`/api/v1/wealth`、`/api/v1/returns`、`/api/v1/finance` 提供，只读 GET。
 - **URL 版本段**：所有内部 API 一律以 **`/api/v1/`** 为前缀；后续不兼容演进发布 v2 时**并行运行 v1**（v1 进入维护期，仅修 bug、不加新端点），客户端可显式指定版本。
 - **写端点授权**：除 `timeline-events`（编年史，经覆盖层）与 `source-files/{id}/versions*`（diff 决策）外，其余**写端点**（创建/全量替换/局部更新/删除 `entities`、新增 `ledger-entries`、新增 `finance-entries` 等）**不面向普通 UI 用户**，仅供 importer / 数据调整员（受限通道，对齐 PRD §1.4 铁律）。普通 UI 对这类写端点的调用应由 serve 层拒绝（409/403）。
+  > **实现注记（issue #87-4）**：守卫 `app/api/deps.py:require_importer` 已实现（`X-Importer: 1` 放行，否则 403），
+  > 但**当前无任何写端点挂载**（现有写端点即四类 UI 派生通道 §19，天然放行）——授权矩阵处于「空转」状态，
+  > 无实际风险。待 P1-05 外部 importer 或任一类受限写端点上线时**强制挂载并补 403 测试**。
 
 ### 14.2 资源端点
 
@@ -791,6 +794,19 @@ class Importer(Protocol):
 - **校验**：**转出年起向后全链 as-of 不得为负**，任一年拐负 → 整体拒绝转出（同投资选 i 的整体拒绝，复用同一套向后重算传播校验）。划拨目标可为另一实体账户（人物 A→公司 A）。
 - **记年**：锁输入年份；落 `ledger_entry` 后传重算；同步编年史 overlay。
 
+### ★ 实现决策备注：UI 派生编年史直写 overlay（issue #86 定案）
+
+UI 派生操作（投资创建/赎回、划拨换汇）的编年史同步为**直写 `timeline_event(overlay=True)`**，
+**不经** `user_data_overlay` 表 + `overlay_dir/编年史.md` 覆盖层文件通道（§6.4）。
+实现位置：`app/core/invest.py`（创建 §19.1 / 赎回 §19.2）、`app/core/transfer.py`（§19.5）。
+
+- **理由**：派生行由系统生成、无用户自由文本编辑需求；timeline ingest 为 insert-only 幂等键
+  `(event_year, title, source_file)`（`app/ingest/writer.py`），重导不会冲掉这些行，数据安全可接受——
+  是对 PRD §1.4「界面更新经覆盖层」字面约束的**有意偏离**（架构决策），据此固化为文档基线。
+- **后果**：§6.4 覆盖层能力（覆盖层 md 导出 / 差异 / 重置回源 / 以源为最新）对这批派生
+  `overlay=True` 行**不适用**。P2-05「编年史 UI 编辑」落地时须明确处理策略占位：视为**系统行
+  只读**（落库按 `note` 标签 `inv#<id>` / `UI 转移` 定位），用户编辑一律走真实覆盖层通道。
+
 ### 19.6 事件·股票与资产模型（Phase 2）
 - **导入链**：`基准/事件/股票/**` Phase 2 重新纳入 detect → 数据调整员导入**不关联账户** → UI 用户按**同币种**手动关联到某账户(人物/公司)；现金流经事件生成 `ledger_entry` 进账户。
 - **总资产**：`银行账户余额(现金) + 投资专款池 + 股票持仓市值`；现金与市值不重叠（买入=ledger 支出「购入股票」移除现金）。
@@ -820,8 +836,8 @@ class Importer(Protocol):
 | F-P0-05 | **Phase1 摄入** | 收益文件模块化挂账(income_stream)：租/经营性房/祖产债券/开店（薪资在 F-P0-06）｜因子外置 core/factors.py，源文件仅基桩值 (#69) | §6.5/§6.3 | ✅ |
 | F-P0-06 | **Phase1 摄入** | 家庭支出(挂 Henri)/薪资各归各账户；2002 BEF/LUF/NLG 关池转 EUR｜家庭支出幂等同 #68 | §6.5/§6.6 | ✅ |
 | F-P0-07 | **DDL** | entity/account(status/closed_on)/ledger_entry/income_stream/initial_asset/snapshot 等 | §5 | ✅ |
-| F-P0-08 | **快照** | 逐年 as-of 快照预计算（snapshot.py）｜三层 scope + from_year 增量已实现，逐年完整覆盖随真实数据联调 | §8 | 🟨 |
-| F-P0-09 | **财富曲线** | 账户/币种/公司/全家族合计 + USD 展示折算（账务本币/展示USD）｜接口已上线，前端曲线仅 Dashboard 单屏可见 | §7/§8 | 🟨 |
+| F-P0-08 | **快照** | 逐年 as-of 快照预计算（snapshot.py）｜三层 scope + from_year 增量已实现；§19.4 专款池在途净值口径经 `pool_in_transit` 加回（issue #85，entity/family 不凹陷），逐年完整覆盖随真实数据联调 | §8/§19.4 | 🟨 |
+| F-P0-09 | **财富曲线** | 账户/币种/公司/全家族合计 + USD 展示折算（账务本币/展示USD）｜接口已上线；年中日历拖动在途不凹陷（issue #85，align §19.4），前端曲线仅 Dashboard 单屏可见 | §7/§8/§19.4 | 🟨 |
 | F-P0-10 | **日历游标** | 全局日历 as-of 拖拽，全 App 联动（服务函数就绪，API 端点 F-P0-13） | §8 | ✅ |
 | F-P0-11 | **健康校验** | H1–H5 汇总 + 问题清单（health.py） | §10 | ✅ |
 | F-P0-12 | **增量重算** | 受影响起点向后传播（recompute.py）+ 提示｜register_job/notification 已接线，范围边界待核实 | §9 | 🟨 |
@@ -838,7 +854,7 @@ class Importer(Protocol):
 | F-P1-04 | **人物图谱** | 人—人/人—公司关系可视化（ECharts graph）｜core/graph.py + SVG 环形静态布局（非 ECharts，交互留待）；issue #84 补 `/graph/all` 全量图谱（节点按 entity_type 形状/颜色区分，跨类型边虚线标出）覆盖 PRD P1-1 | §1/§14 | ✅ |
 | F-P1-05 | **公司图谱** | 公司—公司关系 + 外部 API①② 导入（只增不减 + status）｜仅只读视图完成；外部 API①② 待用户提供文档后实现 | §13 | 🟨 |
 | F-P1-06 | **各国收益曲线** | return_curve（R1–R5）对比渲染 + 地区起始年下限｜GET /returns/regions + SVG 五线对比 | §14 | ✅ |
-| F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜API + 屏已上线；生产写入链路已接通（UI 派生 invest/redeem + ingest 镜像 source=file，issue #80），真实库 ingest 验收后再 ✅ | §5 | 🟨 |
+| F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜API + 屏已上线；生产写入链路已接通（UI 派生 invest/redeem + ingest 镜像 source=file，issue #80），真实库 ingest 验收后再 ✅；编年史同步口径见 §19 决策备注（issue #86） | §5 | 🟨 |
 | F-P1-08 | **统一搜索** | LLM+embedding RAG（omlx 本地）条目检索装配 + serve 后处理｜⚠ 阻塞于本地 omlx 不可用，维持待续 | §18 | ⬜ |
 | F-P1-09 | 四类 UI 改数据操作 | 统一模板：年份×池 + 后传重算 + 失败整体拒绝 + overlay 同步｜useDataOp 钩子已用于投资/划拨屏 | §6.8/§19 | ✅ |
 

--- a/frontend/src/screens/Invest.jsx
+++ b/frontend/src/screens/Invest.jsx
@@ -8,16 +8,27 @@ const RISK = ['R1', 'R2', 'R3', 'R4', 'R5']
 export default function Invest() {
   const regions = useFetch('/api/v1/returns/regions')
   const ents = useFetch('/api/v1/entities?page_size=200')
+  const accts = useFetch('/api/v1/accounts?page_size=500')      // issue #87-2：币种下拉
   const inv = useFetch('/api/v1/investments')
 
   const [form, setForm] = useState({
     year: 1989, region: '欧洲', risk_lvl: 'R3', start_date: '1989-06-30',
-    allocs: [{ entity_id: '', currency: 'BEF', amount: '', all: false }],
+    allocs: [{ entity_id: '', currency: '', amount: '', all: false }],
   })
   const [localErr, setLocalErr] = useState(null)
 
   const regionMap = regions.data || {}
   const entityOpts = (ents.data?.items || []).filter(e => e.type === 'person' || e.type === 'company')
+  // issue #87-2：币种可选来自该主体真实账户池（active，排除关池只读终态 §6.6）
+  const currenciesFor = (eid) => {
+    const n = Number(eid)
+    if (!n) return []
+    const curMap = {}
+    for (const a of (accts.data?.items || [])) {
+      if (a.entity_id === n && a.status === 'active' && !curMap[a.currency]) curMap[a.currency] = true
+    }
+    return Object.keys(curMap)
+  }
 
   const submit = useDataOp(() => inv.refresh())
   const redeem = useDataOp(() => inv.refresh())
@@ -27,6 +38,12 @@ export default function Invest() {
   const setAlloc = (i, k, v) => setForm(f => ({
     ...f, allocs: f.allocs.map((a, idx) => idx === i ? { ...a, [k]: v } : a),
   }))
+  // issue #87-2：选中主体后自动填首个可用币种（避免自由文本拼错大小写落服务端才报无账户）
+  const pickEntity = (i, eid) => {
+    const cs = currenciesFor(eid)
+    setAlloc(i, 'entity_id', eid)
+    setAlloc(i, 'currency', cs[0] || '')
+  }
   const addAlloc = () => setForm(f => ({ ...f, allocs: [...f.allocs, { entity_id: '', currency: '', amount: '', all: false }] }))
   const delAlloc = (i) => setForm(f => ({ ...f, allocs: f.allocs.filter((_, idx) => idx !== i) }))
 
@@ -74,12 +91,15 @@ export default function Invest() {
           <div className="label" style={{ marginTop: 10 }}>分配（主体 × 币种 × 金额 / $全部）</div>
           {form.allocs.map((a, i) => (
             <div key={i} className="alloc-row">
-              <select value={a.entity_id} onChange={e => setAlloc(i, 'entity_id', e.target.value)} style={{ flex: 1 }}>
+              <select value={a.entity_id} onChange={e => pickEntity(i, e.target.value)} style={{ flex: 1 }}>
                 <option value="">—主体—</option>
                 {entityOpts.map(e => <option key={e.id} value={e.id}>{e.type}:{e.name}</option>)}
               </select>
-              <input placeholder="币种" value={a.currency} style={{ width: 76 }}
-                onChange={e => setAlloc(i, 'currency', e.target.value)} />
+              <select value={a.currency} style={{ width: 90 }}
+                onChange={e => setAlloc(i, 'currency', e.target.value)}>
+                <option value="">币种</option>
+                {currenciesFor(a.entity_id).map(c => <option key={c}>{c}</option>)}
+              </select>
               <input type="number" placeholder="金额" value={a.amount} disabled={a.all} style={{ width: 90 }}
                 onChange={e => setAlloc(i, 'amount', e.target.value)} />
               <label className="chk"><input type="checkbox" checked={a.all}

--- a/frontend/src/screens/Returns.jsx
+++ b/frontend/src/screens/Returns.jsx
@@ -4,12 +4,16 @@ import { Field } from './ui'
 
 const RISK_COLOR = { R1: 'var(--s3)', R2: '#2a78d6', R3: '#8878e0', R4: 'var(--s2)', R5: 'var(--crit)' }
 const RISK_ORDER = ['R1', 'R2', 'R3', 'R4', 'R5']
-const COUNTRIES = ['比利时', '卢森堡', '荷兰', '丹麦', '瑞典', '美国', '英国', '中国香港', '中国大陆']
 
-/** F-P1-06 各国收益曲线：R1–R5 五条 SVG 线对比。 */
+/** F-P1-06 各国收益曲线：R1–R5 五条 SVG 线对比。
+ *  issue #87-3：国家下拉来自 /returns/countries，不再前端硬编码 9 国。 */
 export default function Returns() {
-  const [country, setCountry] = useState('比利时')
-  const data = useFetch(country ? `/api/v1/returns?country=${encodeURIComponent(country)}&page_size=500` : null)
+  const [country, setCountry] = useState('')
+  const countries = useFetch('/api/v1/returns/countries')
+  const countryList = countries.data?.countries || []
+  // 国家列表加载后，取当前选中在库者；否则回退首个在库国家（避免硬编码默认）
+  const effective = (country && countryList.includes(country)) ? country : (countryList[0] || '比利时')
+  const data = useFetch(effective ? `/api/v1/returns?country=${encodeURIComponent(effective)}&page_size=500` : null)
   const regions = useFetch('/api/v1/returns/regions')
 
   const series = useMemo(() => {
@@ -28,9 +32,10 @@ export default function Returns() {
       <div className="panel">
         <h3>各国收益曲线（R1–R5 对比）</h3>
         <p className="note">DESIGN §14 returns · §19.3 地区起始年下限由 /returns/regions 标注</p>
-        <Field label="国家">
-          <select value={country} onChange={e => setCountry(e.target.value)}>
-            {COUNTRIES.map(c => <option key={c}>{c}</option>)}
+        <Field label="国家（来自 /returns/countries）">
+          <select value={effective} onChange={e => setCountry(e.target.value)}>
+            {countryList.length ? countryList.map(c => <option key={c}>{c}</option>)
+              : <option>{effective}</option>}
           </select>
         </Field>
         <div className="plot" style={{ height: 300 }}>

--- a/frontend/src/screens/Transfer.jsx
+++ b/frontend/src/screens/Transfer.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useDataOp, useFetch } from './useDataOp'
 import { ErrorBox, Field } from './ui'
 
@@ -9,20 +9,34 @@ export default function Transfer() {
   const op = useDataOp()
 
   const [form, setForm] = useState({
-    year: 2001, source_account_id: '', target_entity_id: '', target_currency: 'USD', amount: '',
+    year: 2001, source_account_id: '', target_entity_id: '', target_currency: '', amount: '',
   })
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+  const fx = useFetch(form.year ? `/api/v1/exchange-rates?year=${form.year}&page_size=500` : null)
 
   const acctOpts = accounts.data?.items || []
   const entOpts = (entities.data?.items || []).filter(e => e.type === 'person' || e.type === 'company')
   const src = acctOpts.find(a => a.id === Number(form.source_account_id))
+
+  // issue #87-1：目标币种下拉 = 源币种（同币划拨）+ 该年与源币种有正向/反向汇率的方向
+  const validTargets = useMemo(() => {
+    const s = new Set()
+    if (src?.currency) s.add(src.currency)
+    for (const r of (fx.data?.items || [])) {
+      if (r.from === src?.currency) s.add(r.to)
+      if (r.to === src?.currency) s.add(r.from)          // 反向可用
+    }
+    return [...s].sort()
+  }, [fx.data, src])
+  // 源账户/年份变化后目标币种随之回落到合法首项（避免显示与提交不一致）
+  const effTarget = validTargets.includes(form.target_currency) ? form.target_currency : (validTargets[0] || '')
 
   const doSubmit = async () => {
     if (!form.source_account_id || !form.target_entity_id) return
     const res = await op.submit('/api/v1/transfers', {
       source_account_id: Number(form.source_account_id),
       target_entity_id: Number(form.target_entity_id),
-      target_currency: form.target_currency,
+      target_currency: effTarget || form.target_currency,
       amount: Number(form.amount),
       year: Number(form.year),
     })
@@ -60,8 +74,12 @@ export default function Transfer() {
               </select>
             </Field>
             <Field label="目标币种">
-              <input value={form.target_currency} style={{ width: 90 }}
-                onChange={e => set('target_currency', e.target.value)} />
+              <select value={effTarget}
+                style={{ width: 110 }}
+                onChange={e => set('target_currency', e.target.value)}>
+                <option value="">币种</option>
+                {validTargets.map(c => <option key={c}>{c}</option>)}
+              </select>
             </Field>
           </div>
           <Field label="金额（源币）">

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ from sqlalchemy.pool import StaticPool
 from app.api.app import app
 from app.api.deps import get_db
 from app.db import Base
-from app.model import Account, Entity, ExchangeRate, Snapshot, TimelineEvent
+from app.model import Account, Entity, ExchangeRate, ReturnCurve, Snapshot, TimelineEvent
 
 
 @pytest.fixture
@@ -206,3 +206,38 @@ class TestCorsMiddleware:
         assert "http://127.0.0.1:5173" in _CORS_ORIGINS
         cors_mw = [m for m in app.user_middleware if "CORS" in m.cls.__name__]
         assert len(cors_mw) == 1
+
+
+class TestIssue87Endpoints:
+    """issue #87：/returns/countries 动态国家列表 + exchange-rates 按年筛方向。
+
+    两个新端点是"静态路由先于动态 /returns、/exchange-rates"展开的补充；
+    验证不吞路由且按预期返回。
+    """
+
+    def test_returns_countries_distinct(self, client):
+        c, Session = client
+        s = Session()
+        s.add(ReturnCurve(country="比利时", risk_lvl="R3", year=1980, rate=10.0))
+        s.add(ReturnCurve(country="比利时", risk_lvl="R2", year=1981, rate=5.0))
+        s.add(ReturnCurve(country="卢森堡", risk_lvl="R3", year=1980, rate=8.0))
+        s.commit()
+        r = c.get("/api/v1/returns/countries")
+        assert r.status_code == 200
+        assert r.json()["countries"] == ["卢森堡", "比利时"]      # distinct + 排序（字典序）
+
+    def test_exchange_rates_year_filter_and_routes_static_first(self, client):
+        c, Session = client
+        s = Session()
+        s.add(ExchangeRate(fx_from="BEF", fx_to="EUR", year=1980, rate=0.024789))
+        s.add(ExchangeRate(fx_from="BEF", fx_to="EUR", year=1981, rate=0.025))
+        s.add(ExchangeRate(fx_from="BEF", fx_to="USD", year=1980, rate=0.02))
+        s.commit()
+        # 静态路由 /exchange-rates 与 /returns 不受 /returns/countries 影响
+        r = c.get("/api/v1/exchange-rates?year=1980&page_size=50")
+        assert r.status_code == 200
+        items = r.json()["items"]
+        assert len(items) == 2                               # 仅 1980 两条（1981 被 year 筛掉）
+        # /exchange-rates?year=1 的长整形校验（year 非路由后缀）
+        r2 = c.get("/api/v1/exchange-rates?year=1981")
+        assert [i["from"] for i in r2.json()["items"]] == ["BEF"]

--- a/tests/test_issue85_pool_in_transit.py
+++ b/tests/test_issue85_pool_in_transit.py
@@ -1,0 +1,158 @@
+"""Unit tests for issue #85：专款池在途 scope（DESIGN §19.4）。
+
+净值口径 = 银行 + 专款池合计；投资期间（划出后~赎回前）总净值**不变**，资金在途不凹陷。
+
+覆盖：
+1. 日级 as-of（calendar.snapshot_as_of）：投资期间（6-30/11-30）family:total 与不投资一致；
+2. 赎回后 family 只增收益（含负收益）；
+3. 年快照（rebuild_snapshots）：未赎回年末 family:total/entity:* 同样加回在途本金；
+4. pool_in_transit 直接单测。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import BigInteger, Column, Integer, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.calendar import snapshot_as_of
+from app.core.invest import create_investment, redeem_investment
+from app.core.snapshot import pool_in_transit, rebuild_snapshots
+from app.db import Base
+from app.model import Account, Entity, ExchangeRate, LedgerEntry, ReturnCurve, Snapshot
+
+
+@pytest.fixture
+def session():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed(session, *, cash: float = 1000, cur: str = "BEF", fx_to_usd: float = 0.02):
+    """Henri Peeters BEF 账户 + 1980 现金 + BEF→USD 汇率 + 1980 比利时 R3 收益 10%。"""
+    h = Entity(entity_type="person", name="Henri Peeters")
+    session.add(h)
+    session.flush()
+    a = Account(entity_id=h.id, currency=cur)
+    session.add(a)
+    session.flush()
+    session.add(LedgerEntry(account_id=a.id, date=date(1980, 1, 1),
+                            inflow=cash, balance=cash, kind="income", reason="初始现金"))
+    session.add(ExchangeRate(fx_from=cur, fx_to="USD", year=1980, rate=fx_to_usd))
+    session.add(ReturnCurve(country="比利时", risk_lvl="R3", year=1980, rate=10.0))
+    session.flush()
+    return h, a
+
+
+def _family_asof(session, as_of: date) -> float:
+    snaps = snapshot_as_of(session, as_of)
+    return next(s["value"] for s in snaps if s["scope"] == "family:total")
+
+
+def _family(session, y: int):
+    """从 Snapshot 表读该年 family:total（rebuild 结果）。"""
+    for s in session.query(Snapshot).filter(
+            Snapshot.scope == "family:total", Snapshot.as_of_year == y):
+        return float(s.value)
+    return None
+
+
+def test_mid_year_asof_invariant_during_invest( session):
+    """5-01 投 100、未赎回：6-30 / 11-30 family:total 与不投资一致（1000 BEF = 20 USD）。"""
+    h, a = _seed(session)
+    base = _family_asof(session, date(1980, 6, 30))
+    assert base == pytest.approx(20.0)                      # 1000 BEF × 0.02
+
+    create_investment(session, year=1980, region="欧洲", risk_lvl="R3",
+                      start_date=date(1980, 5, 1),
+                      allocs=[{"entity_id": h.id, "currency": "BEF", "amount": 100}])
+    session.flush()
+
+    assert _family_asof(session, date(1980, 6, 30)) == pytest.approx(base)   # 不变
+    assert _family_asof(session, date(1980, 11, 30)) == pytest.approx(base)  # 不变
+    # entity 口径同样不变（银行 900 + 在途 100 = 1000）
+    e = next(s["value"] for s in snapshot_as_of(session, date(1980, 6, 30))
+             if s["scope"] == f"entity:{h.id}:BEF")
+    assert e == pytest.approx(1000.0)
+    # account scope 仍是纯银行（划出凹陷），在途不并入账户现金
+    acc = next(s["value"] for s in snapshot_as_of(session, date(1980, 6, 30))
+               if s["scope"].startswith("account:"))
+    assert acc == pytest.approx(900.0)
+
+
+def test_redeem_sets_pool_zero_and_returns_only_increment( session):
+    """赎回后池清空；下一年度 family 只反映收益增量。"""
+    h, a = _seed(session)
+    inv = create_investment(session, year=1980, region="欧洲", risk_lvl="R3",
+                            start_date=date(1980, 5, 1),
+                            allocs=[{"entity_id": h.id, "currency": "BEF", "amount": 100}])
+    session.flush()
+    assert pool_in_transit(session, date(1980, 6, 30)) == {(h.id, "BEF"): pytest.approx(100)}
+
+    redeem_investment(session, inv)
+    session.flush()
+    # 赎回日 12-30 起 pool 归零
+    assert pool_in_transit(session, date(1980, 12, 30)) == {}
+    # 12-31 family = 本金 1000 − 100 + 赎回 100 + 收益 → 只增收益
+    interest = _interest(session, inv)
+    assert _family_asof(session, date(1980, 12, 31)) == pytest.approx(
+        round((1000 + interest) * 0.02, 2))
+
+
+def test_annual_snapshot_includes_unredeemed_pool( session):
+    """年末未赎回：rebuild 的 family:total/entity:* 加回在途本金（净值=银行+池）。"""
+    h, a = _seed(session)
+    base = _family_asof(session, date(1980, 12, 30))        # 未投资基准：1000 BEF = 20 USD
+    create_investment(session, year=1980, region="欧洲", risk_lvl="R3",
+                      start_date=date(1980, 5, 1),
+                      allocs=[{"entity_id": h.id, "currency": "BEF", "amount": 100}])
+    session.flush()
+    rebuild_snapshots(session, range(1980, 1981))
+    # 银行 900 + 在途 100 = 1000 BEF = 20 USD，与不投资基准一致
+    assert _family(session, 1980) == pytest.approx(20.0)
+    assert _family(session, 1980) == pytest.approx(base)
+    ent = next(float(s.value) for s in session.query(Snapshot).filter(
+        Snapshot.scope == f"entity:{h.id}:BEF", Snapshot.as_of_year == 1980))
+    assert ent == pytest.approx(1000.0)
+
+
+def test_annual_snapshot_redeemed_family( session):
+    """年末已赎回：rebuild 的 family:total 只反映收益增量（池清空）。"""
+    h, a = _seed(session)
+    inv = create_investment(session, year=1980, region="欧洲", risk_lvl="R3",
+                            start_date=date(1980, 5, 1),
+                            allocs=[{"entity_id": h.id, "currency": "BEF", "amount": 100}])
+    redeem_investment(session, inv)
+    session.flush()
+    rebuild_snapshots(session, range(1980, 1981))
+    interest = _interest(session, inv)
+    assert _family(session, 1980) == pytest.approx(round((1000 + interest) * 0.02, 2))
+
+
+def _interest(session, inv) -> float:
+    from app.core.invest import compute_interest
+    return compute_interest(session, inv)[0]["interest"]
+
+
+def test_pool_in_transit_edge( session):
+    """start_date 当日入池；赎回前在途；跨期无输入返回空。"""
+    h, a = _seed(session)
+    assert pool_in_transit(session, date(1980, 4, 30)) == {}   # 投资前无池
+    inv = create_investment(session, year=1980, region="欧洲", risk_lvl="R3",
+                            start_date=date(1980, 5, 1),
+                            allocs=[{"entity_id": h.id, "currency": "BEF", "amount": 50}])
+    session.flush()
+    assert pool_in_transit(session, date(1980, 5, 1)) == {(h.id, "BEF"): pytest.approx(50)}
+    assert pool_in_transit(session, date(1980, 12, 29)) == {(h.id, "BEF"): pytest.approx(50)}
+    redeem_investment(session, inv)
+    session.flush()
+    assert pool_in_transit(session, date(1980, 12, 30)) == {}

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -81,6 +81,32 @@ def test_fx_conversion_correct(session):
     assert out["target_amount"] == pytest.approx(round(100 * 0.024789, 2), abs=0.01)
 
 
+def test_fx_reverse_pair_when_forward_missing_issue_87( session):
+    """issue #87-1：仅存 EUR→BEF 反向行时，BEF→EUR 换汇应取倒数成交。"""
+    h, j, a1, a2, a3 = _seed(session)
+    session.add(ExchangeRate(fx_from="EUR", fx_to="BEF", year=1980, rate=1 / 0.024789))
+    session.flush()
+    out = transfer(session, source_account_id=a1.id, target_entity_id=h.id,
+                   target_currency="EUR", amount=100, year=1980)
+    session.flush()
+    assert out["operation"] == "换汇"
+    # 反向倒数折算：100 BEF × (1/rate_eur_to_bef) = 100 × 0.024789
+    assert out["target_amount"] == pytest.approx(round(100 * 0.024789, 2), abs=0.01)
+
+
+def test_fx_missing_error_lists_available_directions( session):
+    """issue #87-1：缺目标方向但该年有其他方向时，错误信息列出可用方向（含反向提示）。"""
+    h, j, a1, a2, a3 = _seed(session)
+    session.add(ExchangeRate(fx_from="BEF", fx_to="USD", year=1980, rate=0.02))
+    session.flush()
+    with pytest.raises(ValidationError) as e:
+        transfer(session, source_account_id=a1.id, target_entity_id=h.id,
+                 target_currency="EUR", amount=100, year=1980)
+    msg = str(e.value.detail)
+    assert "BEF→EUR" in msg
+    assert "BEF→USD" in msg      # 可用方向被列出
+
+
 def test_transfer_causing_negative_rejected(session):
     h, j, a1, a2, a3 = _seed(session)
     # 该账户 1981 又有一笔 950 支出 → 1980 划出 60 后 1981 年未拐负


### PR DESCRIPTION
**关联 issues**：#85、#86、#87（一并，沿用 `fix/80-81-82` / `fix/83-84` 批量合流模式）

## #85 [P2][feature-gap] §19.4 净值口径缺口：投资期间家族净值凹陷
- `app/core/snapshot.py` 新增 `pool_in_transit`：净值 = 银行 + 专款池合计
  （= Σ(`kind='investment'` 划出) − Σ(`kind='pool'` 划回)，按 as-of 日期累计，不依赖 redeemed_at 防重标记）。
- `calendar.snapshot_as_of`（日级 as-of）与 `rebuild_snapshots`（年）的 `entity:*`/`family:total`
  聚合时加回在途本金 → 投资划出后~赎回前 6-30/11-30 **总净值不变**；`account:*` 保留纯银行余额。
- 顺带修复 `calendar.snapshot_as_of` 既有 **Decimal/float 混用** 隐性 bug（issue #28 口径）。
- 验收：5 个单测覆盖 in-transit 不变性 / 赎回只增收益 / 年快照未赎回加回。

## #86 [P3][docs] DESIGN 回写
- §19 补「实现决策备注」：UI 派生操作（投资/划拨换汇）编年史**直写 `timeline_event(overlay=True)`**，
  不经 `user_data_overlay` md 通道；理由 + 后果 + P2-05 处理策略占位。
- §20 F-P0-08/09、F-P1-07 状态与实现核对落注。

## #87 [P3][hygiene]
1. 换汇仅认正向货币对 → `transfer._fx_rate` 缺正向取**反向倒数**成交（精确数学逆）+ 错误列出该年可用方向。
2. `Invest.jsx` 币种自由文本 → 下拉来自 `/api/v1/accounts?entity_id=` 真实账户池（选主体自动填）。
3. `Returns.jsx` 硬编码 9 国 → 新端点 `GET /api/v1/returns/countries`（distinct）动态渲染；`/exchange-rates` 补 `year` 筛。
4. `require_importer` 零挂载 → DESIGN §14.1 备注当前授权矩阵空转 + 待受限写端点上线时强制挂载并补 403 测试（代码不动）。

## 验证
- `pytest tests`：**244 passed**（基线 235 → +9：pool in-transit ×5、reverse fx ×2、api ×2）
- `npm run build`（frontend）：✓ 通过