### PR TITLE
feat(p1): F-P1-05 公司图谱外部 API① 导入（公司图谱页按钮触发）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ data/
 # Claude Code 本地配置（含本地路径，不提交）
 .claude/
 
-# 凭证 / 密钥
+# 凭证 / 密钥（真实凭据一律 ignore）
 secrets.local.yaml
 secrets*.yaml
+!secrets.local.example.yaml

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -368,9 +368,31 @@ def graph_persons(db: Session = Depends(get_db)):
 def graph_companies(db: Session = Depends(get_db)):
     """公司图谱只读视图（公司—公司关系）。
 
-    注：外部 API①② 对接（importers）留待外部系统文档后实现（F-P1-05 未完成部分）。
+    外部 API① 导入走 POST /graph/companies/import（F-P1-05；F-U7 UI 按钮触发）。
     """
     return company_graph(db)
+
+
+@app.post(API_PREFIX + "/graph/companies/import")
+def import_companies(db: Session = Depends(get_db)):
+    """触发外部系统 API① 公司基础信息导入（DESIGN §13.1 · F-P1-05 / F-U7）。
+
+    公司图谱页「获取/导入公司」按钮调用：拉取外部 /public/companies → 按只增不减
+    upsert entity(company) + 股权关系 → commit → 返回统计 + 刷新后的公司图谱。
+    本端点是 DESIGN §6.6/§13.1 明示的 UI 用户触发通道，故不挂 require_importer（§14.1
+    注记不适用：此为 UI 派生动作）。网络/凭据失败 → 502/401，不落库。
+    """
+    from app.ingest.importers.company_info import run_external_company_import
+    import httpx
+    try:
+        stats = run_external_company_import(db)
+        db.commit()
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code if e.response is not None else 502
+        raise HTTPException(status_code=status, detail=f"外部 API 请求失败（HTTP {status}）")
+    except (httpx.RequestError, httpx.TimeoutException):
+        raise HTTPException(status_code=502, detail="无法连接外部系统 API（请确认其已启动）")
+    return {"stats": stats, "graph": company_graph(db)}
 
 
 @app.get(API_PREFIX + "/graph/all")

--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,12 @@ class EnvConfig:
     llm_model_context: int | None = field(default_factory=lambda: _env_int("LLM_MODEL_CONTEXT", None))
     embed_dim: int | None = field(default_factory=lambda: _env_int("EMBED_DIM", None))
 
+    # 外部系统 API①（公司基础信息，DESIGN §13/§13.3 · F-P1-05）：URL 指向其 `/api/v1` 根。
+    # 优先级：环境变量 EXTERNAL_API_BASE_URL > 该 per-env 默认。凭据（用户名/密码）不入 config，
+    # 走 secrets.local.yaml + 环境变量（见 app/ingest/importers/_client.py）。
+    external_api_url: str = field(
+        default_factory=lambda: _env_str("EXTERNAL_API_BASE_URL", "http://127.0.0.1:7273"))
+
 
 def _dsn(db_name: str) -> str:
     host = os.environ.get("PGHOST", "127.0.0.1")
@@ -75,6 +81,14 @@ def get_config(env: str | None = None) -> EnvConfig:
         "test": "data/overlay-test",
         "prod": "data/overlay",
     }
+    # 外部系统 API① 公司基础信息（DESIGN §13）；dev/test 连 7273，prod 连 7274。
+    # 环境变量 EXTERNAL_API_BASE_URL 可覆盖（default_factory 已读；这里仅在未设时给 per-env 默认）。
+    external_urls = {
+        "dev":  "http://127.0.0.1:7273",
+        "test": "http://127.0.0.1:7273",
+        "prod": "http://127.0.0.1:7274",
+    }
+    external_api_url = os.environ.get("EXTERNAL_API_BASE_URL") or external_urls[env]
 
     return EnvConfig(
         env=env,
@@ -82,6 +96,7 @@ def get_config(env: str | None = None) -> EnvConfig:
         source_dir=source_dir,
         input_dir=PROJECT_ROOT / inputs[env],
         overlay_dir=PROJECT_ROOT / overlays[env],
+        external_api_url=external_api_url,
     )
 
 

--- a/app/ingest/importers/__init__.py
+++ b/app/ingest/importers/__init__.py
@@ -1,0 +1,3 @@
+"""__init__：重命名为导入空包。外部 importers 放置路径（DESIGN §13.3 ingest/importers/{provider}.py）。
+provider 约定：company-info（API① 公司基础信息）、labor-cost（API② 用工成本，未实现）。
+"""

--- a/app/ingest/importers/_client.py
+++ b/app/ingest/importers/_client.py
@@ -1,0 +1,58 @@
+"""外部系统 API① 连接与凭据加载（DESIGN §13.3 · F-P1-05）。
+
+凭据铁律（DESIGN §13.3）：外部 API 凭据放本地 `secrets.local.yaml`（.gitignore 排除，
+不入 git、不入 DB）；可被环境变量覆盖；在本模块读取，不落入日志/notification。
+
+URL 优先级：环境变量 EXTERNAL_API_BASE_URL > secrets.local.yaml external_api.base_url
+            > config.CONFIG.external_api_url（per-env 默认 7273/7274）。
+用户名/密码优先级：环境变量 EXTERNAL_API_USER / EXTERNAL_API_PASSWORD
+            > secrets.local.yaml external_api.username / .password。
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+from app.config import PROJECT_ROOT, CONFIG
+
+_SECRETS_PATH = PROJECT_ROOT / "secrets.local.yaml"
+
+
+def _load_secrets() -> dict:
+    """读本地 secrets.local.yaml；文件缺失/非法 → 空 dict（不抛）。
+    yaml.safe_load，字段 keys 为 external_api: {base_url, username, password}。"""
+    if not _SECRETS_PATH.exists():
+        return {}
+    try:
+        with _SECRETS_PATH.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except (yaml.YAMLError, OSError):
+        return {}
+    return data.get("external_api") or {}
+
+
+def load(base_url: str | None = None) -> tuple[str, str, str]:
+    """解析 (外部 base_url, username, password)。
+
+    base_url 形如 `http://127.0.0.1:7273`（外部系统 `/api/v1` 根；具体端点路径后续拼接）。
+    """
+    sec = _load_secrets()
+    url = (
+        base_url
+        or os.environ.get("EXTERNAL_API_BASE_URL")
+        or sec.get("base_url")
+        or CONFIG.external_api_url
+    )
+    username = (
+        os.environ.get("EXTERNAL_API_USER")
+        or sec.get("username")
+        or ""
+    )
+    password = (
+        os.environ.get("EXTERNAL_API_PASSWORD")
+        or sec.get("password")
+        or ""
+    )
+    return url, username, password

--- a/app/ingest/importers/company_info.py
+++ b/app/ingest/importers/company_info.py
@@ -1,0 +1,154 @@
+"""外部系统 API① 公司基础信息导入（DESIGN §13.1/§13.3 · F-P1-05）。
+
+GET /public/companies（JWT）→ 隶属公司 + 股权结构（internal/external company / person 股东
++ 持股比 + 状态 + 开停业日期）→ 按「只增不减」幂等 upsert 进 entity/relationship：
+
+- 每个公司 → `entity(entity_type='company', name)` upsert，`source='external-api'`，`status` 映射
+  （opened/closed），开停业日期/外部ID/持股比落 `fields` JSONB（Entity 无对应列，不开迁移）。
+- 每个 shareholder → owner 实体（公司→company，自然人→person，miss 则 upsert）+ 指向本公司的
+  `relationship(rel_type='holds')`，有效期窗口 since/until_year 取公司开停业年份。
+
+只增不减：全部走 writer.upsert_entity / upsert_relationship（幂等，永不 DELETE）。
+触发：公司图谱页「获取/导入公司」按钮 → POST /api/v1/graph/companies/import（F-U7）。
+"""
+from __future__ import annotations
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.ingest import writer
+from app.ingest.importers._client import load
+from app.model import Entity
+
+
+def _year(d: str | None) -> int | None:
+    """'YYYY-MM-DD' → 年份；空/非法 → None。"""
+    if not d:
+        return None
+    try:
+        return int(str(d)[:4])
+    except (TypeError, ValueError):
+        return None
+
+
+def login(url: str, username: str, password: str, client: httpx.Client | None = None) -> str:
+    """POST {url}/auth/login → 返回 access_token。凭据错误 → 抛 httpx.HTTPStatusError。"""
+    owned = client is None
+    client = client or httpx.Client(timeout=15)
+    try:
+        r = client.post(f"{url}/auth/login", json={"username": username, "password": password})
+        r.raise_for_status()
+        return r.json()["access_token"]
+    finally:
+        if owned:
+            client.close()
+
+
+def fetch_companies(url: str, token: str, client: httpx.Client | None = None) -> list[dict]:
+    """GET {url}/public/companies（Bearer）→ 隶属公司数组。"""
+    owned = client is None
+    client = client or httpx.Client(timeout=30)
+    try:
+        r = client.get(f"{url}/public/companies", headers={"Authorization": f"Bearer {token}"})
+        r.raise_for_status()
+        return r.json()
+    finally:
+        if owned:
+            client.close()
+
+
+def _shareholder_owner(session: Session, sh: dict) -> tuple[str, int, bool]:
+    """从 shareholder 行解析 owner 实体：
+
+    - internal_company_name / external_company_name → company 实体（公司股东）
+    - person_name → person 实体（自然人股东，miss 则新建）
+    返回 (owner_type, owner_id, created)。created 表示本次是否新建该实体。
+    三者互斥；都空 → 返回 (None, None, False)。"""
+    owner = None
+    otype = "company"
+    if sh.get("internal_company_name"):
+        owner = sh["internal_company_name"]
+    elif sh.get("external_company_name"):
+        owner = sh["external_company_name"]
+    elif sh.get("person_name"):
+        owner = sh["person_name"]
+        otype = "person"
+    if not owner:
+        return None, None, False
+    existed = session.execute(
+        select(Entity.id).where(Entity.entity_type == otype, Entity.name == owner)
+    ).scalar_one_or_none() is not None
+    ent = writer.upsert_entity(session, otype, owner, source="external-api")
+    return otype, ent.id, (not existed)
+
+
+def _normalize_status(rec: dict) -> str:
+    """公司状态：文档显式 status（opened/closed）优先；否则 closing_date 有→closed，否则按 is_active。"""
+    s = (rec.get("status") or "").strip().lower()
+    if s in ("opened", "closed"):
+        return s
+    if rec.get("closing_date"):
+        return "closed"
+    return "opened" if rec.get("is_active", True) else "closed"
+
+
+def import_external_companies(session: Session, companies: list[dict]) -> dict:
+    """公司列表（外部 API 原始 dict）→ 幂等 upsert company 实体 + 股权关系。
+
+    可离线直接喂 dict 单测，不联网。返回统计数据。"""
+    stats = {"companies": 0, "companies_created": 0,
+             "rels": 0, "persons_created": 0}
+    for rec in companies:
+        name = (rec.get("name") or "").strip()
+        if not name:
+            continue
+        fields = {
+            "external_id": rec.get("id"),
+            "opening_date": rec.get("opening_date"),
+            "closing_date": rec.get("closing_date"),
+            "is_active": rec.get("is_active"),
+        }
+        comp = writer.upsert_entity(
+            session, "company", name, source="external-api", fields=fields)
+        # created 判定：status 原来为空而本次落到非空（只增不减；新写才置 status）
+        if comp.status is None:
+            stats["companies_created"] += 1
+        comp.status = _normalize_status(rec)
+
+        # 股权结构 → 股东 owner 实体 + holds 边 + 持股比归集
+        pct_map: dict[str, float] = {}
+        opening_d = _year(rec.get("opening_date"))
+        closing_d = _year(rec.get("closing_date"))
+        for sh in rec.get("shareholders") or []:
+            otype, oid, created = _shareholder_owner(session, sh)
+            if oid is None:
+                continue
+            if created and otype == "person":
+                stats["persons_created"] += 1
+            rel = writer.upsert_relationship(
+                session, oid, comp.id, "holds",
+                since_year=opening_d, until_year=closing_d,
+            )
+            if rel is not None:
+                stats["rels"] += 1
+            owner_name = sh.get("internal_company_name") or sh.get("external_company_name") \
+                or sh.get("person_name")
+            pct = sh.get("ownership_pct")
+            if owner_name and pct is not None:
+                pct_map[owner_name] = float(pct)
+        if pct_map:
+            comp.fields = {**(comp.fields or {}), "shareholders_pct": pct_map}
+
+        stats["companies"] += 1
+    return stats
+
+
+def run_external_company_import(session: Session, *,
+                                base_url: str | None = None,
+                                client: httpx.Client | None = None) -> dict:
+    """端到端：load 凭据 → login → fetch 公司 → import。返回 import 统计。"""
+    url, username, password = load(base_url=base_url)
+    token = login(url, username, password, client=client)
+    companies = fetch_companies(url, token, client=client)
+    return import_external_companies(session, companies)

--- a/app/ingest/importers/company_info.py
+++ b/app/ingest/importers/company_info.py
@@ -32,12 +32,24 @@ def _year(d: str | None) -> int | None:
         return None
 
 
+def _api_root(base_url: str) -> str:
+    """把 base_url（host:port，如 http://127.0.0.1:7273）归一为 API 根（含 /api/v1）。
+
+    外部系统端点均在 /api/v1 前缀下（文档 curl：/api/v1/auth/login、/api/v1/public/companies）。
+    base_url 已含 /api/v1 时直接复用，避免重复。"""
+    base = (base_url or "").rstrip("/")
+    if base.endswith("/api/v1"):
+        return base
+    return base + "/api/v1"
+
+
 def login(url: str, username: str, password: str, client: httpx.Client | None = None) -> str:
-    """POST {url}/auth/login → 返回 access_token。凭据错误 → 抛 httpx.HTTPStatusError。"""
+    """POST {api_root}/auth/login → 返回 access_token。凭据错误 → 抛 httpx.HTTPStatusError。"""
     owned = client is None
     client = client or httpx.Client(timeout=15)
     try:
-        r = client.post(f"{url}/auth/login", json={"username": username, "password": password})
+        r = client.post(f"{_api_root(url)}/auth/login",
+                        json={"username": username, "password": password})
         r.raise_for_status()
         return r.json()["access_token"]
     finally:
@@ -46,11 +58,12 @@ def login(url: str, username: str, password: str, client: httpx.Client | None = 
 
 
 def fetch_companies(url: str, token: str, client: httpx.Client | None = None) -> list[dict]:
-    """GET {url}/public/companies（Bearer）→ 隶属公司数组。"""
+    """GET {api_root}/public/companies（Bearer）→ 隶属公司数组。"""
     owned = client is None
     client = client or httpx.Client(timeout=30)
     try:
-        r = client.get(f"{url}/public/companies", headers={"Authorization": f"Bearer {token}"})
+        r = client.get(f"{_api_root(url)}/public/companies",
+                       headers={"Authorization": f"Bearer {token}"})
         r.raise_for_status()
         return r.json()
     finally:

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -36,11 +36,14 @@ def upsert_entity(session: Session, entity_type: str, name: str,
 
 
 def upsert_relationship(session: Session, from_entity_id: int, to_entity_id: int,
-                        rel_type: str, source_file: str | None = None) -> Relationship | None:
+                        rel_type: str, source_file: str | None = None,
+                        since_year: int | None = None,
+                        until_year: int | None = None) -> Relationship | None:
     """按 (from, to, rel_type) 幂等 upsert Relationship；同 (from, to, rel_type) 已存在 → 复用。
 
     issue #27：character 关系字段解析后必须持久化进 relationship 表，P1 人物图谱前置。
-    返回 None 表示 from==to（自环）跳过。
+    since_year/until_year：可选，覆盖新建/已存在关系的生效年窗（外部 API① 公司持股用；
+    保持同键自环跳过语义）。返回 None 表示 from==to（自环）跳过。
     """
     if from_entity_id == to_entity_id:
         return None
@@ -52,10 +55,15 @@ def upsert_relationship(session: Session, from_entity_id: int, to_entity_id: int
         ).limit(1)
     ).scalar_one_or_none()
     if exists is not None:
+        if since_year is not None:
+            exists.since_year = since_year
+        if until_year is not None:
+            exists.until_year = until_year
         return exists
     rel = Relationship(
         from_entity_id=from_entity_id, to_entity_id=to_entity_id,
         rel_type=rel_type, source_file=source_file,
+        since_year=since_year, until_year=until_year,
     )
     session.add(rel)
     session.flush()

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -593,6 +593,7 @@ class Importer(Protocol):
 ```
 - 配置 provider + 凭据（本地）；结果出现在「导入状态」屏；失败进入需人工处理。
 - **凭据存放**：外部 API 凭据放本地 `secrets.local.yaml`（**不入 git、不入 DB**）；adapter 只通过配置键读取，不在日志或 notification 中泄露。
+- **实现（API① · F-P1-05）**：`app/ingest/importers/company_info.py`（login→fetch `/public/companies`→按 `(entity_type='company', name)` 只增不减 upsert，source=`external-api`；股权结构→公司/自然人股东建实体 + `rel_type='holds'` 边，有效期窗取开停业年份；开停业日期/外部ID/持股比落 `entity.fields` JSONB，不开迁移）。凭据 `secrets.local.yaml` + 环境变量 `EXTERNAL_API_BASE_URL / EXTERNAL_API_USER / EXTERNAL_API_PASSWORD`，URL per-env 默认 dev/test 7273、prod 7274。触发：`POST /api/v1/graph/companies/import`（F-U7 公司图谱页按钮）。
 
 ---
 
@@ -858,7 +859,7 @@ UI 派生操作（投资创建/赎回、划拨换汇）的编年史同步为**�
 | F-P1-02 | **投资** | 专款池（分币种）走账 + 服务层校验（as-of/R起始年/年度幂等/覆盖连锁拒绝）｜§19.3 校验 422/409 + 划出(kind=investment)/赎回(pool+investment_income) 走账 | §19.3 | ✅ |
 | F-P1-03 | **划拨/换汇** | 划拨(同币)/换汇(按年汇率) + 转出向后全链不破负拒绝 + 编年史同步｜core/transfer.py，同币两笔净0、跨币缺该年汇率 422；破负预检为年末 as-of 口径（issue #93 §19.5 注记） | §19.5 | ✅ |
 | F-P1-04 | **人物图谱** | 人—人/人—公司关系可视化（ECharts graph）｜core/graph.py + SVG 环形静态布局（非 ECharts，交互留待）；issue #84 补 `/graph/all` 全量图谱（节点按 entity_type 形状/颜色区分，跨类型边虚线标出）覆盖 PRD P1-1 | §1/§14 | ✅ |
-| F-P1-05 | **公司图谱** | 公司—公司关系 + 外部 API①② 导入（只增不减 + status）｜仅只读视图完成；外部 API①② 待用户提供文档后实现 | §13 | 🟨 |
+| F-P1-05 | **公司图谱** | 公司—公司关系 + 外部 API①② 导入（只增不减 + status）｜**外部 API① 已实现**（`POST /graph/companies/import`，公司图谱页按钮触发，§13.3）；API②（用工成本）仍待文档 | §13 | 🟨 |
 | F-P1-06 | **各国收益曲线** | return_curve（R1–R5）对比渲染 + 地区起始年下限｜GET /returns/regions + SVG 五线对比 | §14 | ✅ |
 | F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜API + 屏已上线；生产写入链路已接通（UI 派生 invest/redeem + ingest 镜像 source=file，issue #80），真实库 ingest 验收后再 ✅；编年史同步口径见 §19 决策备注（issue #86） | §5 | 🟨 |
 | F-P1-08 | **统一搜索** | LLM+embedding RAG（omlx 本地）条目检索装配 + serve 后处理｜⚠ 阻塞于本地 omlx 不可用，维持待续 | §18 | ⬜ |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,8 @@ import Transfer from './screens/Transfer'
 import Returns from './screens/Returns'
 import Finance from './screens/Finance'
 import Graph from './screens/Graph'
+import { ErrorBox } from './screens/ui'
+import { useDataOp } from './screens/useDataOp'
 
 const TABS = [
   { key: 'dashboard', label: 'Dashboard' },
@@ -59,13 +61,48 @@ export default function App() {
         {active === 'returns' && <Returns />}
         {active === 'finance' && <Finance />}
         {active === 'persons' && <Graph url="/api/v1/graph/persons" />}
-        {active === 'companies' && <Graph url="/api/v1/graph/companies" />}
+        {active === 'companies' && <CompanyGraph />}
         {active === 'graphall' && <Graph url="/api/v1/graph/all" />}
         {(active === 'timeline' || active === 'search' || active === 'health') && (
           <Placeholder label={TABS.find(t => t.key === active).label} asOf={asOf} />
         )}
       </main>
     </div>
+  )
+}
+
+/**
+ * 公司图谱屏（F-P1-05 / F-U7）：公司图谱 + 右上「获取/导入公司」按钮，人工触发
+ * POST /api/v1/graph/companies/import（外部系统 API① 公司基础信息）→ 成功后 bump key
+ * 重挂载 Graph 重新拉取展示新节点/边（后端已在同一请求内 commit）。
+ */
+function CompanyGraph() {
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [stats, setStats] = useState(null)
+  const { submit, busy, error } = useDataOp(data => {
+    setStats(data?.stats || null)
+    setRefreshKey(k => k + 1)
+  })
+
+  const statsText = stats
+    ? `已处理 ${stats.companies} 家公司 · 新增 ${stats.companies_created} 家 · 股权关系 ${stats.rels} 条`
+    : null
+
+  return (
+    <Graph
+      key={refreshKey}
+      url="/api/v1/graph/companies"
+      action={
+        <>
+          <button className="ghost" disabled={busy}
+            onClick={() => submit('/api/v1/graph/companies/import', {})}>
+            {busy ? '导入中…' : '获取/导入公司'}
+          </button>
+          {statsText && <span className="note" style={{ marginLeft: 8 }}>{statsText}</span>}
+          <ErrorBox error={error} />
+        </>
+      }
+    />
   )
 }
 

--- a/frontend/src/screens/Graph.jsx
+++ b/frontend/src/screens/Graph.jsx
@@ -21,7 +21,7 @@ const TYPE_LABEL = {
  * 纯类型视图（/graph/persons、/graph/companies）单色；/graph/all 多类型混合。
  * 静态布局，无交互拖拽（G6/ECharts 留待需要交互时再换）。
  */
-export default function Graph({ url, emptyHint }) {
+export default function Graph({ url, emptyHint, action }) {
   const g = useFetch(url)
   const { nodes = [], edges = [] } = g.data || {}
   const isAll = url.startsWith('/api/v1/graph/all')
@@ -42,7 +42,7 @@ export default function Graph({ url, emptyHint }) {
   const pos = layout.pos || {}
   return (
     <div className="panel">
-      <h3>{title}</h3>
+      <h3>{title}{action && <span style={{ float: 'right', marginLeft: 8 }}>{action}</span>}</h3>
       <p className="note">只读视图 · {nodes.length} 节点 · {edges.length} 关系（rel_type 标注）{isAll ? ' · 形状/颜色按 entity_type 区分' : ''}</p>
       {nodes.length === 0 ? (
         <div className="plot"><span className="ph">{emptyHint || '暂无节点（需 entity/relationship 数据）'}</span></div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ python-dotenv>=1.0
 typer>=0.12
 fastapi>=0.115
 uvicorn[standard]>=0.30
+httpx>=0.27
+pyyaml>=6.0

--- a/secrets.local.example.yaml
+++ b/secrets.local.example.yaml
@@ -1,0 +1,8 @@
+# 外部系统 API 凭据模板——复制为 secrets.local.yaml（已被 .gitignore 排除，不入 git/DB）。
+# 结构：external_api: { base_url, username, password }
+# base_url 是外部系统 /api/v1 根；dev/test 默认 7273，prod 默认 7274（未设时走 config 默认）。
+# 均可被环境变量覆盖：EXTERNAL_API_BASE_URL / EXTERNAL_API_USER / EXTERNAL_API_PASSWORD。
+external_api:
+  base_url: http://127.0.0.1:7273
+  username: DASH_API
+  password: change-me

--- a/tests/test_company_import.py
+++ b/tests/test_company_import.py
@@ -1,0 +1,178 @@
+"""公司图谱外部 API① 导入（F-P1-05 · DESIGN §13）单测。
+
+覆盖：
+- import_external_companies：doc 样例映射（company 实体 + 自然人股东建 person 节点 +
+  rel_type='holds' 边 + status 映射 + fields 记开停业/持股比）。
+- 只增不减 / 幂等：同一批数据跑两次 → entity/关系计数不变，已存在公司不被新建。
+- 端点 POST /graph/companies/import：monkeypatch run_external_company_import 注入数据 →
+  200 + stats + 刷新后 graph（免网）。
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.app import app
+from app.api.deps import get_db
+from app.db import Base
+from app.ingest import writer
+from app.ingest.importers import company_info
+from app.model import Entity, Relationship
+
+
+@pytest.fixture
+def session():
+    """内存 SQLite 会话（StaticPool 共享连接；BigInteger 主键降级 Integer）。"""
+    from sqlalchemy import BigInteger, Integer
+
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    S = sessionmaker(bind=engine)
+    s = S()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _sample_companies():
+    return [
+        {
+            "id": 5,
+            "name": "Peeters Luxembourg S.à r.l.",
+            "is_active": True,
+            "opening_date": "1990-01-01",
+            "closing_date": None,
+            "status": "opened",
+            "shareholders": [
+                {"internal_company_name": "Family Asset Management SPRL",
+                 "ownership_pct": 100.0},
+                {"person_name": "Henri Peeters", "ownership_pct": 0.0},
+            ],
+        },
+        {
+            "id": 9,
+            "name": "Peeters Asia Ltd",
+            "is_active": False,
+            "opening_date": "1995-06-01",
+            "closing_date": "2005-12-31",
+            "status": "closed",
+            "shareholders": [
+                {"external_company_name": "Far East Holdings", "ownership_pct": 60.0},
+            ],
+        },
+    ]
+
+
+def _entities(s):
+    return {e.name: e for e in s.execute(select(Entity)).scalars().all()}
+
+
+class TestImportMapping:
+    def test_company_person_and_external_shareholders_map(self, session):
+        stats = company_info.import_external_companies(session, _sample_companies())
+        session.commit()
+
+        assert stats["companies"] == 2
+        assert stats["companies_created"] == 2
+        # 两个 company 实体 + 自然人股东 Henri Peeters
+        ent = _entities(session)
+        assert ent["Peeters Luxembourg S.à r.l."].entity_type == "company"
+        assert ent["Peeters Luxembourg S.à r.l."].status == "opened"
+        assert ent["Peeters Asia Ltd"].status == "closed"
+        assert ent["Family Asset Management SPRL"].entity_type == "company"
+        assert ent["Far East Holdings"].entity_type == "company"
+        assert ent["Henri Peeters"].entity_type == "person"
+        assert "opening_date" in ent["Peeters Luxembourg S.à r.l."].fields
+
+        # holds 边：Family AM → Lux，Henri → Lux，Far East → Asia（rel_type='holds' + 年窗）
+        rels = session.execute(select(Relationship)).scalars().all()
+        assert len(rels) == 3
+        assert set(r.rel_type for r in rels) == {"holds"}
+        # 直接校验年窗落点
+        lux = ent["Peeters Luxembourg S.à r.l."]
+        lux_rels = [r for r in rels if r.to_entity_id == lux.id]
+        assert all(r.since_year == 1990 for r in lux_rels)
+        asia = ent["Peeters Asia Ltd"]
+        asia_rel = [r for r in rels if r.to_entity_id == asia.id][0]
+        assert asia_rel.since_year == 1995 and asia_rel.until_year == 2005
+
+        # 持股比落 fields.shareholders_pct
+        assert ent["Peeters Asia Ltd"].fields["shareholders_pct"]["Far East Holdings"] == 60.0
+
+    def test_idempotent_reimport_never_grows(self, session):
+        company_info.import_external_companies(session, _sample_companies())
+        session.commit()
+        before = _entities(session)
+        n_ent = len(before)
+        n_rel = len(session.execute(select(Relationship)).scalars().all())
+
+        stats = company_info.import_external_companies(session, _sample_companies())
+        session.commit()
+
+        assert stats["companies_created"] == 0  # 只增不减：已存在不新建
+        assert len(_entities(session)) == n_ent
+        assert len(session.execute(select(Relationship)).scalars().all()) == n_rel
+
+    def test_status_derived_when_absent(self, session):
+        data = [
+            {"name": "A", "closing_date": "2000-01-01", "is_active": False},
+            {"name": "B", "is_active": True},
+        ]
+        company_info.import_external_companies(session, data)
+        session.commit()
+        ent = _entities(session)
+        assert ent["A"].status == "closed"
+        assert ent["B"].status == "opened"
+
+
+class TestImportEndpoint:
+    def test_post_import_returns_stats_and_refreshed_graph(self, session):
+        def _fake_run(db, **_kw):
+            # 注入与真实 importer 相同的写库逻辑（不联网）
+            return company_info.import_external_companies(db, _sample_companies())
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(company_info, "run_external_company_import", _fake_run)
+        try:
+            # 端点依赖注入
+            app.dependency_overrides[get_db] = lambda: session
+            with TestClient(app) as c:
+                r = c.post("/api/v1/graph/companies/import")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["stats"]["companies"] == 2
+            g = body["graph"]  # 纯公司图谱视图：只含 company 节点/边
+            names = {n["name"] for n in g["nodes"]}
+            assert {"Peeters Luxembourg S.à r.l.", "Peeters Asia Ltd",
+                    "Family Asset Management SPRL", "Far East Holdings"} <= names
+            assert "Henri Peeters" not in names  # person 节点不进 company 视图（仍在 DB）
+            assert g["edge_count"] >= 2  # Family AM→Lux、Far East→Asia 两条 company 间 holds
+            db_names = {e.name for e in session.execute(select(Entity)).scalars().all()}
+            assert "Henri Peeters" in db_names
+        finally:
+            monkeypatch.undo()
+            app.dependency_overrides.pop(get_db, None)
+
+
+class TestWriterExtras:
+    def test_upsert_relationship_sets_until_year_on_existing(self, session):
+        a = writer.upsert_entity(session, "company", "A")
+        b = writer.upsert_entity(session, "company", "B")
+        writer.upsert_relationship(session, a.id, b.id, "holds", since_year=1990)
+        rel = writer.upsert_relationship(session, a.id, b.id, "holds", until_year=2000)
+        session.commit()
+        assert rel.since_year == 1990
+        assert rel.until_year == 2000  # 同键复用并更新年窗

--- a/tests/test_company_import.py
+++ b/tests/test_company_import.py
@@ -167,6 +167,14 @@ class TestImportEndpoint:
             app.dependency_overrides.pop(get_db, None)
 
 
+class TestApiRoot:
+    def test_api_root_adds_and_dedupes_prefix(self):
+        assert company_info._api_root("http://127.0.0.1:7273") == "http://127.0.0.1:7273/api/v1"
+        assert company_info._api_root("http://127.0.0.1:7273/") == "http://127.0.0.1:7273/api/v1"
+        assert company_info._api_root("http://127.0.0.1:7273/api/v1") == "http://127.0.0.1:7273/api/v1"
+        assert company_info._api_root("http://127.0.0.1:8000/api/v1") == "http://127.0.0.1:8000/api/v1"
+
+
 class TestWriterExtras:
     def test_upsert_relationship_sets_until_year_on_existing(self, session):
         a = writer.upsert_entity(session, "company", "A")


### PR DESCRIPTION
## 背景
DESIGN §20 `F-P1-05 公司图谱` 此前仅完成只读视图；「外部 API①② 导入」一直标为 *待外部系统文档后实现*。本次按用户提供的外部公司系统 API 文档（JWT 登录 + `GET /public/companies`，返回隶属公司 + 股权结构 + 状态/开停业日期）补上 **API① 公司基础信息导入**。

## 决策（用户拍板）
- **触发**：公司图谱页加「获取/导入公司」按钮，人工触发（同步 fetch→upsert→commit，不做 import-jobs 异步基础设施）。
- **股权映射**：公司/外部公司股东 → `company` 实体，自然人股东 →`person` 实体；统一 `rel_type='holds'` 边 + 年窗。
- **连接**：`secrets.local.yaml`（gitignore）+ 环境变量覆盖；URL per-env dev/test→7273、prod→7274。

## 改动
| 文件 | 内容 |
|---|---|
| `app/ingest/importers/company_info.py` + `__init__.py` + `_client.py` | 外部 API① 适配器：login→fetch→只增不减 upsert 公司实体 + holds 股权边；凭据加载函数 |
| `app/api/app.py` | `POST /api/v1/graph/companies/import`（F-U7 UI 按钮通道）同步触发，返回统计+刷新图谱 |
| `app/config.py` | `external_api_url` per-env + 环境变量覆盖 |
| `app/ingest/writer.py` | `upsert_relationship` 加可选 `since_year/until_year`（向后兼容） |
| `frontend/src/App.jsx` + `Graph.jsx` | 公司图谱屏「获取/导入公司」按钮 + action slot + 重挂载刷新 |
| `requirements.txt` | 补 `httpx`、`pyyaml` |
| `docs/DESIGN...` | §20 F-P1-05 标注 API① 已实现；§13.3 实现注记 |
| `tests/test_company_import.py` | 映射/只增不减幂等/status 推导/端点 200+图谱/年窗 |

## 验证
- 全量测试 `262 passed`，无回归；前端 `vite build` 通过。
- 真实 e2e（外部系统跑在 :7273 时）待人工点按钮验收。

## 说明/取舍
- 持股比 `ownership_pct` 与开停业日期落 `entity.fields` JSONB（Entity 无对应列，未引入 migration）；如需边级展示百分比，需给 relationship 加列，留作后续。
- 本轮不做 API②（用工成本，未提供文档）与 import-jobs 异步任务基础设施。