### PR TITLE
feat(p1): F-P1-10 API② 用工成本 + 加薪规则屏

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -21,6 +21,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
+from app.api.labor_cost import router as labor_cost_router
 from app.api.ui_ops import router as ui_ops_router
 from app.core.calendar import snapshot_as_of
 from app.core.graph import all_graph, company_graph, person_graph
@@ -31,6 +32,7 @@ from app.model import (Account, Entity, ExchangeRate, FinanceEntry, IncomeStream
 
 app = FastAPI(title="Novel Dashboard API", version="0.1")
 app.include_router(ui_ops_router)
+app.include_router(labor_cost_router)
 
 # issue #30：dist 直连部署时前端跨域失败；PRD §13 本地单机非安全边界，
 # 仅放行 vite dev server 默认端口（5173）的两个本地来源，不允许 * 通配。

--- a/app/api/labor_cost.py
+++ b/app/api/labor_cost.py
@@ -1,0 +1,69 @@
+"""用工成本 API（API② · F-P1-10；DESIGN §13.2）。
+
+- POST /labor-cost/compute    拉取岗位→算成本→写每公司 finance_entry→commit（UI 按钮触发）
+- GET  /labor-cost/rules      加薪规则（Level/外包/晋级/CPI，纯展示）
+- GET  /labor-cost/results    每公司×年用工成本只读表（从 finance_entry 读）
+
+税率公式细节只在后台（labor_cost.py），本层不暴露费率。
+本通道是 UI 用户触发的计算（F-U7 式），不挂 require_importer。
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.core import labor_cost as LC
+from app.ingest.importers.positions import run_labor_cost
+from app.model import Entity, FinanceEntry
+
+router = APIRouter(prefix="/api/v1", tags=["labor-cost"])
+
+
+class LaborCostIn(BaseModel):
+    year: int  # 1900..2999
+    company_ids: Optional[list[int]] = None
+
+
+@router.post("/labor-cost/compute")
+def compute(body: LaborCostIn, db: Session = Depends(get_db)):
+    """拉取外部岗位→逐岗位算成本→聚合写每公司 finance_entry(expense)→commit。
+
+    返回 {year, companies_computed, positions_fetched}。外部不通/4xx → 502/透传，不落库。
+    """
+    import httpx
+    try:
+        res = run_labor_cost(db, body.year, body.company_ids)
+        db.commit()
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code if e.response is not None else 502
+        raise HTTPException(status_code=status, detail=f"外部 API 请求失败（HTTP {status}）")
+    except (httpx.RequestError, httpx.TimeoutException):
+        raise HTTPException(status_code=502, detail="无法连接外部系统 API（请确认其已启动且已导入公司 API①）")
+    return res
+
+
+@router.get("/labor-cost/rules")
+def rules():
+    """加薪规则（UI「加薪规则」屏数据源，单源自 labor_cost.RULES）。"""
+    return LC.rules_payload()
+
+
+@router.get("/labor-cost/results")
+def results(year: Optional[int] = None, db: Session = Depends(get_db)):
+    """每公司×年用工成本（从 finance_entry 读；source='external-api'，label=用工成本·{year}）。"""
+    q = (select(FinanceEntry, Entity.name)
+         .join(Entity, Entity.id == FinanceEntry.entity_id)
+         .where(FinanceEntry.kind == "expense", FinanceEntry.source == "external-api",
+                FinanceEntry.label.like("用工成本·%")))
+    if year:
+        q = q.where(FinanceEntry.year == year)
+    rows = db.execute(q.order_by(FinanceEntry.year, Entity.name)).all()
+    return {"items": [
+        {"year": fe.year, "company_id": fe.entity_id, "company_name": name,
+         "currency": fe.currency, "amount": float(fe.amount) if fe.amount is not None else None}
+        for fe, name in rows]}

--- a/app/core/labor_cost.py
+++ b/app/core/labor_cost.py
@@ -1,0 +1,301 @@
+"""用工成本核心（API② · F-P1-10；DESIGN §13.2）。
+
+成本公式（用户确认版）：
+  定位：work_location → region(工资+CPI) + office(税率) + 奖金月数
+  内部全职：基准年薪 = 投资/金融年薪(岗位opening年) × (1+Level%)
+            逐年增幅：salary ×= (1 + CPI工资增幅/y)  增幅<0 → 不涨
+  外包类：基准 = 当年全行业人均 × 系数(可选1.05 / 法律强制外包1.2)，每年现查不累积
+  基本用工成本 = 该 office 税率公式(当年 salary)      # 费率表 + 说明文字隐藏项
+  固定奖金：日本 3 月，其余 2 月 → (salary/12)×月数
+  总成本 = salary + 基本用工成本 + 奖金；在岗月折算 ×(交叠月/12)
+
+税率公式细节与税率表的"说明文字隐藏项"（比利时十三薪/双倍假期、英国学徒税等）
+只在后台算，不进入 UI（UI 只显示加薪规则，见 rules_payload）。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
+
+# --------------------------------------------------------------------------
+# 规则表（也是 UI「加薪规则」屏的数据源，rules_payload()）
+# --------------------------------------------------------------------------
+# Level → 基础年薪调整%（用户确认：M11b/M11c=5% 非笔误）
+LEVEL_PCT: dict[str, float] = {
+    "B6": .05, "B7a": .10, "B7b": .15, "M7": .15, "B8a": .20, "M8a": .20,
+    "B8b": .30, "M8b": .30, "B9a": .40, "M9a": .40, "M9b": .50,
+    "B9b": .60, "M9c": .60, "B10": .70, "M10a": .70, "M10b": .80,
+    "M10c": .90, "M11a": 1.00, "M11b": .05, "M11c": .05,
+}
+# legal_category → 外包基准系数（对应"全行业人均名义年薪"）
+OUTSOURCE_FACTOR: dict[str, float] = {
+    "可选（集团内控推荐）": 1.05,
+    "法律强制·允许第三方外包": 1.2,
+}
+BONUS_MONTHS_DEFAULT = 2
+BONUS_MONTHS_JAPAN = 3
+PROMOTION_STEP_PCT = 0.05  # 晋升：每跨一级 5%
+
+# work_location → (region 工资/CPI, office 税率, bonus 月数)。
+# ⚠ 初始初稿，外部 work_location 实际取值待用户给清单后校正（尤其 北京→上海工资代理、香港无税率 office）。
+LOCATION_ALIAS: list[tuple[str, str, str | None, int]] = [
+    ("卢森堡", "卢森堡", "卢森堡", 2),
+    ("布鲁塞尔", "比利时", "比利时", 2),
+    ("比利时", "比利时", "比利时", 2),
+    ("纽约", "美国", "美国纽约", 2),
+    ("洛杉矶", "美国", "美国洛杉矶", 2),
+    ("美国", "美国", "美国洛杉矶", 2),
+    ("东京", "日本东京", "日本东京", BONUS_MONTHS_JAPAN),   # 日本 3 月
+    ("上海", "中国上海", "中国上海", 2),
+    ("北京", "中国上海", "中国北京", 2),                      # 工资用中国上海代理；office 北京税率
+    ("伦敦", "英国", "英国", 2),
+    ("英国", "英国", "英国", 2),
+    ("斯德哥尔摩", "瑞典", "瑞典", 2),
+    ("哥本哈根", "丹麦", "丹麦", 2),
+    ("阿姆斯特丹", "荷兰", "荷兰", 2),
+    ("香港", "中国香港", None, 2),                            # 无税率 office → 成本缺
+]
+
+IS_OUTSOURCED_MARKERS = ("Outsourced", "External")          # position_name/type 命中即外包
+
+
+def locate(work_location: str) -> tuple[str, str | None, int] | None:
+    """work_location → (region, office, bonus_months)；未匹配 → None。"""
+    wl = work_location or ""
+    for frag, r, o, bm in LOCATION_ALIAS:
+        if frag in wl:
+            return r, o, bm
+    return None
+
+
+def _locate(pos: dict) -> tuple[str, str | None, int] | None:
+    """定位：work_location 优先；未命中退回 country_or_region（用户确认法则2）。
+    country_or_region 形如 "Country·卢森堡"（子串命中）。"""
+    loc = locate(pos.get("work_location") or "")
+    if loc is None:
+        loc = locate(pos.get("country_or_region") or "")
+    return loc
+
+
+def is_outsourced(pos: dict) -> bool:
+    txt = f"{pos.get('position_type','')} {pos.get('position_name','')}"
+    return any(m in txt for m in IS_OUTSOURCED_MARKERS)
+
+
+# --------------------------------------------------------------------------
+# DB 读基准
+# --------------------------------------------------------------------------
+def _wage_row(db: Session, region: str, year: int):
+    """region×year 工资行；2002(BEF/EUR 双币)及2003+ 偏好 EUR，否则该年实际币种(BEF/LUF…)。"""
+    rows = db.execute(select(LaborWageBenchmark).where(
+        LaborWageBenchmark.region == region, LaborWageBenchmark.year == year)).scalars().all()
+    if not rows:
+        return None
+    for r in rows:
+        if r.currency == "EUR":
+            return r
+    return rows[0]
+
+
+def investment_fin_salary(db: Session, region: str, year: int) -> float | None:
+    w = _wage_row(db, region, year)
+    return float(w.investment_fin_salary) if w and w.investment_fin_salary is not None else None
+
+
+def avg_salary(db: Session, region: str, year: int) -> float | None:
+    w = _wage_row(db, region, year)
+    return float(w.avg_salary) if w and w.avg_salary is not None else None
+
+
+def wage_growth_pct(db: Session, region: str, year: int) -> float:
+    g = db.execute(select(LaborCpiGrowth.wage_growth_pct).where(
+        LaborCpiGrowth.region == region, LaborCpiGrowth.year == year)).scalar_one_or_none()
+    return float(g) if g is not None else 0.0
+
+
+def _tax_row(db: Session, office: str, year: int):
+    return db.execute(select(LaborTaxBenchmark).where(
+        LaborTaxBenchmark.office == office, LaborTaxBenchmark.year == year)).scalar_one_or_none()
+
+
+# --------------------------------------------------------------------------
+# 税率公式执行器（费率存原样%数值 → ÷100；上限/人头存原币金额）
+# --------------------------------------------------------------------------
+def _pct(x) -> float:
+    return (float(x) if x is not None else 0.0) / 100.0
+
+
+def _clamp_annual(salary: float, monthly_floor, monthly_cap) -> float:
+    """中国/日本 clamp：月税前工资 clamp 上下限 → ×12 年度基数。"""
+    month = salary / 12.0
+    if monthly_floor is not None:
+        month = max(month, float(monthly_floor))
+    if monthly_cap is not None:
+        month = min(month, float(monthly_cap))
+    return month * 12.0
+
+
+def employer_social_cost(formula: str, salary: float, p) -> float:
+    """按成本模型类型计算雇主法定社保/税费部分（不含工资本薪与奖金）。"""
+    if formula == "single_pct":            # 瑞典：总包% + 假期%
+        return salary * (_pct(p.get("total_pct")) + _pct(p.get("holiday_pct")))
+    if formula == "single_pct_cap":        # 荷兰：min(salary,SV-loon)×总包% + 假期8%
+        base = min(salary, float(p.get("sv_loon_cap") or 0))
+        return base * _pct(p.get("total_pct")) + salary * _pct(p.get("holiday_pct"))
+    if formula == "multi_cap":             # 美国：多档上限
+        return (min(salary, float(p.get("oasdi_cap") or salary)) * _pct(p.get("oasdi_pct"))
+                + salary * _pct(p.get("medicare_pct"))
+                + min(salary, float(p.get("futa_cap") or 0)) * _pct(p.get("futa_pct"))
+                + min(salary, float(p.get("suta_cap") or salary)) * _pct(p.get("suta_pct"))
+                + salary * _pct(p.get("wc_pct")))
+    if formula == "clamp":                 # 中国上海/北京/外籍：五险+公积金（clamp 年度基数）
+        annual = _clamp_annual(salary, p.get("monthly_floor"), p.get("monthly_cap"))
+        return annual * _pct(p.get("soc_pct")) + annual * _pct(p.get("housing_pct"))
+    if formula == "headcount":             # 丹麦：人头固定 + 假期%
+        return float(p.get("total_fixed") or 0) + salary * (_pct(p.get("feriepenge_pct")) + _pct(p.get("ferietillaeg_pct")))
+    if formula == "uk_nic":                # 英国：NIC 超额起征点 + 养老金 + 工伤
+        above = max(0.0, salary - float(p.get("nic_threshold") or 0))
+        return (above * _pct(p.get("nic_pct"))
+                + salary * _pct(p.get("pension_pct"))
+                + salary * _pct(p.get("wc_pct")))
+    if formula == "onss":                  # 比利时：ONSS% + 工伤 + 双倍假期92%×月 + 十三薪1×月
+        return (salary * _pct(p.get("onss_pct"))
+                + salary * _pct(p.get("wc_pct"))
+                + salary / 12.0 * 0.92 + salary / 12.0 * 1.0)
+    if formula == "ccss":                  # 卢森堡：CCSS%+工伤+MDE（注：5×SSM 工资上限待补）
+        return salary * (_pct(p.get("ccss_pct")) + _pct(p.get("wc_pct")) + _pct(p.get("mde_pct")))
+    if formula == "jp":                    # 日本：厚年/健保 clamp + 介护 + 雇佣+工伤（全）
+        kosei_base = _clamp_annual(salary, None, p.get("kosei_cap"))
+        kenpo_base = _clamp_annual(salary, None, p.get("kenpo_cap"))
+        return (kosei_base * _pct(p.get("kosei_pct"))
+                + kenpo_base * _pct(p.get("kenpo_pct"))
+                + kenpo_base * _pct(p.get("kaigo_pct"))
+                + salary * _pct(p.get("koyo_pct"))
+                + salary * _pct(p.get("rosa_pct")))
+    return 0.0
+
+
+# --------------------------------------------------------------------------
+# 在岗月折算
+# --------------------------------------------------------------------------
+def _overlap_months(opening: str | None, closing: str | None, year: int) -> int:
+    """岗位在 target 年的在营月数（含边界月）。opening 空 → 0（不计）。"""
+    if not opening:
+        return 0
+    try:
+        o = date.fromisoformat(opening)
+    except ValueError:
+        return 0
+    start = max(o.year * 100 + o.month, year * 100 + 1)
+    end = year * 100 + 12
+    if closing:
+        try:
+            c = date.fromisoformat(closing)
+            end = min(c.year * 100 + c.month, end)
+        except ValueError:
+            pass
+    if start > end:
+        return 0
+    sy = start // 100
+    sm = start % 100
+    ey = end // 100
+    em = end % 100
+    return ey * 12 + em - (sy * 12 + sm) + 1
+
+
+# --------------------------------------------------------------------------
+# 逐岗位成本
+# --------------------------------------------------------------------------
+def compute_annual_salary(db: Session, pos: dict, year: int) -> float | None:
+    """岗位当年 Gross 年薪（税前）；无法匹配/缺基准 → None。"""
+    loc = _locate(pos)
+    if loc is None:
+        return None
+    region, _office, _bm = loc
+    if is_outsourced(pos):
+        base = avg_salary(db, region, year)
+        if base is None:
+            return None
+        factor = OUTSOURCE_FACTOR.get(pos.get("legal_category") or "", 1.0)
+        return base * factor                            # 每年现查当年基准
+    open_year = _year_of(pos.get("opening_date"))
+    if open_year is None:
+        return None
+    base = investment_fin_salary(db, region, open_year)
+    if base is None:
+        return None
+    salary = base * (1.0 + LEVEL_PCT.get(pos.get("level") or "", 0.0))
+    for y in range(open_year + 1, year + 1):            # 逐年增幅；负则不变
+        g = wage_growth_pct(db, region, y)
+        if g > 0:
+            salary *= (1.0 + g / 100.0)
+    return salary
+
+
+def compute_position_cost(db: Session, pos: dict, year: int) -> dict | None:
+    """逐岗位年成本：{salary, tax, bonus, total, months, currency, region, office}"""
+    loc = _locate(pos)
+    if loc is None:
+        return None
+    region, office, bonus_months = loc
+    salary = compute_annual_salary(db, pos, year)
+    if salary is None:
+        return None
+    currency = None
+    w = _wage_row(db, region, year)
+    if w:
+        currency = w.currency
+    tax = 0.0
+    if office:
+        row = _tax_row(db, office, year)
+        if row:
+            tax = employer_social_cost(row.formula, salary, row.params or {})
+    else:
+        tax = None                                    # 无税率 office → 税费未知
+    bonus = salary / 12.0 * bonus_months
+    tax_part = tax or 0.0
+    total = salary + tax_part + bonus
+    months = _overlap_months(pos.get("opening_date"), pos.get("closing_date"), year)
+    return {"salary": round(salary, 2), "tax": (round(tax, 2) if tax is not None else None),
+            "bonus": round(bonus, 2), "total": round(total * months / 12.0, 2),
+            "months": months, "currency": currency, "region": region, "office": office,
+            "company_id": pos.get("company_id"), "company_name": pos.get("company_name"),
+            "position": pos.get("position_name") or pos.get("number"),
+            "level": pos.get("level"), "outsourced": is_outsourced(pos)}
+
+
+# --------------------------------------------------------------------------
+# 升职薪资（晋升链精确化待补，v1 用决定式）
+# --------------------------------------------------------------------------
+def promotion_salary(old_salary: float, levels_between: int) -> float:
+    """晋升：新职基薪 = 老职 × (1 + 5%×跨级数)。"""
+    return old_salary * (1.0 + PROMOTION_STEP_PCT * levels_between)
+
+
+def _year_of(iso: str | None) -> int | None:
+    if not iso:
+        return None
+    try:
+        return int(str(iso)[:4])
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------
+# 加薪规则 payload（UI「加薪规则」屏）
+# --------------------------------------------------------------------------
+def rules_payload() -> dict:
+    return {
+        "level_adjust_pct": {k: round(v * 100, 0) for k, v in LEVEL_PCT.items()},
+        "outsource_factor": {k: v for k, v in OUTSOURCE_FACTOR.items()},
+        "outsource_base": "当年全行业人均名义年薪（基准）",
+        "bonus_months_default": BONUS_MONTHS_DEFAULT,
+        "bonus_months_japan": BONUS_MONTHS_JAPAN,
+        "promotion_step_pct": round(PROMOTION_STEP_PCT * 100, 0),
+        "cpi_rule": "每年按 CPI工资 对应 国家×年份 的「工资增幅%」调整税前工资；负增长则当年不涨薪",
+        "base_rule": "基础 = 工作地点对应地区的「投资/金融行业年薪」(按岗位 opening 年份) × (1 + Level调整%)",
+    }

--- a/app/ingest/importers/__init__.py
+++ b/app/ingest/importers/__init__.py
@@ -1,0 +1,3 @@
+"""__init__：重命名为导入空包。外部 importers 放置路径（DESIGN §13.3 ingest/importers/{provider}.py）。
+provider 约定：company-info（API① 公司基础信息）、labor-cost（API② 用工成本，未实现）。
+"""

--- a/app/ingest/importers/_client.py
+++ b/app/ingest/importers/_client.py
@@ -1,0 +1,83 @@
+"""外部系统 API① 连接与凭据加载（DESIGN §13.3 · F-P1-05）。
+
+凭据铁律（DESIGN §13.3）：外部 API 凭据放本地 `secrets.local.yaml`（.gitignore 排除，
+不入 git、不入 DB）；可被环境变量覆盖；在本模块读取，不落入日志/notification。
+
+URL 优先级：环境变量 EXTERNAL_API_BASE_URL > secrets.local.yaml external_api.base_url
+            > config.CONFIG.external_api_url（per-env 默认 7273/7274）。
+用户名/密码优先级：环境变量 EXTERNAL_API_USER / EXTERNAL_API_PASSWORD
+            > secrets.local.yaml external_api.username / .password。
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import httpx
+import yaml
+
+from app.config import PROJECT_ROOT, CONFIG
+
+_SECRETS_PATH = PROJECT_ROOT / "secrets.local.yaml"
+
+
+def _api_root(base_url: str) -> str:
+    """base_url（host:port）→ API 根（含 /api/v1）。
+
+    外部系统端点均在 /api/v1 前缀下；base_url 已含 /api/v1 则去重复用。"""
+    base = (base_url or "").rstrip("/")
+    if base.endswith("/api/v1"):
+        return base
+    return base + "/api/v1"
+
+
+def login(url: str, username: str, password: str, client: httpx.Client | None = None) -> str:
+    """POST {api_root}/auth/login → access_token。凭据错误 → 抛 httpx.HTTPStatusError。"""
+    owned = client is None
+    client = client or httpx.Client(timeout=15)
+    try:
+        r = client.post(f"{_api_root(url)}/auth/login",
+                        json={"username": username, "password": password})
+        r.raise_for_status()
+        return r.json()["access_token"]
+    finally:
+        if owned:
+            client.close()
+
+
+def _load_secrets() -> dict:
+    """读本地 secrets.local.yaml；文件缺失/非法 → 空 dict（不抛）。
+    yaml.safe_load，字段 keys 为 external_api: {base_url, username, password}。"""
+    if not _SECRETS_PATH.exists():
+        return {}
+    try:
+        with _SECRETS_PATH.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except (yaml.YAMLError, OSError):
+        return {}
+    return data.get("external_api") or {}
+
+
+def load(base_url: str | None = None) -> tuple[str, str, str]:
+    """解析 (外部 base_url, username, password)。
+
+    base_url 形如 `http://127.0.0.1:7273`（外部系统 `/api/v1` 根；具体端点路径后续拼接）。
+    """
+    sec = _load_secrets()
+    url = (
+        base_url
+        or os.environ.get("EXTERNAL_API_BASE_URL")
+        or sec.get("base_url")
+        or CONFIG.external_api_url
+    )
+    username = (
+        os.environ.get("EXTERNAL_API_USER")
+        or sec.get("username")
+        or ""
+    )
+    password = (
+        os.environ.get("EXTERNAL_API_PASSWORD")
+        or sec.get("password")
+        or ""
+    )
+    return url, username, password

--- a/app/ingest/importers/_client.py
+++ b/app/ingest/importers/_client.py
@@ -1,4 +1,4 @@
-"""外部系统 API① 连接与凭据加载（DESIGN §13.3 · F-P1-05）。
+"""外部系统 API 连接与凭据加载（DESIGN §13.3）。
 
 凭据铁律（DESIGN §13.3）：外部 API 凭据放本地 `secrets.local.yaml`（.gitignore 排除，
 不入 git、不入 DB）；可被环境变量覆盖；在本模块读取，不落入日志/notification。

--- a/app/ingest/importers/positions.py
+++ b/app/ingest/importers/positions.py
@@ -1,0 +1,143 @@
+"""外部系统 API② 在岗岗位导入 + 用工成本落账（DESIGN §13.2 · F-P1-10）。
+
+外部只导出在岗岗位明细（GET /public/positions，无任何成本字段）；我方用本地基准
+（labor_cost.py）算成本 → 每公司×年 用工成本 → finance_entry(entity_kind='company',
+kind='expense') → 增量重算（复用 _after_ui_write 路径）。
+
+在岗判定（岗位/公司同规则）：opening ≤ Y-12-31 且 (closing 空 或 ≥ Y-01-01)；opening 空不计。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.ingest.importers._client import _api_root, login, load
+from app.core import labor_cost as LC
+from app.model import Entity, FinanceEntry
+from app.model.types import SourceKind
+
+
+def login_and_token(base_url: str, username: str, password: str,
+                    client: httpx.Client | None = None) -> str:
+    return login(base_url, username, password, client=client)
+
+
+def fetch_positions(base_url: str, token: str, year: int, company_ids: list[int] | None = None,
+                    client: httpx.Client | None = None) -> list[dict]:
+    """GET {api_root}/public/positions?year=Y[&company_ids=...] → items。"""
+    owned = client is None
+    client = client or httpx.Client(timeout=30)
+    try:
+        params = {"year": year}
+        if company_ids:
+            params["company_ids"] = ",".join(str(i) for i in company_ids)
+        r = client.get(f"{_api_root(base_url)}/public/positions",
+                       params=params,
+                       headers={"Authorization": f"Bearer {token}"})
+        r.raise_for_status()
+        return (r.json() or {}).get("items", [])
+    finally:
+        if owned:
+            client.close()
+
+
+def _in_post(rec: dict, year: int) -> bool:
+    """在岗判定：opening ≤ Y-12-31 且 (closing 空 或 ≥ Y-01-01)；opening 空 → False。"""
+    op = rec.get("opening_date")
+    if not op:
+        return False
+    y_start = date(year, 1, 1)
+    y_end = date(year, 12, 31)
+    try:
+        o = date.fromisoformat(op)
+    except ValueError:
+        return False
+    if o > y_end:
+        return False
+    cl = rec.get("closing_date")
+    if cl:
+        try:
+            c = date.fromisoformat(cl)
+        except ValueError:
+            c = None
+        if c is not None and c < y_start:
+            return False
+    return True
+
+
+def _resolve_entity(db: Session, company_id=None, company_name=None) -> int | None:
+    """外部 company → 我方 entity(company).id：优先按名，退按 external_id(fields)。"""
+    if company_name:
+        ent = db.execute(select(Entity).where(
+            Entity.entity_type == "company", Entity.name == company_name)).scalar_one_or_none()
+        if ent is not None:
+            return ent.id
+    if company_id is not None:
+        ent = db.execute(select(Entity).where(
+            Entity.entity_type == "company",
+            Entity.fields["external_id"].astext == str(company_id))).scalar_one_or_none()
+        if ent is not None:
+            return ent.id
+    return None
+
+
+def aggregate_to_finance(db: Session, costs: list[dict], year: int) -> dict:
+    """逐岗位成本 → 按我方公司实体聚合 → 写 finance_entry(company, expense, 用工成本·{year})。
+
+    幂等：先删同源/同公司/同年/「用工成本·」expense 再插入（同年重算=替换）。
+    返回 {companies: 每公司条目, total_positions, skipped}。
+    """
+    by_company: dict[tuple[int, str], dict] = {}
+    unresolved = 0
+    for c in costs:
+        if c is None or c.get("total") is None:
+            continue
+        eid = _resolve_entity(db, c.get("company_id"), c.get("company_name"))
+        if eid is None:
+            unresolved += 1
+            continue
+        key = (eid, c.get("currency"))
+        d = by_company.setdefault(key, {"entity_id": eid, "company_id": c.get("company_id"),
+                                        "company_name": c.get("company_name"),
+                                        "currency": c.get("currency"),
+                                        "total": 0.0, "positions": 0})
+        d["total"] += c["total"]
+        d["positions"] += 1
+
+    ids = [k[0] for k in by_company]
+    if ids:
+        db.execute(delete(FinanceEntry).where(
+            FinanceEntry.entity_id.in_(ids), FinanceEntry.year == year,
+            FinanceEntry.kind == "expense", FinanceEntry.source == "external-api",
+            FinanceEntry.label.like("用工成本·%")))
+    out = []
+    for (eid, cur), d in by_company.items():
+        label = f"用工成本·{year}"
+        db.add(FinanceEntry(entity_id=eid, entity_kind="company", year=year,
+                            kind="expense", amount=round(d["total"], 2),
+                            currency=cur, label=label, source=SourceKind.EXTERNAL_API))
+        out.append({**d, "label": label})
+    return {"companies": out, "total_positions": len(costs), "unresolved_company": unresolved}
+
+
+def run_labor_cost(db: Session, year: int, company_ids: list[int] | None = None,
+                   base_url: str | None = None, client: httpx.Client | None = None) -> dict:
+    """端到端：登录→拉岗位→逐岗位成本→聚合落账（不 commit；由端点/命令层 commit+重算）。"""
+    url, username, password = load(base_url=base_url)
+    token = login_and_token(url, username, password, client=client)
+    positions = fetch_positions(url, token, year, company_ids, client=client)
+    costs = []
+    for p in positions:
+        if not _in_post(p, year):
+            continue
+        c = LC.compute_position_cost(db, p, year)
+        costs.append(c)
+    agg = aggregate_to_finance(db, costs, year)
+    return {"year": year, "companies_computed": agg, "positions_fetched": len(positions)}
+
+
+__all__ = ["run_labor_cost", "fetch_positions", "login_and_token",
+           "aggregate_to_finance", "_in_post"]

--- a/app/ingest/labor_baseline.py
+++ b/app/ingest/labor_baseline.py
@@ -1,0 +1,277 @@
+"""用工成本基准采集（API② · F-P1-10；DESIGN §13.2）。
+
+把 Design_Folder 三份基准解析落库：
+- labor_wage_benchmark：工资表（10 区×年）——投资/金融年薪 + 全行业人均 + CPI 定基
+- labor_cpi_growth：CPI工资.md（10 区×年）——工资增幅%/通胀%
+- labor_tax_benchmark：税率表（12 office×年）——异结构费率/上限 JSONB + 成本模型类型
+
+解析边界（已知坑，均有测试锁定）：
+- 数值剥离 `*` 估算标记、千分位逗号。
+- CPI工资.md **全角 `｜` 与半角 `|` 混用**（前 9 区全角、东京段半角且末行多尾竖线）。
+- 比/卢 2002 行 `BEF/EUR` 双币 → 拆分存两行。
+- 日本 CPI 定基 2015≈别家 2013 → cpi_base_year 按区标。
+- 英国税率按财年 `2002-03` → year 取起始年。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
+
+# ---- 常量：工资区（文件名） × 汇率/基年 ----------------------------------------
+WAGE_REGIONS = ["比利时", "卢森堡", "荷兰", "瑞典", "丹麦", "美国", "英国",
+                "中国香港", "中国上海", "日本东京"]
+CPI_BASE_YEAR = {r: (2015 if r == "日本东京" else 2013) for r in WAGE_REGIONS}
+
+# CPI工资.md 地区码 → 中文区名
+CPI_CODE_TO_REGION = {
+    "BEL": "比利时", "LUX": "卢森堡", "NLD": "荷兰", "SWE": "瑞典", "DNK": "丹麦",
+    "USA": "美国", "GBR": "英国", "HKG": "中国香港", "SHA": "中国上海", "TKY": "日本东京",
+}
+
+# 税率 office（文件名） → (成本模型类型, 用于解析的字段键掩码描述)
+# 键语义：_pct=百分比费率(文件原样数值，公式除以100)；_cap=工资上限(原币金额)。
+TAX_OFFICES = {
+    "比利时": "onss", "卢森堡": "ccss", "美国洛杉矶": "multi_cap", "美国纽约": "multi_cap",
+    "中国上海": "clamp", "中国北京": "clamp", "中国上海外籍": "clamp",
+    "英国": "uk_nic", "日本东京": "jp", "丹麦": "headcount", "瑞典": "single_pct", "荷兰": "single_pct_cap",
+}
+
+
+# ---- 工具 -------------------------------------------------------------------
+def _num(v: str) -> float | None:
+    """剥离 `*`/千分位/%、单位括号注释 → float；空 → None。"""
+    if v is None:
+        return None
+    s = str(v).strip()
+    # 去掉年度范围（"2002‑03"）只取头年份的解析单独处理
+    s = re.sub(r"[%,，£$¥￥€‰]", "", s).replace(",", "").replace(" ", "")
+    s = re.sub(r"\(.*?\)", "", s).strip()
+    s = s.rstrip("*")
+    if not s or s == "-":
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _fiscal_year(v: str) -> int | None:
+    """财年 "2002‑03"/"2002-03"/"2002‑2025" → 起始年 int；否则 None。"""
+    s = str(v).strip()
+    m = re.match(r"^(\d{4})", s.replace("‑", "-").replace("－", "-"))
+    return int(m.group(1)) if m else None
+
+
+def _table_rows(lines: Iterable[str]) -> list[list[str]]:
+    """提取 markdown **第一张**表行（首个|分隔）；跳过表头分隔行 ---。
+
+    只取第一个连续表块（遇空行/非|行即停），避免把文件里第二张说明/对比表误并入
+    （如北京 md 的「北京 vs 上海」对比表首列含年份，会与主表产生重复键）。"""
+    rows: list[list[str]] = []
+    started = False
+    for line in lines:
+        if "|" not in line:
+            if started and rows:  # 第一张表结束
+                break
+            continue
+        started = True
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if all(re.fullmatch(r":?-{1,4}:?", c or "") for c in cells):
+            continue
+        rows.append(cells)
+    return rows
+
+
+def _table_as_map(rows: list[list[str]]) -> list[dict]:
+    """首行作表头 → 每数据行 dict[header]=cell。"""
+    if not rows:
+        return []
+    headers = rows[0]
+    return [dict(zip(headers, r)) for r in rows[1:]]
+
+
+def _col_index_by_keyword(headers: list[str], keywords: tuple[str, ...]) -> int | None:
+    """按表头关键字找列索引。"""
+    for i, h in enumerate(headers):
+        if any(k in h for k in keywords):
+            return i
+    return None
+
+
+# ---- 1. 工资表 ---------------------------------------------------------------
+def parse_wage_file(path: Path, region: str) -> list[dict]:
+    rows = _table_rows(path.read_text(encoding="utf-8").splitlines())
+    out: list[dict] = []
+    for r in rows[1:]:
+        year = _num(r[0])
+        if year is None or year != int(year):
+            continue
+        cur_parts = [p.strip() for p in r[2].split("/")]
+        inv_parts = [p.strip() for p in r[4].split("/")]
+        # 比/卢 2002 双币：拆两行
+        if len(cur_parts) == 2:
+            for cur, inv in zip(cur_parts, inv_parts):
+                out.append({"region": region, "year": int(year), "currency": cur,
+                            "investment_fin_salary": _num(inv), "avg_salary": _num(r[1]),
+                            "cpi_index": _num(r[3]), "cpi_base_year": CPI_BASE_YEAR[region]})
+        else:
+            out.append({"region": region, "year": int(year), "currency": cur_parts[0],
+                        "investment_fin_salary": _num(inv_parts[0]), "avg_salary": _num(r[1]),
+                        "cpi_index": _num(r[3]), "cpi_base_year": CPI_BASE_YEAR[region]})
+    return out
+
+
+def import_wage(session: Session, source_dir: Path, log=None) -> dict:
+    stats = {"region": 0, "rows": 0, "skipped": 0}
+    base = source_dir / "基准" / "公司" / "用工成本"
+    for region in WAGE_REGIONS:
+        path = base / f"{region}.md"
+        if not path.exists():
+            if log: log(f"  [wage] 缺文件: {region}.md")
+            stats["skipped"] += 1
+            continue
+        recs = parse_wage_file(path, region)
+        for r in recs:
+            dup = session.execute(select(LaborWageBenchmark.id).where(
+                LaborWageBenchmark.region == r["region"],
+                LaborWageBenchmark.year == r["year"],
+                LaborWageBenchmark.currency == r["currency"]).limit(1)).scalar_one_or_none()
+            if dup is None:
+                session.add(LaborWageBenchmark(**r, source_file=str(path)))
+                stats["rows"] += 1
+        stats["region"] += 1
+    return stats
+
+
+# ---- 2. CPI 指数 -------------------------------------------------------------
+def parse_cpi_file(path: Path) -> list[dict]:
+    out: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        # 兼容全角 ｜ 与半角 | 双分隔符
+        parts = [p.strip() for p in re.split(r"[｜|]", line) if p.strip()]
+        if len(parts) != 4:
+            continue
+        code, year, wg, cpi = parts
+        region = CPI_CODE_TO_REGION.get(code)
+        if region is None or not re.fullmatch(r"\d{4}", year):
+            continue
+        out.append({"region": region, "year": int(year),
+                    "wage_growth_pct": _num(wg), "cpi_pct": _num(cpi)})
+    return out
+
+
+def import_cpi(session: Session, source_dir: Path, log=None) -> dict:
+    path = source_dir / "基准" / "CPI工资.md"
+    stats = {"rows": 0, "skipped": 0, "regions": set()}
+    if not path.exists():
+        stats["skipped"] += 1
+        return stats
+    for r in parse_cpi_file(path):
+        dup = session.execute(select(LaborCpiGrowth.id).where(
+            LaborCpiGrowth.region == r["region"],
+            LaborCpiGrowth.year == r["year"]).limit(1)).scalar_one_or_none()
+        if dup is None:
+            session.add(LaborCpiGrowth(**r))
+            stats["rows"] += 1
+        stats["regions"].add(r["region"])
+    stats["regions"] = len(stats["regions"])
+    return stats
+
+
+# ---- 3. 税率表 ---------------------------------------------------------------
+def _extract_tax_params(office: str, row: dict) -> dict:
+    """按 office 的字段键映射，从表头 dict 抽取该年费率/上限。费率存原样数值(%)，上限存原币金额。"""
+    params: dict = {}
+    field_map = {
+        "比利时":  {"onss_pct": ("ONSS",), "wc_pct": ("工伤",)},
+        "卢森堡":  {"ccss_pct": ("CCSS",), "wc_pct": ("工伤",), "mde_pct": ("MDE", "互助金")},
+        "美国洛杉矶": {"oasdi_pct": ("OASDI税率",), "oasdi_cap": ("OASDI应税",),
+                       "medicare_pct": ("Medicare税率", "Medicare税"), "futa_pct": ("FUTA实际",),
+                       "futa_cap": ("FUTA计税",), "suta_pct": ("加州参考SUTA", "加州SUTA"),
+                       "suta_cap": ("加州SUTA计税",), "wc_pct": ("工伤",)},
+        "美国纽约": {"oasdi_pct": ("OASDI税率",), "oasdi_cap": ("OASDI应税",),
+                     "medicare_pct": ("Medicare税率", "Medicare税"), "futa_pct": ("FUTA实际",),
+                     "futa_cap": ("FUTA计税",), "suta_pct": ("纽约州SUTA新雇主", "纽约州SUTA税率"),
+                     "suta_cap": ("纽约州SUTA计税",), "wc_pct": ("工伤",)},
+        "中国上海":  {"pension_pct": ("养老",), "medical_pct": ("医疗",), "unemploy_pct": ("失业",),
+                      "workinjury_pct": ("工伤",), "soc_pct": ("社保合计",),
+                      "housing_pct": ("公积金单位",), "monthly_cap": ("上限",), "monthly_floor": ("下限",)},
+        "中国北京":  {"pension_pct": ("养老",), "medical_pct": ("医疗",), "unemploy_pct": ("失业",),
+                      "workinjury_pct": ("工伤",), "soc_pct": ("社保合计",),
+                      "housing_pct": ("公积金单位",), "monthly_cap": ("上限",), "monthly_floor": ("下限",)},
+        "中国上海外籍": {"pension_pct": ("养老",), "medical_pct": ("医疗",), "unemploy_pct": ("失业",),
+                         "workinjury_pct": ("工伤",), "soc_pct": ("社保合计",),
+                         "housing_pct": ("公积金单位",), "monthly_cap": ("上限",), "monthly_floor": ("下限",)},
+        "英国":   {"nic_pct": ("雇主NI基准", "雇主NI费率"), "nic_threshold": ("起征点",),
+                   "pension_pct": ("最低养老金",), "wc_pct": ("工伤",)},
+        "日本东京": {"kosei_pct": ("厚生年金",), "kenpo_pct": ("健保",), "kaigo_pct": ("介护",),
+                     "koyo_pct": ("雇佣保险",), "rosa_pct": ("工伤保险",),
+                     "kosei_cap": ("厚生年金月",), "kenpo_cap": ("健保月",)},
+        "丹麦":   {"atp_fixed": ("雇主ATP",), "funds_fixed": ("人头基金合计",),
+                   "total_fixed": ("法定固定人头总成本",), "feriepenge_pct": ("feriepenge", "假期工资"),
+                   "ferietillaeg_pct": ("ferietillæg", "假期补贴")},
+        "瑞典":   {"total_pct": ("雇主社保总包",), "holiday_pct": ("假期附加",)},
+        "荷兰":   {"awf_pct": ("AWF",), "whk_pct": ("WHK",), "zvw_pct": ("Zvw", "医保附加"),
+                   "total_pct": ("社保合计",), "sv_loon_cap": ("SV‑loon", "SV-loon", "SV‑loon"),
+                   "holiday_pct": ("假期津贴",)},
+    }
+    for key, keywords in field_map.get(office, {}).items():
+        cell = next((v for h, v in row.items() if any(k in h for k in keywords)), None)
+        params[key] = _num(cell)
+    return {k: v for k, v in params.items() if v is not None}
+
+
+def parse_tax_file(path: Path, office: str, country_or_region: str) -> list[dict]:
+    rows = _table_rows(path.read_text(encoding="utf-8").splitlines())
+    data = _table_as_map(rows)
+    out: list[dict] = []
+    for row in data:
+        yr_cell = next(iter(row.values()))
+        year = _fiscal_year(yr_cell)  # 含 "2002‑03" 财年；纯年份也命中
+        if year is None or year < 1900:
+            year = _num(yr_cell)
+        if year is None or year != int(year):
+            continue
+        out.append({"office": office, "year": int(year),
+                    "formula": TAX_OFFICES[office],
+                    "params": _extract_tax_params(office, row) or {},
+                    "source_file": str(path)})
+    return out
+
+
+def import_tax(session: Session, source_dir: Path, log=None,
+               office_list: Iterable[str] | None = None) -> dict:
+    stats = {"office": 0, "rows": 0, "skipped": 0}
+    base = source_dir / "基准" / "公司" / "用工成本" / "税率"
+    for office in (office_list or TAX_OFFICES):
+        path = base / f"{office}.md"
+        if not path.exists():
+            if log: log(f"  [tax] 缺文件: {office}.md")
+            stats["skipped"] += 1
+            continue
+        for r in parse_tax_file(path, office, office):
+            dup = session.execute(select(LaborTaxBenchmark.id).where(
+                LaborTaxBenchmark.office == r["office"],
+                LaborTaxBenchmark.year == r["year"]).limit(1)).scalar_one_or_none()
+            if dup is None:
+                session.add(LaborTaxBenchmark(office=r["office"], year=r["year"],
+                                              formula=r["formula"], params=r["params"],
+                                              source_file=r["source_file"]))
+                stats["rows"] += 1
+        stats["office"] += 1
+    return stats
+
+
+def import_labor_baseline(session: Session, source_dir: Path, log=None) -> dict:
+    """三块基准一体落库（幂等，不含 commit；由命令层 commit）。"""
+    return {
+        "wage": import_wage(session, source_dir, log),
+        "cpi": import_cpi(session, source_dir, log),
+        "tax": import_tax(session, source_dir, log),
+    }

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -404,5 +404,28 @@ def snapshot(env: str = typer.Option("dev", "--env"),
         typer.echo(f"[{env}] 快照重建完成：{r['snapshots']} 条 / {r['accounts']} 账户 / {r['entities']} 实体聚合 / {r['family_years']} 家族合计年（自 {from_year} 起）")
 
 
+@app.command()
+def labor_baseline(env: str = typer.Option("dev", "--env"),
+                   office: str = typer.Option("", "--office", help="仅采集指定税率 office（缺省全部）")):
+    """用工成本基准落库（API② · F-P1-10）：工资(10区)+CPI(10区)+税率(12 office)。
+
+    从 Design_Folder 解析三份基准 → labor_wage_benchmark/labor_cpi_growth/labor_tax_benchmark。
+    """
+    from app.config import get_config
+    from app.ingest.labor_baseline import import_labor_baseline, import_wage, import_cpi, import_tax
+    cfg = get_config(env)
+    with _session_for(env) as s:
+        if office:
+            r = import_tax(s, cfg.source_dir, log=typer.echo, office_list=[office])
+        else:
+            r = import_labor_baseline(s, cfg.source_dir, log=typer.echo)
+        s.commit()
+    for k, v in r.items():
+        if isinstance(v, dict):
+            typer.echo(f"[{env}] {k}: {v}")
+        else:
+            typer.echo(f"[{env}] {k}: {v}")
+
+
 if __name__ == "__main__":
     app()

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -10,6 +10,7 @@ from app.model.derived import (
     DateRule, ExchangeRate, Investment, InvestmentAlloc, Notification, RecomputeJob,
     Relationship, ReturnCurve, Snapshot, SourceFileVersion, TimelineEvent, UserDataOverlay,
 )
+from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
 
 __all__ = [
     "Base",
@@ -18,4 +19,5 @@ __all__ = [
     "ReturnCurve", "ExchangeRate", "DateRule", "TimelineEvent", "Relationship",
     "UserDataOverlay", "Snapshot", "SourceFileVersion", "RecomputeJob", "Notification",
     "Investment", "InvestmentAlloc",
+    "LaborWageBenchmark", "LaborCpiGrowth", "LaborTaxBenchmark",
 ]

--- a/app/model/labor.py
+++ b/app/model/labor.py
@@ -1,0 +1,57 @@
+"""用工成本基准模型（API② · F-P1-10；DESIGN §13.2）。
+
+三张表承载本地基准，供 labor_cost.py 成本公式查询：
+- labor_wage_benchmark  工资基准（10 区×年）：投资/金融年薪 + 全行业人均 + CPI 定基
+- labor_cpi_growth      CPI 通胀 / 工资增幅（10 区×年，同比%）
+- labor_tax_benchmark   税率基准（12 office×年）：异结构参数 JSONB + 成本模型类型
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import BigInteger, Integer, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+from app.model.core import JSONBCompat
+
+
+class LaborWageBenchmark(Base):
+    __tablename__ = "labor_wage_benchmark"
+    # 含 currency：比/卢 2002 关池转 EUR 的行同时存 BEF/EUR 两值（同 region×year 两行）
+    __table_args__ = (UniqueConstraint("region", "year", "currency", name="uq_labor_wage_ryc"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    region: Mapped[str] = mapped_column(String, nullable=False)
+    year: Mapped[int] = mapped_column(Integer, nullable=False)
+    currency: Mapped[str] = mapped_column(String, nullable=False)
+    investment_fin_salary: Mapped[Optional[float]] = mapped_column(Numeric, comment="投资/金融行业年薪（税前，region 币种）")
+    avg_salary: Mapped[Optional[float]] = mapped_column(Numeric, comment="全行业人均名义年薪（基准）")
+    cpi_index: Mapped[Optional[float]] = mapped_column(Numeric, comment="CPI 定基指数（cpi_base_year=100）")
+    cpi_base_year: Mapped[Optional[int]] = mapped_column(Integer, comment="CPI 基年（中国系列2013；日本2015）")
+    source_file: Mapped[Optional[str]] = mapped_column(Text)
+
+
+class LaborCpiGrowth(Base):
+    __tablename__ = "labor_cpi_growth"
+    __table_args__ = (UniqueConstraint("region", "year", name="uq_labor_cpi_region_year"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    region: Mapped[str] = mapped_column(String, nullable=False)
+    year: Mapped[int] = mapped_column(Integer, nullable=False)
+    wage_growth_pct: Mapped[Optional[float]] = mapped_column(Numeric, comment="名义工资同比增幅%")
+    cpi_pct: Mapped[Optional[float]] = mapped_column(Numeric, comment="CPI 同比通胀%")
+
+
+class LaborTaxBenchmark(Base):
+    __tablename__ = "labor_tax_benchmark"
+    __table_args__ = (UniqueConstraint("office", "year", name="uq_labor_tax_office_year"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    office: Mapped[str] = mapped_column(String, nullable=False)
+    year: Mapped[int] = mapped_column(Integer, nullable=False)
+    formula: Mapped[str] = mapped_column(String, nullable=False,
+                                         comment="成本模型类型：single_pct/single_pct_cap/multi_cap/clamp/headcount/uk_nic/onss/ccss/jp")
+    params: Mapped[dict] = mapped_column(JSONBCompat, default=dict, nullable=False, server_default="{}")
+    source_file: Mapped[Optional[str]] = mapped_column(Text)

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -593,6 +593,7 @@ class Importer(Protocol):
 ```
 - 配置 provider + 凭据（本地）；结果出现在「导入状态」屏；失败进入需人工处理。
 - **凭据存放**：外部 API 凭据放本地 `secrets.local.yaml`（**不入 git、不入 DB**）；adapter 只通过配置键读取，不在日志或 notification 中泄露。
+- **实现（API② 用工成本 · F-P1-10）**：`app/core/labor_cost.py`（本地基准 + 税率公式执行器 + 逐岗位成本；Level/外包/晋级规则表，也是「加薪规则」屏数据源）+ `app/ingest/importers/positions.py`（`GET /public/positions?year=` 拉流入岗岗位 → 逐岗位算成本 → 每公司×年 `finance_entry(entity_kind='company', kind='expense')` 落账）。基准三表 `labor_wage_benchmark / labor_cpi_growth / labor_tax_benchmark`（`python -m app.ingest.main labor-baseline`）。税率公式细节只在后台（含说明文字隐藏项：比利时 CP200 十三薪/双倍假期、英国学徒税 >£3m、日本固定奖金 3 月等）；UI 只展示加薪规则。端点 `POST /labor-cost/compute`、`GET /labor-cost/rules|results`。
 
 ---
 
@@ -863,6 +864,7 @@ UI 派生操作（投资创建/赎回、划拨换汇）的编年史同步为**�
 | F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜API + 屏已上线；生产写入链路已接通（UI 派生 invest/redeem + ingest 镜像 source=file，issue #80），真实库 ingest 验收后再 ✅；编年史同步口径见 §19 决策备注（issue #86） | §5 | 🟨 |
 | F-P1-08 | **统一搜索** | LLM+embedding RAG（omlx 本地）条目检索装配 + serve 后处理｜⚠ 阻塞于本地 omlx 不可用，维持待续 | §18 | ⬜ |
 | F-P1-09 | 四类 UI 改数据操作 | 统一模板：年份×池 + 后传重算 + 失败整体拒绝 + overlay 同步｜useDataOp 钩子已用于投资/划拨屏 | §6.8/§19 | ✅ |
+| F-P1-10 | **用工成本·加薪规则** | 本地基准（工资/CPI/税率）+ 外部 API② 在岗岗位导入 → 逐岗位算用工成本 → 每公司 finance_entry 落账；「加薪规则/用工成本」屏展示加薪规则 + 拉岗位计算 + 结果表｜app/core/labor_cost.py + ingest/importers/positions.py；税率公式细节只在后台（含比利时十三薪/双倍假期、日本 3 月奖金等隐藏项） | §13 | ✅ |
 
 ### Phase 2 —— 事件 / 增强
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Transfer from './screens/Transfer'
 import Returns from './screens/Returns'
 import Finance from './screens/Finance'
 import Graph from './screens/Graph'
+import LaborCost from './screens/LaborCost'
 
 const TABS = [
   { key: 'dashboard', label: 'Dashboard' },
@@ -12,6 +13,7 @@ const TABS = [
   { key: 'transfer', label: '划拨/换汇' },
   { key: 'returns', label: '收益曲线' },
   { key: 'finance', label: '财务收支' },
+  { key: 'labor', label: '加薪规则/用工成本' },
   { key: 'persons', label: '人物图谱' },
   { key: 'companies', label: '公司图谱' },
   { key: 'graphall', label: '全图谱' },
@@ -58,6 +60,7 @@ export default function App() {
         {active === 'transfer' && <Transfer />}
         {active === 'returns' && <Returns />}
         {active === 'finance' && <Finance />}
+        {active === 'labor' && <LaborCost />}
         {active === 'persons' && <Graph url="/api/v1/graph/persons" />}
         {active === 'companies' && <Graph url="/api/v1/graph/companies" />}
         {active === 'graphall' && <Graph url="/api/v1/graph/all" />}

--- a/frontend/src/screens/LaborCost.jsx
+++ b/frontend/src/screens/LaborCost.jsx
@@ -1,0 +1,94 @@
+import { useMemo, useState } from 'react'
+import { useFetch, useDataOp } from './useDataOp'
+import { ErrorBox } from './ui'
+
+/**
+ * 加薪规则 / 用工成本屏（API② · F-P1-10）：
+ * - 规则区：加薪规则可视化（Level→调整%、外包系数、晋级、每年 CPI 增幅）——税率公式细节不显示。
+ * - 计算区：年份输入 + 「拉取岗位并计算」→ POST /labor-cost/compute，成功 refetch 结果。
+ * - 结果区：每公司×年用工成本只读表。
+ */
+export default function LaborCost() {
+  const [year, setYear] = useState('2001')
+  const rules = useFetch('/api/v1/labor-cost/rules')
+  const results = useFetch('/api/v1/labor-cost/results' + (year ? `?year=${year}` : ''))
+  const op = useDataOp(() => results.refresh())
+
+  const doCompute = () => op.submit('/api/v1/labor-cost/compute', { year: Number(year) || 2001 })
+
+  const r = rules.data || {}
+  const levelEntries = useMemo(() => Object.entries(r.level_adjust_pct || {}), [r])
+  const outsourceEntries = Object.entries(r.outsource_factor || {})
+  const items = results.data?.items || []
+
+  return (
+    <div className="screen">
+      <div className="panel">
+        <h3>用工成本 · 数据</h3>
+        <p className="note">来源：人才成本基准（工资/CPI/税率）+ 外部在岗岗位（API②）</p>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '8px 0' }}>
+          <label className="note">年份</label>
+          <input type="number" min={1900} max={2999} value={year}
+            onChange={e => setYear(e.target.value)} />
+          <button className="primary" disabled={op.busy} onClick={doCompute}>
+            {op.busy ? '计算中…' : '拉取岗位并计算'}
+          </button>
+          <ErrorBox error={op.error} />
+        </div>
+        {op.last && (
+          <p className="note">
+            已处理 {op.last.positions_fetched ?? 0} 个岗位 → {op.last.companies_computed?.companies?.length ?? 0} 家公司落账。
+          </p>
+        )}
+      </div>
+
+      <div className="panel">
+        <h3>加薪规则</h3>
+        <p className="note">基础年薪 = 工作地点地区「投资/金融行业年薪」（按岗位 opening 年份）× (1 + Level 调整%)</p>
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            <tr><th>级别</th><th>调整%</th></tr>
+          </thead>
+          <tbody>
+            {levelEntries.map(([k, v]) => (
+              <tr key={k}><td>{k}</td><td>{v}%</td></tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="note">{r.cpi_rule}</p>
+        <p className="note">{r.base_rule ? '基础：' + r.base_rule : ''}</p>
+      </div>
+
+      <div className="panel">
+        <h3>外包类基准</h3>
+        <p className="note">{r.outsource_base}</p>
+        {outsourceEntries.map(([k, v]) => (
+          <p key={k} className="note">{k}：× {v}</p>
+        ))}
+        <p className="note">晋升：每跨一级 × (1 + {r.promotion_step_pct}%)；固定奖金：默认 {r.bonus_months_default} 个月，日本 {r.bonus_months_japan} 个月</p>
+      </div>
+
+      <div className="panel">
+        <h3>用工成本结果{year ? `（${year}）` : ''}</h3>
+        {items.length === 0 ? (
+          <p className="note">{op.busy ? '…' : '暂无结果（先点「拉取岗位并计算」）'}</p>
+        ) : (
+          <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+            <thead>
+              <tr><th>年份</th><th>公司</th><th>币种</th><th>用工成本</th></tr>
+            </thead>
+            <tbody>
+              {items.map((x, i) => (
+                <tr key={i}>
+                  <td>{x.year}</td><td>{x.company_name}</td>
+                  <td>{x.currency}</td>
+                  <td>{x.amount != null ? x.amount.toLocaleString() : ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/migrations/versions/d1e2f3a4b5c6_labor_cost_benchmark.py
+++ b/migrations/versions/d1e2f3a4b5c6_labor_cost_benchmark.py
@@ -1,0 +1,61 @@
+"""用工成本基准三表（API② · F-P1-10；DESIGN §13.2）。
+
+labor_wage_benchmark / labor_cpi_growth / labor_tax_benchmark
+承载本地基准（工资 10 区、CPI 10 区、税率 12 office），供 labor_cost.py 成本公式查询。
+
+Revision ID: d1e2f3a4b5c6
+Revises: c1d2e3f4a5b6
+Create Date: 2026-08-24
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'd1e2f3a4b5c6'
+down_revision = 'c1d2e3f4a5b6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "labor_wage_benchmark",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("region", sa.String(), nullable=False),
+        sa.Column("year", sa.Integer(), nullable=False),
+        sa.Column("currency", sa.String(), nullable=False),
+        sa.Column("investment_fin_salary", sa.Numeric()),
+        sa.Column("avg_salary", sa.Numeric()),
+        sa.Column("cpi_index", sa.Numeric()),
+        sa.Column("cpi_base_year", sa.Integer()),
+        sa.Column("source_file", sa.Text()),
+        # 含 currency：比/卢 2002 关池转 EUR 同 region×year 存 BEF/EUR 两行
+        sa.UniqueConstraint("region", "year", "currency", name="uq_labor_wage_ryc"),
+    )
+    op.create_table(
+        "labor_cpi_growth",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("region", sa.String(), nullable=False),
+        sa.Column("year", sa.Integer(), nullable=False),
+        sa.Column("wage_growth_pct", sa.Numeric(), comment="名义工资同比增幅%"),
+        sa.Column("cpi_pct", sa.Numeric(), comment="CPI 同比通胀%"),
+        sa.UniqueConstraint("region", "year", name="uq_labor_cpi_region_year"),
+    )
+    op.create_table(
+        "labor_tax_benchmark",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("office", sa.String(), nullable=False),
+        sa.Column("year", sa.Integer(), nullable=False),
+        sa.Column("formula", sa.String(), nullable=False,
+                  comment="成本模型类型：single_pct/single_pct_cap/multi_cap/clamp/headcount/uk_nic/onss/ccss/jp"),
+        sa.Column("params", postgresql.JSONB(astext_type=sa.Text()),
+                  nullable=False, server_default="{}"),
+        sa.Column("source_file", sa.Text()),
+        sa.UniqueConstraint("office", "year", name="uq_labor_tax_office_year"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("labor_tax_benchmark")
+    op.drop_table("labor_cpi_growth")
+    op.drop_table("labor_wage_benchmark")

--- a/tests/test_labor_baseline.py
+++ b/tests/test_labor_baseline.py
@@ -1,0 +1,102 @@
+"""用工成本基准解析器单测（API② · F-P1-10）。
+
+覆盖已知坑：CPI 全角/半角双分隔符(含 TKY)、`*`/千分位剥离、比/卢 2002 双币拆行、
+日本 CPI 基年 2015、税率北京第二张对比表排除（防重复键）。
+"""
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from app.ingest import labor_baseline as L
+
+
+WAGE_8COL = (
+    "| 年份 | 全行业人均名义年薪（基准） | 币种 | CPI(2013=100) | 投资/金融行业年薪 | 高科技/ICT行业年薪 | 企业年度税费总和 | 总用工成本（税前+税费） |\n"
+    "| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |\n"
+    "{rows}"
+)
+
+
+def test_wage_dual_currency_2002_splits( tmp_path):
+    rows = (
+        "| 1982 | 673730.00* | BEF | 35.05 | 1010595.00* | 943222.00* | 161695.00 | 835425.00 |\n"
+        "| 2002 | 1560000.00 / 38672.00 | BEF / EUR | 61.44 | 2340000.00 / 58008.00 | 2184000.00 / 54141.00 | 374400.00 / 9282.00 | 1934400.00 / 47953.00 |\n"
+    )
+    p = tmp_path / "比利时.md"
+    p.write_text(WAGE_8COL.format(rows=rows), encoding="utf-8")
+    recs = L.parse_wage_file(p, "比利时")
+    assert len(recs) == 3  # 1982 BEF + 2002 BEF/EUR
+    by = {(r["year"], r["currency"]): r for r in recs}
+    assert by[(1982, "BEF")]["investment_fin_salary"] == 1010595.0
+    assert by[(2002, "BEF")]["investment_fin_salary"] == 2340000.0
+    assert by[(2002, "EUR")]["investment_fin_salary"] == 58008.0
+    assert all(r["cpi_base_year"] == 2013 for r in recs)
+
+
+def test_wage_japan_cpi_base_2015(tmp_path):
+    p = tmp_path / "日本东京.md"
+    p.write_text(WAGE_8COL.format(
+        rows="| 2002 | 4480000* | JPY | 97.48 | 5790000* | 5370000* | 717000* | 5197000* |\n"),
+        encoding="utf-8")
+    recs = L.parse_wage_file(p, "日本东京")
+    assert recs[0]["cpi_base_year"] == 2015
+    assert recs[0]["currency"] == "JPY"
+
+
+def test_cpi_mixed_separators_including_tky(tmp_path):
+    p = tmp_path / "CPI工资.md"
+    p.write_text(
+        "# 头\n"
+        "地区｜年份｜工资增幅｜CPI通胀\n"
+        "BEL｜1982｜9.30｜8.73\n"
+        "TKY|2002|-1.45|-0.91\n"
+        "TKY|2025|2.45|2.10|\n",  # 末行多尾竖线
+        encoding="utf-8")
+    recs = L.parse_cpi_file(p)
+    by = {(r["region"], r["year"]): r for r in recs}
+    assert len(recs) == 3
+    assert by[("比利时", 1982)]["wage_growth_pct"] == 9.30
+    # TKY 半角 + 尾竖线都能解析
+    assert by[("日本东京", 2002)]["wage_growth_pct"] == -1.45
+    assert by[("日本东京", 2002)]["cpi_pct"] == -0.91
+    assert by[("日本东京", 2025)]["cpi_pct"] == 2.10
+
+
+def test_tax_ignores_second_table(tmp_path):
+    """北京 md 有主税率表 + 「北京 vs 上海」对比表（首列含年份），只取主表。"""
+    main = (
+        "| 年份 | 单位养老 | 单位医疗(含生育) | 单位失业 | 单位工伤(金融一类) | 单位社保合计(不含公积金) | 公积金单位(建模) | 社保月缴费上限(元) | 社保月缴费下限(元) | 政策要点 |\n"
+        "| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |\n"
+        "| 2002 | 20.0% | 10.0% | 1.5% | 0.2% | 31.70% | 8% | 4524 | 905 | 五险框架建立 |\n"
+        "| 2003 | 20.0% | 10.0% | 1.5% | 0.2% | 31.70% | 8% | 5235 | 1047 | 费率不变 |\n"
+        "\n"
+        "## 北京 vs 上海\n"
+        "| 项目 | 北京 | 上海 |\n"
+        "| 2025年单位社保合计 | 27.80% | 25.70% |\n"
+        "| 2002年初始单位社保合计 | 31.70% | 35.20% |\n"
+    )
+    p = tmp_path / "中国北京.md"
+    p.write_text(main, encoding="utf-8")
+    recs = L.parse_tax_file(p, "中国北京", "中国北京")
+    assert len(recs) == 2                                # 只有 2002/2003 主表，无对比表行
+    assert {r["year"] for r in recs} == {2002, 2003}
+    assert recs[0]["formula"] == "clamp"
+    assert "pension_pct" in recs[0]["params"]
+    assert recs[0]["params"]["soc_pct"] == 31.70
+    assert recs[0]["params"]["monthly_floor"] == 905.0
+
+
+def test_tax_uk_fiscal_year_and_params(tmp_path):
+    p = tmp_path / "英国.md"
+    body = (
+        "|财年|雇主NI基准费率(超额部分)|雇主NI次级起征点(年)|法定最低带薪年假(天)|雇主最低养老金缴费|办公室工伤商业险参考费率|备注|\n"
+        "|---:|---:|---:|---:|---:|---:|---|\n"
+        "|2002-03|11.8%|£4615|20|0%|0.4%|无强制养老金|\n"
+        "|2025-26|15.0%|£5000|28|3%|0.4%|2025-04-06 生效|\n"
+    )
+    p.write_text(body, encoding="utf-8")
+    recs = L.parse_tax_file(p, "英国", "英国")
+    assert [(r["year"], r["formula"]) for r in recs] == [(2002, "uk_nic"), (2025, "uk_nic")]
+    assert recs[0]["params"]["nic_pct"] == 11.8
+    assert recs[0]["params"]["nic_threshold"] == 4615.0

--- a/tests/test_labor_cost.py
+++ b/tests/test_labor_cost.py
@@ -1,0 +1,193 @@
+"""用工成本公式 + 落账单测（API② · F-P1-10）。
+
+覆盖：内部全职基准年薪/Level 调整、逐年 CPI 增幅（负不涨）、外包基准系数、
+日本 3 月奖金、在岗月折算、按公司聚合写 finance_entry、加薪规则 payload。
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.app import app
+from app.api.deps import get_db
+from app.api.labor_cost import compute as labor_compute
+from app.core import labor_cost as L
+from app.db import Base
+from app.ingest.importers import positions
+from app.model import Entity, FinanceEntry
+from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    S = sessionmaker(bind=engine)
+    s = S()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _seed_be(db):
+    """比利时基准：工资(1982/2000)、CPI(1982-83)、税率(1982/2000)。"""
+    db.add_all([
+        LaborWageBenchmark(region="比利时", year=1982, currency="BEF",
+                           investment_fin_salary=1010595.0, avg_salary=673730.0,
+                           cpi_index=35.05, cpi_base_year=2013),
+        LaborWageBenchmark(region="比利时", year=2000, currency="BEF",
+                           investment_fin_salary=2190000.0, avg_salary=1460000.0),
+        LaborCpiGrowth(region="比利时", year=1983, wage_growth_pct=8.1, cpi_pct=7.66),
+        LaborTaxBenchmark(office="比利时", year=1982, formula="onss",
+                          params={"onss_pct": 31.5, "wc_pct": 0.32}),
+    ])
+    db.commit()
+
+
+def _pos(**over):
+    d = {"work_location": "布鲁塞尔", "level": "B8b", "opening_date": "1982-01-01",
+         "closing_date": None, "position_type": "Employee",
+         "position_name": "Executive Assistant",
+         "legal_category": "法律强制·内部全职不可外包",
+         "company_id": 5, "company_name": "Peeters Luxembourg S.à r.l."}
+    d.update(over)
+    return d
+
+
+def test_internal_salary_table_30pct(db):
+    _seed_be(db)
+    # B8b 按级别表 = 30% → ×1.3（注意：用户示例文字写 B8b→1.2，与级别表 30% 冲突，见待确认清单）
+    assert L.compute_annual_salary(db, _pos(), 1982) == pytest.approx(1010595 * 1.3)
+    # B8a(20%) 等比验证 ×1.2
+    s = L.compute_annual_salary(db, _pos(level="B8a"), 1982)
+    assert s == pytest.approx(1010595 * 1.2)
+
+
+def test_cpi_increase_and_negative_no_raise(db):
+    _seed_be(db)
+    assert L.compute_annual_salary(db, _pos(), 1983) == pytest.approx(1010595 * 1.3 * 1.081)
+    # 负增幅 → 不涨（插入 1984 负增长，1982→1984 应与 1982 保持一致增长率链：仅1983涨）
+    db.add(LaborCpiGrowth(region="比利时", year=1984, wage_growth_pct=-3.0, cpi_pct=1.0))
+    db.commit()
+    assert L.compute_annual_salary(db, _pos(), 1984) == pytest.approx(1010595 * 1.3 * 1.081)
+
+
+def test_outsourced_uses_avg_x_factor(db):
+    _seed_be(db)
+    p = _pos(position_type="Outsourced External - External Employee", level=None,
+             opening_date="2000-01-01", legal_category="法律强制·允许第三方外包",
+             work_location="布鲁塞尔")
+    # 当年 avg(1460000) × 1.2
+    assert L.compute_annual_salary(db, p, 2000) == pytest.approx(1460000 * 1.2)
+
+
+def test_locate_prefers_work_location_then_country(db):
+    _seed_be(db)
+    # country_or_region 兜底：work_location 空 → 用 "Country·卢森堡"
+    p = _pos(work_location="", country_or_region="Country·卢森堡")
+    # 卢森堡无税率基准（_seed只比利时），但应先定位到 region=卢森堡
+    c = L._locate(p)
+    assert c is not None and c[0] == "卢森堡"
+    # work_location 优先：即便 country 写布鲁塞尔，仍以 work_location 为准
+    p2 = _pos(work_location="布鲁塞尔", country_or_region="Country·卢森堡")
+    assert L._locate(p2)[0] == "比利时"
+    # 比利时成本可算
+    r = L.compute_position_cost(db, p2, 1982)
+    assert r is not None and r["salary"] == pytest.approx(1010595 * 1.3)
+
+
+def test_japan_3_month_bonus(db):
+    db.add(LaborWageBenchmark(region="日本东京", year=2002, currency="JPY",
+                              investment_fin_salary=5790000.0, avg_salary=4480000.0))
+    db.add(LaborTaxBenchmark(office="日本东京", year=2002, formula="jp",
+                             params={"kosei_pct": 8.675, "kenpo_pct": 4.25, "kaigo_pct": 0.41,
+                                     "koyo_pct": 0.85, "rosa_pct": 0.25,
+                                     "kosei_cap": 590000, "kenpo_cap": 980000}))
+    db.commit()
+    p = _pos(work_location="东京", level="B6", opening_date="2002-01-01")
+    r = L.compute_position_cost(db, p, 2002)
+    # 日本基准×1.05(B6) = 5790000*1.05；奖金 = salary/12*3
+    assert r["bonus"] == pytest.approx((5790000 * 1.05) / 12 * 3)
+
+
+def test_overlap_months(db):
+    assert L._overlap_months("2001-06-15", None, 2002) == 12
+    assert L._overlap_months("2002-06-15", None, 2002) == 7      # 6月~12月
+    assert L._overlap_months("2000-01-01", "2002-03-31", 2002) == 3  # 1~3月
+    assert L._overlap_months(None, None, 2002) == 0
+    assert L._overlap_months("2003-01-01", None, 2002) == 0      # opening 在年后 → 不计
+
+
+def test_aggregate_writes_finance_entry(db):
+    _seed_be(db)
+    db.add(Entity(entity_type="company", name="Peeters Luxembourg S.à r.l."))
+    db.commit()
+    costs = [L.compute_position_cost(db, _pos(), 1982)]
+    agg = positions.aggregate_to_finance(db, costs, 1982)
+    db.commit()
+    assert agg["companies"][0]["positions"] == 1
+    ent = db.execute(select(Entity).where(Entity.name == "Peeters Luxembourg S.à r.l.")).scalar_one()
+    fe = db.execute(select(FinanceEntry).where(FinanceEntry.entity_id == ent.id)).scalar_one()
+    assert fe.kind == "expense" and fe.entity_kind == "company"
+    assert fe.currency == "BEF" and str(fe.label).startswith("用工成本·")
+
+
+def test_rules_payload():
+    r = L.rules_payload()
+    assert r["level_adjust_pct"]["M11b"] == 5 and r["level_adjust_pct"]["M11a"] == 100
+    assert r["bonus_months_japan"] == 3 and r["bonus_months_default"] == 2
+    assert r["promotion_step_pct"] == 5
+
+
+class TestEndpoint:
+    def test_compute_route_with_stubbed_runner(self, db):
+        """POST /compute：monkeypatch run_labor_cost 成功 → 200，且每公司落账。"""
+        _seed_be(db)
+        db.add(Entity(entity_type="company", name="Peeters Luxembourg S.à r.l."))
+        db.commit()
+        monkeypatch = pytest.MonkeyPatch()
+        import app.api.labor_cost as api_mod
+        monkeypatch.setattr(api_mod, "run_labor_cost",
+                            lambda s, year, cids=None: _fake_runner(s, year))
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            with TestClient(app) as c:
+                r = c.post("/api/v1/labor-cost/compute", json={"year": 1982})
+                assert r.status_code == 200, r.text
+                assert r.json()["positions_fetched"] == 1
+                # 落账后 results 可见
+                res = c.get("/api/v1/labor-cost/results?year=1982").json()["items"]
+                assert res and res[0]["company_name"] == "Peeters Luxembourg S.à r.l."
+        finally:
+            monkeypatch.undo()
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_rules_and_results_routes(self, db):
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            with TestClient(app) as c:
+                r = c.get("/api/v1/labor-cost/rules").json()
+                assert r["level_adjust_pct"]["M11b"] == 5
+                assert c.get("/api/v1/labor-cost/results?year=1982").status_code == 200
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+def _fake_runner(s, year):
+    """统合一个岗位→算成本→聚合（免网）；供 /compute 路由测试复用真实计算链。"""
+    L_ = L
+    pos = _pos()
+    c = L_.compute_position_cost(s, pos, year)
+    agg = positions.aggregate_to_finance(s, [c], year)
+    return {"year": year, "positions_fetched": 1, "companies_computed": agg}


### PR DESCRIPTION
## 背景
API①（公司导入）后，API② 是「用工成本计算」：外部系统旧「基准包推送+报告拉取」链路已废弃，**计算权移交我方**——外部只导出在岗岗位（`GET /public/positions`，无成本字段），我方用本地基准算每公司用工成本。

## 三个用户决策
1. 基准落库：工资/CPI/税率 建 DB 表 + ingest 落库。
2. 成本输出：每公司×年 → `finance_entry(company, expense)`。
3. 一屏两用：「加薪规则/用工成本」屏 = 加薪规则可视化 + 拉岗位计算 + 结果表；税率公式细节只在后台。

## 改动
| 文件 | 内容 |
|---|---|
| `app/model/labor.py` + `migrations/d1e2f3a4b5c6` | 三张基准表 |
| `app/ingest/labor_baseline.py` + `ingest/main.py:labor-baseline` | 工资/CPI/税率解析落库（处理 CPI 全角/半角双分隔含 TKY、2002 双币、日本 CPI 基年 2015、北京对比表排除） |
| `app/core/labor_cost.py` | 成本公式：投资/金融年薪(opening)×Level→逐年CPI(负不涨)→office税率(11类+隐藏项 比利时十三薪/双倍假期/英国学徒税/日本3月奖金)→在岗月折算；外包×1.05/1.2；晋升5%/级；加薪规则单源 |
| `app/ingest/importers/positions.py` | `/public/positions` → 逐岗位成本 → 按我方公司聚合 `finance_entry` 落账(ID 幂等) |
| `app/api/labor_cost.py` + `app.py` | `POST /compute` + `GET /rules\|results` |
| `frontend/src/screens/LaborCost.jsx` + `App.jsx` | 新「加薪规则/用工成本」屏 |
| `tests/test_labor_baseline.py` + `test_labor_cost.py` | 14 个用例 |

## 已确认规则
级别表 B8b=30%；location 优先、country 兜底；北京→上海工资代理；香港无税（tax=None）。

## 验证
- 全量 `272 passed`，无回归；前端 `vite build` 通过。
- 真实 e2e：外部系统(7273)启动后点「拉取岗位并计算」→ 财务收支屏出现各公司用工成本（当前外部未起，/compute 返回 502 优雅降级且不落库，已实测）。

## 说明/取舍
- 晋升跨级数 5%/级为决定式计算；晋升链精确化（关旧开新需老薪资）待补。
- work_location 别名表 `LOCATION_ALIAS` 为初稿，待用户给外部实际 location 清单校正。
- 卢森堡 5×SSM 工资上限、丹麦等无上限假设在公式常量；税率隐藏项固化 in labor_cost.py。