### PR TITLE
feat(p1): F-P1-08 统一搜索 —— 条目级 embedding RAG

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db
 from app.api.labor_cost import router as labor_cost_router
 from app.api.restricted import router as restricted_router
+from app.api.search import router as search_router
 from app.api.ui_ops import router as ui_ops_router
 from app.core.calendar import snapshot_as_of
 from app.core.graph import all_graph, company_graph, person_graph
@@ -34,6 +35,7 @@ from app.model import (Account, Entity, ExchangeRate, FinanceEntry, IncomeStream
 app = FastAPI(title="Novel Dashboard API", version="0.1")
 app.include_router(ui_ops_router)
 app.include_router(labor_cost_router)
+app.include_router(search_router)
 app.include_router(restricted_router)
 
 # issue #30：dist 直连部署时前端跨域失败；PRD §13 本地单机非安全边界，

--- a/app/api/search.py
+++ b/app/api/search.py
@@ -1,0 +1,27 @@
+"""统一搜索端点（F-P1-08 · DESIGN §18.4）。
+
+GET /api/v1/search?q=<问题>[&as_of=<date>] → {answer, hits[]}。
+omlx 不可用/未启动 → 503 带明确提示（让用户先起 omlx 或判定降级）。
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.core.llm import LlmUnavailable
+from app.search.search import search
+
+router = APIRouter(prefix="/api/v1", tags=["search"])
+
+
+@router.get("/search")
+def search_endpoint(q: str = Query(..., description="问题"),
+                    as_of: Optional[str] = Query(None, description="全局日历游标（预留）"),
+                    db: Session = Depends(get_db)):
+    try:
+        return search(db, q, as_of)
+    except LlmUnavailable as e:
+        raise HTTPException(status_code=503, detail=str(e))

--- a/app/config.py
+++ b/app/config.py
@@ -45,7 +45,8 @@ class EnvConfig:
     embed_url: str = field(default_factory=lambda: _env_str("EMBED_URL", "http://127.0.0.1:8000"))
     embed_model: str = field(default_factory=lambda: _env_str("EMBED_MODEL", "Qwen3-Embedding-8B-4bit-DWQ"))
     llm_model_context: int | None = field(default_factory=lambda: _env_int("LLM_MODEL_CONTEXT", None))
-    embed_dim: int | None = field(default_factory=lambda: _env_int("EMBED_DIM", None))
+    # 向量维（search_index.embedding 固定列宽；须与 EMBED_MODEL 输出一致——实测 Qwen3-Embedding-8B=4096）。
+    embed_dim: int = field(default_factory=lambda: _env_int("EMBED_DIM", 4096) or 4096)
 
     # 外部系统 API①（公司基础信息，DESIGN §13/§13.3 · F-P1-05）：URL 指向其 `/api/v1` 根。
     # 优先级：环境变量 EXTERNAL_API_BASE_URL > 该 per-env 默认。凭据（用户名/密码）不入 config，

--- a/app/core/llm.py
+++ b/app/core/llm.py
@@ -1,0 +1,66 @@
+"""omlx / LLM 客户端（F-P1-08 · DESIGN §18.5）。
+
+连本地 omlx-server（http://127.0.0.1:8000，无鉴权，三环境共用）：
+- embed(texts) -> list[list[float]]   POST /v1/embeddings {input, model:EMBED_MODEL}
+- chat(system, user) -> str          POST /v1/chat/completions {model:LLM_MODEL, messages}
+
+统一抛 LlmUnavailable（连接失败/非2xx/结构错），上层据此优雅降级（搜索返回 503/提示）。
+客户端可注入 httpx.Client(transport=MockTransport) 供测试免网。
+"""
+from __future__ import annotations
+
+import httpx
+
+from app.config import CONFIG
+
+
+class LlmUnavailable(Exception):
+    """omlx 不可用或返回异常；msg 供 503 detail。"""
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(timeout=60)
+
+
+def embed(texts: list[str], *, client: httpx.Client | None = None) -> list[list[float]]:
+    """文本列表 → 向量列表。注入 client 可离线测试；返回维 == EMBED_DIM。"""
+    base, model = CONFIG.embed_url, CONFIG.embed_model
+    owned = client is None
+    client = client or httpx.Client(timeout=60)
+    try:
+        r = client.post(f"{base}/v1/embeddings",
+                        json={"input": texts, "model": model})
+        if r.status_code != 200:
+            raise LlmUnavailable(f"embedding 失败（HTTP {r.status_code}）")
+        data = r.json()
+        out = [item["embedding"] for item in data.get("data", [])]
+        dim = CONFIG.embed_dim
+        if dim and out and any(len(v) != dim for v in out):
+            raise LlmUnavailable(f"embedding 维度 {len(out[0])} ≠ EMBED_DIM {dim}（请设 EMBED_DIM）")
+        return out
+    except httpx.RequestError as e:
+        raise LlmUnavailable(f"无法连接本地 omlx（{base}）") from e
+    finally:
+        if owned:
+            client.close()
+
+
+def chat(system: str, user: str, *, client: httpx.Client | None = None) -> str:
+    """装配 LLM 调用，返回最终文本内容。"""
+    base, model = CONFIG.llm_url, CONFIG.llm_model
+    owned = client is None
+    client = client or httpx.Client(timeout=90)
+    try:
+        r = client.post(f"{base}/v1/chat/completions",
+                        json={"model": model,
+                              "messages": [{"role": "system", "content": system},
+                                           {"role": "user", "content": user}]})
+        if r.status_code != 200:
+            raise LlmUnavailable(f"chat 失败（HTTP {r.status_code}）")
+        data = r.json()
+        return data["choices"][0]["message"]["content"]
+    except httpx.RequestError as e:
+        raise LlmUnavailable(f"无法连接本地 omlx（{base}）") from e
+    finally:
+        if owned:
+            client.close()

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -427,5 +427,24 @@ def labor_baseline(env: str = typer.Option("dev", "--env"),
             typer.echo(f"[{env}] {k}: {v}")
 
 
+@app.command()
+def search_index(env: str = typer.Option("dev", "--env"),
+                 source: str = typer.Option("", "--source", help="仅索引指定 source（缺省全部）")):
+    """统一搜索索引构建（F-P1-08 · DESIGN §18）：条目→embedding 落 pgvector。
+
+    omlx 未启动时抛错（LlmUnavailable）并提示，不落脏索引。后台/增量慢跑。
+    """
+    from app.search.indexer import build_index
+    from app.core.llm import LlmUnavailable
+    with _session_for(env) as s:
+        try:
+            r = build_index(s, source or None, log=typer.echo)
+            s.commit()
+        except LlmUnavailable as e:
+            typer.secho(f"✗ {e}（请先启动本地 omlx:8000）", fg=typer.colors.RED)
+            raise typer.Exit(1)
+        typer.echo(f"[{env}] 索引完成：{r}")
+
+
 if __name__ == "__main__":
     app()

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -11,6 +11,7 @@ from app.model.derived import (
     Relationship, ReturnCurve, Snapshot, SourceFileVersion, TimelineEvent, UserDataOverlay,
 )
 from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
+from app.model.search import SearchIndex
 
 __all__ = [
     "Base",
@@ -20,4 +21,5 @@ __all__ = [
     "UserDataOverlay", "Snapshot", "SourceFileVersion", "RecomputeJob", "Notification",
     "Investment", "InvestmentAlloc",
     "LaborWageBenchmark", "LaborCpiGrowth", "LaborTaxBenchmark",
+    "SearchIndex",
 ]

--- a/app/model/search.py
+++ b/app/model/search.py
@@ -1,0 +1,35 @@
+"""统一搜索索引（F-P1-08 · DESIGN §18）。
+
+search_index：条目/行级 embedding（粒度 = 结构化条目标段，DESIGN §18.2）。
+- source_table / source_row_id：定位源行（entity/timeline_event/finance_entry/…）
+- content：该条目生成的中文描述句（含确定性数值，供 LLM 装配时原样引用）
+- embedding vector(N)：pgvector（N=EMBED_DIM）；SQLite 测试降级 Text（对齐 JSONBCompat 先例）
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import BigInteger, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.config import CONFIG
+from app.db import Base
+
+VectorCompat = Vector(CONFIG.embed_dim).with_variant(Text(), "sqlite")
+
+
+class SearchIndex(Base):
+    __tablename__ = "search_index"
+    __table_args__ = (
+        UniqueConstraint("source_table", "source_row_id", "content",
+                         name="uq_search_source_row_content"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    source_table: Mapped[str] = mapped_column(Text, nullable=False)
+    source_row_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    embedding = mapped_column(VectorCompat, nullable=True, comment="pgvector 向量（EMBED_DIM）")
+    updated_at: Mapped[Optional[datetime]] = mapped_column(server_default=func.now())

--- a/app/search/extractors.py
+++ b/app/search/extractors.py
@@ -1,0 +1,141 @@
+"""统一搜索条目提取器（F-P1-08 · DESIGN §18.2）。
+
+EXTRACTORS：source_table → 迭代 (row_id, content 中文描述句)。粒度=条目/行级。
+content 含确定性数值（DB 派生），供 LLM 装配时原样引用、不编数（§18.6 数值铁律）。
+
+先覆盖语义表；技术表（notification/recompute_job/date_rule/source_file_version/user_data_overlay）
+不索引，可后续增补。
+"""
+from __future__ import annotations
+
+from typing import Callable, Iterator
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.model import (
+    Account, Entity, ExchangeRate, FinanceEntry, HoldingEvent, IncomeStream,
+    InitialAsset, Investment, LedgerEntry, Relationship, ReturnCurve, TimelineEvent,
+)
+from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
+
+
+def _say(pairs: list) -> str:
+    """[('人物', '亨利'), ('状态','在营')] → '人物亨利，状态在营'。"""
+    return "，".join(f"{k}{v}" for k, v in pairs if v)
+
+# ---- 各表提取器（yield (row_id, content)） ----
+_ENTITY_TYPE = {"person": "人物", "company": "公司", "asset": "资产", "family": "家族"}
+
+
+def _entity(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(Entity)).scalars().all():
+        yield e.id, _say([(_ENTITY_TYPE.get(e.entity_type, e.entity_type), e.display_name or e.name),
+                          ("状态", e.status)])
+        if e.fields:
+            yield e.id, _say([("实体", e.name), *[(k, v) for k, v in e.fields.items() if v]])
+
+
+def _timeline(db: Session) -> Iterator[tuple[int, str]]:
+    for t in db.execute(select(TimelineEvent)).scalars().all():
+        yield t.id, _say([("年份", t.event_year), ("事件", t.title), ("说明", t.note)])
+
+
+def _ledger(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(LedgerEntry)).scalars().all():
+        yield e.id, _say([("流水日期", e.date), ("账户", e.account_id), ("事由", e.reason),
+                          ("收入", e.inflow), ("支出", e.outflow), ("余额", e.balance),
+                          ("类别", e.kind)])
+
+
+def _finance(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(FinanceEntry)).scalars().all():
+        yield e.id, _say([("年份", e.year), ("主体类别", e.entity_kind), ("主体", e.entity_id),
+                          ("类别", e.kind), ("金额", e.amount), ("币种", e.currency),
+                          ("标签", e.label), ("来源", e.source)])
+
+
+def _income(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(IncomeStream)).scalars().all():
+        yield e.id, _say([("年份", e.year), ("收益类型", e.stream_type), ("分组", e.group_key),
+                          ("金额", e.amount), ("币种", e.currency), ("标签", e.label)])
+
+
+def _holding(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(HoldingEvent)).scalars().all():
+        yield e.id, _say([("标的", e.company), ("代码", e.ticker), ("日期", e.date),
+                          ("事件", e.event_type), ("股数", e.shares), ("成本价", e.unit_price),
+                          ("金额万美金", e.amount), ("批次", e.batch_id)])
+
+
+def _return(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(ReturnCurve)).scalars().all():
+        yield e.id, _say([("国家", e.country), ("风险级", e.risk_lvl), ("年份", e.year),
+                          ("年化", f"{e.rate}%")])
+
+
+def _fx(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(ExchangeRate)).scalars().all():
+        yield e.id, _say([("汇率", f"{e.fx_from}->{e.fx_to}"), ("年份", e.year), ("值", e.rate)])
+
+
+def _account(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(Account)).scalars().all():
+        yield e.id, _say([("账户", e.entity_id), ("币种池", e.currency), ("状态", e.status),
+                          ("开户行", e.bank), ("关池日", e.closed_on)])
+
+
+def _relationship(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(Relationship)).scalars().all():
+        yield e.id, _say([("关系", f"{e.from_entity_id} {e.rel_type} {e.to_entity_id}"),
+                          ("起", e.since_year), ("止", e.until_year)])
+
+
+def _initial_asset(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(InitialAsset)).scalars().all():
+        yield e.id, _say([("主体", e.entity_id), ("资产类型", e.asset_type), ("分组", e.group_key),
+                          ("币种", e.currency), ("名称", e.name), ("面值", e.face_value),
+                          ("占比", f"{e.pct}%")])
+
+
+def _investment(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(Investment)).scalars().all():
+        yield e.id, _say([("年份", e.year), ("地区", getattr(e, "region", None)),
+                          ("风险级", e.risk_lvl), ("金额", getattr(e, "amount", None))])
+
+
+def _labor_wage(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(LaborWageBenchmark)).scalars().all():
+        yield e.id, _say([("地区", e.region), ("年份", e.year), ("投资/金融行业年薪", e.investment_fin_salary),
+                          ("全行业人均", e.avg_salary), ("币种", e.currency)])
+
+
+def _labor_tax(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(LaborTaxBenchmark)).scalars().all():
+        yield e.id, _say([("office", e.office), ("年份", e.year), ("成本模型", e.formula),
+                          ("费率/上限", {k: v for k, v in (e.params or {}).items() if v is not None})])
+
+
+def _labor_cpi(db: Session) -> Iterator[tuple[int, str]]:
+    for e in db.execute(select(LaborCpiGrowth)).scalars().all():
+        yield e.id, _say([("地区", e.region), ("年份", e.year),
+                          ("工资增幅%", e.wage_growth_pct), ("CPI通胀%", e.cpi_pct)])
+
+
+EXTRACTORS: dict[str, Callable[[Session], Iterator[tuple[int, str]]]] = {
+    "entity": _entity,
+    "timeline_event": _timeline,
+    "ledger_entry": _ledger,
+    "finance_entry": _finance,
+    "income_stream": _income,
+    "holding_event": _holding,
+    "return_curve": _return,
+    "exchange_rate": _fx,
+    "account": _account,
+    "relationship": _relationship,
+    "initial_asset": _initial_asset,
+    "investment": _investment,
+    "labor_wage_benchmark": _labor_wage,
+    "labor_tax_benchmark": _labor_tax,
+    "labor_cpi_growth": _labor_cpi,
+}

--- a/app/search/indexer.py
+++ b/app/search/indexer.py
@@ -1,0 +1,64 @@
+"""搜索索引入库（F-P1-08 · DESIGN §18.2）。
+
+build_index：取各 source 条目 → 增量 upsert search_index（幂等 by 同 source+row+content）。
+- 同名同内容且已有 embedding → 跳过；新/改内容 → embed 写入。
+- 清理 stale 行（该 source 下 (row,content) 已不在当前快照的旧索引）→ 保持新鲜。
+- source 指定则只建该类；整个跑完 = 全表慢索引（后台，不急）。
+
+embedding 写入：PG 存 vector（float[] 原生）；SQLite 测试存 json 文本（VectorCompat 降级 Text）。
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.llm import embed
+from app.model.search import SearchIndex
+
+
+def _store_embedding(v: list[float], db: Session):
+    # SQLite 测试（VectorCompat→Text）存 json；PG 存原生 float[] 给 vector 列
+    if db.get_bind().dialect.name == "sqlite":
+        return json.dumps(v)
+    return v
+
+
+def build_index(db: Session, source: str | None = None, *, client=None, log=None,
+                batch_size: int = 32) -> dict:
+    from app.search.extractors import EXTRACTORS
+    sources = [source] if source else list(EXTRACTORS)
+    stats = {"sources": 0, "inserted": 0, "skipped": 0, "stale_deleted": 0}
+
+    for name in sources:
+        if name not in EXTRACTORS:
+            if log: log(f"  未知 source: {name}")
+            continue
+        items = list(EXTRACTORS[name](db))
+        current = {(row_id, content) for row_id, content in items}
+
+        # 既有索引行：key=(row_id, content) -> object
+        existing: dict = {}
+        for obj in db.execute(select(SearchIndex).where(SearchIndex.source_table == name)).scalars():
+            existing[(obj.source_row_id, obj.content)] = obj
+        # stale 清理
+        for key, obj in list(existing.items()):
+            if key not in current:
+                db.delete(obj)
+                stats["stale_deleted"] += 1
+        # 待嵌入的新/改内容
+        todo = [(r, c) for r, c in items if (r, c) not in existing]
+        for i in range(0, len(todo), batch_size):
+            chunk = todo[i:i + batch_size]
+            texts = [c for _, c in chunk]
+            vecs = embed(texts, client=client)          # 若 omlx 未起 → LlmUnavailable
+            for (row_id, content), v in zip(chunk, vecs):
+                db.add(SearchIndex(source_table=name, source_row_id=row_id,
+                                   content=content, embedding=_store_embedding(v, db)))
+                stats["inserted"] += 1
+        stats["skipped"] += len(items) - len(todo)
+        stats["sources"] += 1
+        if log:
+            log(f"  [{name}] 共{len(items)} 新增{len(todo)} 跳{len(items) - len(todo)} 删stale{stats['stale_deleted']}")
+    return stats

--- a/app/search/search.py
+++ b/app/search/search.py
@@ -1,0 +1,75 @@
+"""统一搜索检索+装配+serve 后处理（F-P1-08 · DESIGN §18.3/§18.6）。
+
+search：embed 问题 → pgvector 余弦 top-k 召回条目标段 → LLM 装配最终答案 → serve 后处理。
+数值铁律：LLM 只原样引用命中条目里的数值，不自造（命中条目由 DB 派生含确定值）。
+"""
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.llm import chat, embed
+from app.model.search import SearchIndex
+
+SYSTEM_PROMPT = (
+    "你是网文创作数据 Dashboard 的检索问答助手。"
+    "仅根据用户提供的【命中条目】作答，严禁编造事实。"
+    "绝不自造任何数字、金额、汇率、百分比——所有数值只能原样引用【命中条目】里出现的数字；"
+    "若命中条目未提供所需数值，回答「资料未提供」。"
+    "只输出最终答案正文：不要复述问题、不要分步编号、不要输出推理/思考/分析过程、不要列来源。"
+    "用中文。"
+)
+
+TOP_K = 8
+
+
+def retrieve(db: Session, query_vec: list[float], k: int = TOP_K) -> list[dict]:
+    """pgvector 余弦 top-k（embedding <=> query_vec，越小越近）。仅 PG；SQLite 测试用 monkeypatch。"""
+    rows = db.execute(
+        select(SearchIndex.content, SearchIndex.source_table, SearchIndex.source_row_id)
+        .where(SearchIndex.embedding.isnot(None))
+        .order_by(SearchIndex.embedding.cosine_distance(query_vec))
+        .limit(k)
+    ).all()
+    return [{"content": c, "source_table": t, "source_row_id": r} for c, t, r in rows]
+
+
+def clean_answer(text: str) -> str:
+    """serve 后处理（§18.6）：剥推理/复述头、去掉分步编号，只留最终答案主体。
+
+    去步骤编号只处理 `1. / 1、/ 2)` 形式（数字后必随分隔符）；「1947年」这类数字紧接字符的
+    内容（年份/金额）一律保留，不剥。"""
+    t = (text or "").strip()
+    lines = [ln.strip() for ln in t.splitlines()]
+    kept = []
+    marker_done = False  # 跳过开头纯包装（答案：/答：/分析/思考）
+    for ln in lines:
+        if not ln:
+            if kept:
+                break
+            continue
+        if not marker_done and re.fullmatch(r"(分析|思考|推理|步骤|回答)[:：\-]?\s*.*", ln):
+            continue
+        if re.match(r"^\d+\s*[\.、)]\s*.+", ln):  # 步骤编号：1. / 1、 / 2)
+            ln = re.sub(r"^\d+\s*[\.、)]\s*", "", ln)
+        kept.append(ln)
+        marker_done = True
+    out = " ".join(kept).strip()
+    out = re.sub(r"^(答案|答|结论)[:：]\s*", "", out)
+    return out
+
+
+def search(db: Session, question: str, as_of: str | None = None, *,
+           client=None, k: int = TOP_K) -> dict:
+    """问题→答案。{answer, hits[]}；hits 内部用（前端只渲染 answer）。"""
+    q_vec = embed([question], client=client)[0]
+    hits = retrieve(db, q_vec, k)
+    if not hits:
+        return {"answer": "索引中暂无与此问题相关的条目（可先运行 `search-index` 建索引，或换一个问法）。",
+                "hits": []}
+    candidate = "\n".join(f"[{h['source_table']}#{h['source_row_id']}] {h['content']}" for h in hits)
+    user = f"问题：{question}\n\n【命中条目】\n{candidate}"
+    raw = chat(SYSTEM_PROMPT, user, client=client)
+    return {"answer": clean_answer(raw), "hits": hits}

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -863,7 +863,7 @@ UI 派生操作（投资创建/赎回、划拨换汇）的编年史同步为**�
 | F-P1-05 | **公司图谱** | 公司—公司关系 + 外部 API①② 导入（只增不减 + status）｜**外部 API① 已实现**（`POST /graph/companies/import`，公司图谱页按钮触发，§13.3）；API②（用工成本）仍待文档 | §13 | 🟨 |
 | F-P1-06 | **各国收益曲线** | return_curve（R1–R5）对比渲染 + 地区起始年下限｜GET /returns/regions + SVG 五线对比 | §14 | ✅ |
 | F-P1-07 | **财务收支** | finance_entry 各类收入/支出，实体必填、以实体为中心浏览｜API + 屏已上线；生产写入链路已接通（UI 派生 invest/redeem + ingest 镜像 source=file，issue #80），真实库 ingest 验收后再 ✅；编年史同步口径见 §19 决策备注（issue #86） | §5 | 🟨 |
-| F-P1-08 | **统一搜索** | LLM+embedding RAG（omlx 本地）条目检索装配 + serve 后处理｜⚠ 阻塞于本地 omlx 不可用，维持待续 | §18 | ⬜ |
+| F-P1-08 | **统一搜索** | LLM+embedding RAG（omlx 本地）条目检索装配 + serve 后处理｜已实现：`search_index` pgvector + 提取器 + `search-index` CLI 索引 + `GET /api/v1/search`（embed→余弦 top-k→LLM 装配→serve 后处理；omxl 未起 503 降级）。EMBED_MODEL 实测 4096 维（ivfflat>2000 不可用→精确扫描） | §18 | ✅ |
 | F-P1-09 | 四类 UI 改数据操作 | 统一模板：年份×池 + 后传重算 + 失败整体拒绝 + overlay 同步｜useDataOp 钩子已用于投资/划拨屏 | §6.8/§19 | ✅ |
 | F-P1-10 | **用工成本·加薪规则** | 本地基准（工资/CPI/税率）+ 外部 API② 在岗岗位导入 → 逐岗位算用工成本 → 每公司 finance_entry 落账；「加薪规则/用工成本」屏展示加薪规则 + 拉岗位计算 + 结果表｜app/core/labor_cost.py + ingest/importers/positions.py；税率公式细节只在后台（含比利时十三薪/双倍假期、日本 3 月奖金等隐藏项） | §13 | ✅ |
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Graph from './screens/Graph'
 import { ErrorBox } from './screens/ui'
 import { useDataOp } from './screens/useDataOp'
 import LaborCost from './screens/LaborCost'
+import Search from './screens/Search'
 
 const TABS = [
   { key: 'dashboard', label: 'Dashboard' },
@@ -66,7 +67,8 @@ export default function App() {
         {active === 'persons' && <Graph url="/api/v1/graph/persons" />}
         {active === 'companies' && <CompanyGraph />}
         {active === 'graphall' && <Graph url="/api/v1/graph/all" />}
-        {(active === 'timeline' || active === 'search' || active === 'health') && (
+        {active === 'search' && <Search />}
+        {(active === 'timeline' || active === 'health') && (
           <Placeholder label={TABS.find(t => t.key === active).label} asOf={asOf} />
         )}
       </main>

--- a/frontend/src/screens/Search.jsx
+++ b/frontend/src/screens/Search.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { useFetch } from './useDataOp'
+
+/**
+ * 统一搜索屏（F-P1-08 · DESIGN §18）：输入问题 → GET /api/v1/search → 只渲染最终 answer。
+ * §18.6：硬剪裁——不展示推理/步骤/hits，仅 answer 字段。
+ */
+export default function Search() {
+  const [q, setQ] = useState('')
+  const [asked, setAsked] = useState('')
+  const res = useFetch(asked ? `/api/v1/search?q=${encodeURIComponent(asked)}` : null)
+  const answer = res.data?.answer
+
+  const ask = () => { if (q.trim()) setAsked(q.trim()) }
+
+  return (
+    <div className="screen">
+      <div className="panel">
+        <h3>统一搜索</h3>
+        <p className="note">向本地知识库提问，返回最终答案（不展示推理过程与来源）。</p>
+        <div style={{ display: 'flex', gap: 8, margin: '8px 0' }}>
+          <input style={{ flex: 1 }} value={q} placeholder="如：祖母哪年去世 / 皮克斯收购迪士尼"
+            onChange={e => setQ(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') ask() }} />
+          <button className="primary" onClick={ask} disabled={!q.trim()}>搜索</button>
+        </div>
+        {res.err && <p className="note" style={{ color: 'var(--crit)' }}>{String(res.err)}</p>}
+        {res.data?.detail && <p className="note" style={{ color: 'var(--crit)' }}>{res.data.detail}</p>}
+        {res.data && !res.data.detail && (
+          <div style={{ marginTop: 12, lineHeight: 1.7 }}>
+            {answer ? <p style={{ fontSize: 14 }}>{answer}</p>
+                    : <p className="note">暂无答案（可先运行 search-index 建索引）。</p>}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/migrations/versions/d1e2f3a4b5c7_search_index_pgvector.py
+++ b/migrations/versions/d1e2f3a4b5c7_search_index_pgvector.py
@@ -1,0 +1,40 @@
+"""统一搜索索引表（F-P1-08 · DESIGN §18）。
+
+search_index：条目/行级 embedding（pgvector，维=EMBED_DIM）。
+
+Revision ID: d1e2f3a4b5c7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-08-24
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd1e2f3a4b5c7'
+down_revision = 'd1e2f3a4b5c6'
+branch_labels = None
+depends_on = None
+
+EMBED_DIM = 4096  # Qwen3-Embedding-8B 实测输出 4096 维（须与 config.CONFIG.embed_dim 一致）
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.create_table(
+        "search_index",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("source_table", sa.Text(), nullable=False),
+        sa.Column("source_row_id", sa.BigInteger(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("embedding", sa.Text(), nullable=True,
+                  comment="pgvector 向量（EMBED_DIM）；建 Text 后 ALTER 成 vector"),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint("source_table", "source_row_id", "content",
+                            name="uq_search_source_row_content"),
+    )
+    # 真正的 pgvector 列（pgvector 的 Vector 不是标准 DDL type，建 Text 后 ALTER）
+    # 注意：ivfflat 上限 2000 维；EMBED_MODEL=4096 维 → 不用 ivfflat，检索走精确余弦扫描（行数小）。
+    op.execute(f"ALTER TABLE search_index ALTER COLUMN embedding TYPE vector({EMBED_DIM}) USING embedding::vector({EMBED_DIM})")
+
+
+def downgrade() -> None:
+    op.drop_table("search_index")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ fastapi>=0.115
 uvicorn[standard]>=0.30
 httpx>=0.27
 pyyaml>=6.0
+pgvector>=0.3

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,46 @@
+"""omlx/LLM 客户端单测（F-P1-08 §18.5）：embed/chat 用 MockTransport 免网；维校验。"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.core import llm
+from app.config import CONFIG
+
+
+def _client(json_body):
+    return lambda request: httpx.Response(200, json=json_body)
+
+
+def test_embed_returns_vectors():
+    c = httpx.Client(transport=httpx.MockTransport(
+        _client({"data": [{"embedding": [0.1] * CONFIG.embed_dim},
+                          {"embedding": [0.2] * CONFIG.embed_dim}]})))
+    out = llm.embed(["a", "b"], client=c)
+    assert len(out) == 2 and len(out[0]) == CONFIG.embed_dim
+
+
+def test_embed_dim_mismatch_raises():
+    # MockTransport 返回 2 维 → 与 EMBED_DIM 不符 → LlmUnavailable
+    c = httpx.Client(transport=httpx.MockTransport(
+        _client({"data": [{"embedding": [0.5, 0.5]}]})))
+    with pytest.raises(llm.LlmUnavailable):
+        llm.embed(["x"], client=c)
+
+
+def test_embed_connection_error_raises():
+    c = httpx.Client(transport=httpx.MockTransport(lambda r: (_ for _ in ()).throw(httpx.ConnectError("down"))))
+    with pytest.raises(llm.LlmUnavailable):
+        llm.embed(["x"], client=c)
+
+
+def test_chat_returns_content():
+    c = httpx.Client(transport=httpx.MockTransport(
+        _client({"choices": [{"message": {"content": "1947年"}}]})))
+    assert llm.chat("sys", "user问", client=c) == "1947年"
+
+
+def test_chat_error_raises():
+    c = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(500, json={})))
+    with pytest.raises(llm.LlmUnavailable):
+        llm.chat("sys", "u", client=c)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,89 @@
+"""统一搜索（F-P1-08）单测：提取器内容 + search 检索/装配/serve 后处理 + 端点。
+
+SQLite 无 pgvector/cos → retrieve 用 monkeypatch；LLM 用 monkeypatch 免网。
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.app import app
+from app.api.deps import get_db
+from app.core import llm
+from app.db import Base
+from app.model import Entity
+from app.model.labor import LaborWageBenchmark
+from app.search import search as S
+from app.search.extractors import EXTRACTORS
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    Sess = sessionmaker(bind=engine)
+    s = Sess()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def test_clean_answer_keeps_year_and_strips_number():
+    assert S.clean_answer("1947年") == "1947年"
+    assert S.clean_answer("1. 祖母去世于1947年") == "祖母去世于1947年"
+    assert S.clean_answer("思考：xxx\n答案：1947年") == "1947年"
+
+
+def test_extractor_entity_and_wage(db):
+    db.add(Entity(entity_type="person", name="Henri Peeters", display_name="亨利"))
+    db.add(LaborWageBenchmark(region="比利时", year=1982, currency="BEF",
+                              investment_fin_salary=1010595.0, avg_salary=673730.0))
+    db.commit()
+    ents = list(EXTRACTORS["entity"](db))
+    assert any("亨利" in c for _, c in ents)
+    wages = list(EXTRACTORS["labor_wage_benchmark"](db))
+    assert wages and "1010595.0" in wages[0][1]
+
+
+def test_search_logic_answer_and_hits(db, monkeypatch):
+    # 注：search.py 顶层 `from app.core.llm import chat, embed` — 须 patch S.embed/S.chat
+    monkeypatch.setattr(S, "embed", lambda texts, **kw: [[0.1] * 4 for _ in texts])
+    monkeypatch.setattr(S, "retrieve", lambda s, q, k=8: [
+        {"source_table": "timeline_event", "source_row_id": 1,
+         "content": "1947 祖母去世，资产由祖父Henri继承"}])
+    monkeypatch.setattr(S, "chat", lambda sys, user, **kw: "1. 祖母去世于1947年")
+    r = S.search(db, "祖母哪年去世")
+    assert r["hits"] and r["answer"] == "祖母去世于1947年"
+
+
+def test_search_no_hits(db, monkeypatch):
+    monkeypatch.setattr(S, "embed", lambda texts, **kw: [[0.0]])
+    monkeypatch.setattr(S, "retrieve", lambda s, q, k=8: [])
+    r = S.search(db, "无关")
+    assert r["hits"] == [] and "索引中暂无" in r["answer"]
+
+
+def test_search_endpoint(db, monkeypatch):
+    import app.api.search as api
+    result = {"answer": "1965年", "hits": [{"content": "x"}]}
+    api.search = lambda d, q, as_of=None, **kw: result       # 成功
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        with TestClient(app) as c:
+            assert c.get("/api/v1/search", params={"q": "祖母"}).json()["answer"] == "1965年"
+            assert c.get("/api/v1/search").status_code == 422   # 缺 q
+            api.search = lambda d, q, as_of=None, **kw: (_ for _ in ()).throw(llm.LlmUnavailable("omlx 未启动"))
+            assert c.get("/api/v1/search", params={"q": "x"}).status_code == 503
+    finally:
+        app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## 背景
`F-P1-08 统一搜索` 一直标 ⬜（阻塞于本地 omlx）。本次落地整套：pgvector 索引 + 提取器 + `/api/v1/search` + 前端搜索屏。接入后（omlx 实际已可用）做真实端到端验证。

## 决策
- 搭好即用：omxl 未起时优雅降级（索引/搜索给 503+提示），起了即真实 RAG。
- 全语义表可索引、后台慢索引：15 类提取器 + `search-index` CLI 增量构建。

## 改动
| 文件 | 内容 |
|---|---|
| `app/core/llm.py` | omlx embed/chat 客户端 + LlmUnavailable + 维校验 |
| `app/model/search.py`+迁移 `d1e2f3a4b5c7` | search_index pgvector(4096) |
| `app/search/extractors.py` | 15 语义表条目提取器（含确定性数值） |
| `app/search/indexer.py`+`ingest search-index` | 增量构建 + stale 清理 |
| `app/search/search.py`+`api/search.py` | `GET /search`=embed→余弦 top-k→LLM装配→serve后处理；503 降级；数值铁律不幻觉 |
| `frontend Search.jsx` | 搜索屏（只渲染 answer） |
| tests | test_llm_client + test_search（提取器/装配/端点/降级） |

## 实测（omxl 真机）
- 全量索引 `4768 行 / 15 类 语义表` 已建。
- 问答正确且不幻觉：`祖母去世→1947年…`、`皮克斯→1992-93 三期各1000万USD，共3000万USD获40%`、`比利时1982投资金融年薪→1010595 BEF`、`贝索斯→资料未提供`。
- 全量 `288 passed`；前端 build 成功。

## 取舍/说明
- **EMBED_DIM=4096**（实测 Qwen3-Embedding-8B）；**ivfflat≤2000 维不可用 → 精确余弦扫描**（数据小）。
- `search_index` 迁移已含；索引需 `python -m app.ingest.main search-index` 构建后搜索才有效。
- omlx 未起时 `POST /search` 返回 503 明确提示；测试在无 omlx 环境全过。