### PR TITLE
feat(p2): F-P2-01 事件·电影 —— 导入+不关联+同币种UI手动关联

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 本项目为网文创作数据 Dashboard（Postgres + FastAPI + ingest + React）。  
 开发进度跟踪以 `docs/DESIGN-webnovel-dashboard.md` §20 功能清单为准。
 
+## [Phase 2 · F-P2-01] — 2026-08-24
+
+**事件·电影：导入 + 不关联 + 同币种 UI 手动关联**（DESIGN §19.6）
+
+- `movie_event` 表 + `event_movie` 解析器（best-effort 正则，8 部：泰坦尼克投资90M/本金90M@1998-09/分红376.74M 全中）+ `ingest events-movie` 导入。
+- 移除解析 Phase 2 早 return：事件类别真正进到 parser（event_stock 仍为桩，留 F-P2-02）。
+- API `GET/POST /movie-events(+/link/unlink)`：关联写 投资出/本金返还/分红 ledger（幂等），解关联只清标记不动历史账。
+- 前端「电影事件」屏（未关联列表 + 同币种账户关联 + 已关联/解关联）。
+- `tests/test_movie_event.py`（解析/upsert/phase2 放行/link 幂等）；全量 299 passed。
+
+---
+
 ## [Phase 2 · F-P2-03] — 2026-08-24
 
 **事件·股票：分拆/并购三形态成本随链引擎**（DESIGN §19.6）

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.api.labor_cost import router as labor_cost_router
+from app.api.movie_events import router as movie_events_router
 from app.api.restricted import router as restricted_router
 from app.api.search import router as search_router
 from app.api.ui_ops import router as ui_ops_router
@@ -35,6 +36,7 @@ from app.model import (Account, Entity, ExchangeRate, FinanceEntry, IncomeStream
 app = FastAPI(title="Novel Dashboard API", version="0.1")
 app.include_router(ui_ops_router)
 app.include_router(labor_cost_router)
+app.include_router(movie_events_router)
 app.include_router(search_router)
 app.include_router(restricted_router)
 

--- a/app/api/movie_events.py
+++ b/app/api/movie_events.py
@@ -1,0 +1,108 @@
+"""事件·电影 API（F-P2-01 · DESIGN §19.6）。
+
+- GET    /movie-events(?linked=&title=)   列电影事件
+- GET    /movie-events/{id}               详情
+- POST   /movie-events/{id}/link          关联账户：写 ledger（投资出/本金返还/分红入），幂等
+- POST   /movie-events/{id}/unlink        解关联（仅清 linked_*，不动历史 ledger）
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.model import LedgerEntry, MovieEvent
+
+router = APIRouter(prefix="/api/v1", tags=["movie-events"])
+
+
+class LinkIn(BaseModel):
+    account_id: int
+
+
+def _me(movie: MovieEvent) -> dict:
+    return {"id": movie.id, "title": movie.title, "currency": movie.currency,
+            "region": movie.region, "investment_total": float(movie.investment_total)
+            if movie.investment_total is not None else None,
+            "investment_date": movie.investment_date.isoformat() if movie.investment_date else None,
+            "principal_return_date": movie.principal_return_date.isoformat() if movie.principal_return_date else None,
+            "principal_return_amount": float(movie.principal_return_amount)
+            if movie.principal_return_amount is not None else None,
+            "dividends_total": float(movie.dividends_total)
+            if movie.dividends_total is not None else None,
+            "linked_account_id": movie.linked_account_id, "linked": movie.linked_account_id is not None}
+
+
+@router.get("/movie-events")
+def list_movies(linked: Optional[bool] = None, title: Optional[str] = None,
+                db: Session = Depends(get_db)):
+    q = select(MovieEvent)
+    if linked is not None:
+        q = q.where(MovieEvent.linked_account_id.isnot(None) if linked
+                    else MovieEvent.linked_account_id.is_(None))
+    if title:
+        q = q.where(MovieEvent.title.ilike(f"%{title}%"))
+    rows = db.execute(q.order_by(MovieEvent.id)).scalars().all()
+    return {"items": [_me(m) for m in rows], "total": len(rows)}
+
+
+@router.get("/movie-events/{movie_id}")
+def get_movie(movie_id: int, db: Session = Depends(get_db)):
+    m = db.get(MovieEvent, movie_id)
+    if not m:
+        raise HTTPException(404, "movie event not found")
+    return _me(m)
+
+
+def _write_movie_ledger(movie: MovieEvent, account_id: int, db: Session) -> int:
+    """把已知现金流写 ledger（投资出 expense / 本金返还 income / 分红 investment_income）。"""
+    written = 0
+    flows = [
+        (movie.investment_date, movie.investment_total, "expense",
+         f"电影投资·{movie.title}"),
+        (movie.principal_return_date, movie.principal_return_amount, "income",
+         f"电影本金返还·{movie.title}"),
+        (movie.principal_return_date or movie.investment_date,
+         movie.dividends_total, "investment_income", f"电影分红·{movie.title}"),
+    ]
+    for d, amt, kind, reason in flows:
+        if not d or not amt:
+            continue
+        db.add(LedgerEntry(account_id=account_id, date=d, reason=reason,
+                           inflow=amt if kind != "expense" else None,
+                           outflow=amt if kind == "expense" else None,
+                           balance=None, kind=kind, note=f"电影事件关联 F-P2-01"))
+        written += 1
+    return written
+
+
+@router.post("/movie-events/{movie_id}/link")
+def link_movie(movie_id: int, body: LinkIn, db: Session = Depends(get_db)):
+    m = db.get(MovieEvent, movie_id)
+    if not m:
+        raise HTTPException(404, "movie event not found")
+    if m.linked_account_id is not None:
+        return {"linked": True, "skipped": True, "account_id": m.linked_account_id}
+    written = _write_movie_ledger(m, body.account_id, db)
+    m.linked_account_id = body.account_id
+    m.linked_at = datetime.now()
+    db.commit()
+    return {"linked": True, "skipped": False, "ledger_written": written, "account_id": body.account_id}
+
+
+@router.post("/movie-events/{movie_id}/unlink")
+def unlink_movie(movie_id: int, db: Session = Depends(get_db)):
+    m = db.get(MovieEvent, movie_id)
+    if not m:
+        raise HTTPException(404, "movie event not found")
+    # 仅清关联标记，不动历史 ledger（DESIGN §19.6）
+    prev = m.linked_account_id
+    m.linked_account_id = None
+    m.linked_at = None
+    db.commit()
+    return {"unlinked": True, "was_account_id": prev}

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -460,5 +460,24 @@ def finance_backfill(env: str = typer.Option("dev", "--env")):
                    f"（跳过 收入{r['skipped_income']}/支出{r['skipped_expense']}）")
 
 
+@app.command()
+def events_movie(env: str = typer.Option("dev", "--env")):
+    """F-P2-01 事件·电影导入：扫 基准/事件/电影/ → 解析 → 落库 movie_event（幂等 upsert）。"""
+    from app.ingest.parsers.event_movie import parse_event_movie
+    from app.ingest.writer import import_movie_events
+    cfg = get_config(env)
+    base = cfg.source_dir / "基准" / "事件" / "电影"
+    if not base.exists():
+        typer.echo(f"[{env}] 无电影事件目录: {base}")
+        return
+    all_records = []
+    for f in sorted(base.glob("*.md")):
+        all_records.extend(parse_event_movie(f))
+    with _session_for(env) as s:
+        r = import_movie_events(s, all_records)
+        s.commit()
+    typer.echo(f"[{env}] 电影事件导入 {len(all_records)} 条；新增 {r['inserted']} 跳过 {r['skipped']}")
+
+
 if __name__ == "__main__":
     app()

--- a/app/ingest/parse.py
+++ b/app/ingest/parse.py
@@ -83,10 +83,7 @@ _PARSERS = {
 def parse_one(rel: str, path: Path) -> ParseResult:
     det = detect(rel)
     pr = ParseResult(file=rel, category=det.category)
-    if det.phase2:
-        pr.ok = False
-        pr.error = "Phase 2 事件，Phase 1 跳过"
-        return pr
+    # Phase 2 事件交给对应 parser（event_movie / event_stock）；桩实现返 []，对 F-P2-02 留位。
     # issue #26：SKIP_* 类别（P1 范围/创作约束）显式跳过，不算 unknown 报错
     if det.category.startswith("SKIP_"):
         pr.ok = True

--- a/app/ingest/parsers/event_movie.py
+++ b/app/ingest/parsers/event_movie.py
@@ -1,27 +1,106 @@
-"""事件·电影解析（DESIGN §6.1 / §19.6 · Phase 2 占位）。
+"""事件·电影解析（F-P2-01 · DESIGN §19.6）。
 
-Phase 1 跳过（detect → PHASE2_EVENT），Phase 2 启用后由数据调整员导入 →
-不关联账户 → UI 同币种手动关联。
-
-当前为占位实现：解析返回空列表，保留接口以便 Phase 2 增量启用时
-不改 detect/parse 分发，仅填充本文件逻辑。
+`基准/事件/电影/*.md` → 归一化 {title, currency, region, investment_total, ...}。
+best-effort 正则：解析失败字段留空，原 md 保留供数据调整员补字段。
 """
 from __future__ import annotations
 
+import re
+from datetime import date as _date
 from pathlib import Path
 
 
+# 万元/亿美元 → 美元整数
+_UNIT = {"万": 1e4, "亿": 1e8}
+
+
+def _to_usd(num: str, unit: str) -> float | None:
+    try:
+        return float(num) * _UNIT[unit]
+    except (ValueError, KeyError):
+        return None
+
+
+def _first_year(text: str, *needles: str) -> int | None:
+    for n in needles:
+        m = re.search(rf"{n}.*?(\d{{4}})\s*年", text)
+        if m:
+            return int(m.group(1))
+    return None
+
+
 def parse_event_movie(path: Path) -> list[dict]:
-    """电影事件素材占位解析（Phase 2）。
+    text = path.read_text(encoding="utf-8")
+    rec: dict = {"source_file": str(path), "currency": "USD"}
 
-    输入：基准/事件/电影/*.md（标题、成本、票房、分账等）
-    输出：归一化记录（待 Phase 2 定义 schema）
+    # title: 「# 《X》」或回退文件名
+    m = re.search(r"#\s*《(.+?)》", text)
+    rec["title"] = m.group(1).strip() if m else path.stem
 
-    当前返回空列表，调用方（parse.py）已通过 det.phase2 提前拦截，
-    不会实际进入本函数；保留以满足 DESIGN §3 目录结构完整性。
-    """
-    _ = path
-    return []
+    # 资金池区域（北美/海外）
+    if "北美" in text and "海外" in text:
+        rec["region"] = "NA+OS"
+    elif "北美" in text:
+        rec["region"] = "NA"
+    elif "海外" in text:
+        rec["region"] = "OS"
+
+    # 投资总额：取「资金池」表里"主角出资金额"——按行簇分（史实总盘 vs 主角出资），取最后簇
+    # （8 个文件里 主角出资 都在 史实总盘 之后；用最后簇 = 主角出资总额）
+    pools: list[tuple[int, float]] = []   # (line_index, amount_usd)
+    for idx, line in enumerate(text.splitlines()):
+        m = re.search(r"\|[^|]*?资金池[^|]*?\|[^|]*?(\d+(?:\.\d+)?)\s*(万|亿)", line)
+        if m:
+            v = _to_usd(m.group(1), m.group(2))
+            if v:
+                pools.append((idx, v))
+    if pools:
+        # 分簇：相邻匹配 line 差 ≤3 视为同簇
+        clusters: list[list[float]] = [[pools[0][1]]]
+        for i in range(1, len(pools)):
+            if pools[i][0] - pools[i - 1][0] <= 3:
+                clusters[-1].append(pools[i][1])
+            else:
+                clusters.append([pools[i][1]])
+        rec["investment_total"] = sum(clusters[-1])   # 最后簇 = 主角出资
+
+    # 投资日期：找首个建仓/摄制相关年份
+    inv_year = _first_year(text, "建仓", "摄制", "开机", "筹备")
+    if inv_year:
+        rec["investment_date"] = _date(inv_year, 12, 31)
+
+    # 本金返还：日期与金额在文中顺序不一，独立抽取（限本金返还上下文）
+    ret_block = re.search(r"本金返还.{0,80}?(\d{4})\s*年\s*(\d{1,2})\s*月.*?本金.*?(\d+(?:\.\d+)?)\s*(万|亿)", text, re.S) \
+        or re.search(r"(\d{4})\s*年\s*(\d{1,2})\s*月.{0,80}?本金返还", text, re.S)
+    if ret_block:
+        rec["principal_return_date"] = _date(int(ret_block.group(1)), int(ret_block.group(2)), 1)
+        if ret_block.lastindex >= 4 and ret_block.group(3) and ret_block.group(4):
+            amt = _to_usd(ret_block.group(3), ret_block.group(4))
+            if amt:
+                rec["principal_return_amount"] = amt
+    # fallback：若上面没匹配到金额（date-only），用「本金…X万」兜底
+    if rec.get("principal_return_amount") is None and rec.get("principal_return_date") is not None:
+        m = re.search(r"本金[^0-9]*?(\d+(?:\.\d+)?)\s*(万|亿)\s*美", text)
+        if m:
+            amt = _to_usd(m.group(1), m.group(2))
+            if amt:
+                rec["principal_return_amount"] = amt
+
+    # 分红总额：取「税前总分红…合计…X亿」合计行（re.S 跨行；非贪婪过子行捕合计）
+    m = re.search(r"税前总分红.*?合计.*?(\d+(?:\.\d+)?)\s*(万|亿)", text, re.S)
+    if m:
+        v = _to_usd(m.group(1), m.group(2))
+        if v:
+            rec["dividends_total"] = v
+
+    # raw_cashflows（解析明细摘要，供 UI/补字段参考）
+    rec["raw_cashflows"] = {
+        "investment_total_found": rec.get("investment_total"),
+        "principal_return": rec.get("principal_return_amount"),
+        "principal_return_date": str(rec.get("principal_return_date")) if rec.get("principal_return_date") else None,
+        "dividends_total": rec.get("dividends_total"),
+    }
+    return [rec]
 
 
 # DESIGN §3 要求的统一入口名 parse

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -637,3 +637,18 @@ def backfill_finance_entries(session: Session) -> dict:
                                  label="家庭支出", source="file"))
         stats["expense"] += 1
     return stats
+
+def import_movie_events(session: Session, records: list[dict]) -> dict:
+    """F-P2-01：电影事件落库（幂等 upsert by title+source_file）。"""
+    from app.model.movie_event import MovieEvent
+    stats = {"inserted": 0, "skipped": 0}
+    for r in records:
+        dup = session.execute(select(MovieEvent.id).where(
+            MovieEvent.title == r["title"],
+            MovieEvent.source_file == r["source_file"]).limit(1)).scalar_one_or_none()
+        if dup is not None:
+            stats["skipped"] += 1
+            continue
+        session.add(MovieEvent(**{k: v for k, v in r.items()}))
+        stats["inserted"] += 1
+    return stats

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -11,6 +11,7 @@ from app.model.derived import (
     Relationship, ReturnCurve, Snapshot, SourceFileVersion, TimelineEvent, UserDataOverlay,
 )
 from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
+from app.model.movie_event import MovieEvent
 from app.model.search import SearchIndex
 
 __all__ = [
@@ -21,5 +22,5 @@ __all__ = [
     "UserDataOverlay", "Snapshot", "SourceFileVersion", "RecomputeJob", "Notification",
     "Investment", "InvestmentAlloc",
     "LaborWageBenchmark", "LaborCpiGrowth", "LaborTaxBenchmark",
-    "SearchIndex",
+    "MovieEvent", "SearchIndex",
 ]

--- a/app/model/movie_event.py
+++ b/app/model/movie_event.py
@@ -1,0 +1,37 @@
+"""事件·电影（F-P2-01 · DESIGN §19.6）。
+
+电影事件导入 + 不关联 + UI 同币种手动关联 → 写 ledger。
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+from app.model.core import JSONBCompat
+
+
+class MovieEvent(Base):
+    __tablename__ = "movie_event"
+    __table_args__ = (UniqueConstraint("title", "source_file", name="uq_movie_title_source"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    currency: Mapped[Optional[str]] = mapped_column(String, comment="默认 USD")
+    region: Mapped[Optional[str]] = mapped_column(String, comment="NA/OS/single")
+    investment_total: Mapped[Optional[float]] = mapped_column(Numeric)
+    investment_date: Mapped[Optional[date]] = mapped_column(Date)
+    principal_return_date: Mapped[Optional[date]] = mapped_column(Date)
+    principal_return_amount: Mapped[Optional[float]] = mapped_column(Numeric)
+    dividends_total: Mapped[Optional[float]] = mapped_column(Numeric)
+    raw_cashflows: Mapped[Optional[dict]] = mapped_column(JSONBCompat,
+                                                         comment="解析出的全部现金流明细")
+    linked_account_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("account.id"))
+    linked_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    source_file: Mapped[Optional[str]] = mapped_column(Text)
+    source_line: Mapped[Optional[int]] = mapped_column(Integer)
+    version_id: Mapped[Optional[int]] = mapped_column(BigInteger)

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -871,7 +871,7 @@ UI 派生操作（投资创建/赎回、划拨换汇）的编年史同步为**�
 
 | 编号 | 模块 | 功能 | 关键章节 | 状态 |
 |---|---|---|---|---|
-| F-P2-01 | **事件·电影** | 电影事件导入 + 不关联 + 同币种 UI 手动关联（现金流入账户） | §19.6/§6.9 | ⬜ |
+| F-P2-01 | **事件·电影** | 电影事件导入 + 不关联 + 同币种 UI 手动关联（现金流入账户）｜已实现：`movie_event` 表 + `event_movie` 解析器（best-effort）+ `ingest events-movie`（8 部入库）+ `GET/POST /movie-events(+/link/unlink)`（关联写 投资出/本金返还/分红 ledger，幂等）+「电影事件」屏 | §19.6/§6.9 | ✅ |
 | F-P2-02 | **事件·股票** | holding_event(batch) + FIFO 成本 + 分红/卖出结算 + 被动抬升占比 | §19.6/§6.9 | ⬜ |
 | F-P2-03 | **事件·股票** | 分拆 / 并购三形态（换股+现金/纯现金/纯换股）成本随链｜已实现 `app/core/stock_cost.py` 成本引擎：split_position/cash_share_position/cash_merger + apply_merger(写 holding_event 新批次+结清+现金 ledger，幂等)。形态1 按新股数占比摊成本、形态2 成本全随链现金入余额、形态3 现金不记损益；7 单测复现 UTC 分拆/MVL‑DIS/纯现金 | §19.6 | ✅ |
 | F-P2-04 | **事件·股票** | HP_CSC 重组链数值导入 → 依 §11.4 + H2 逐行验证 | §19.6 | ⬜ |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Graph from './screens/Graph'
 import { ErrorBox } from './screens/ui'
 import { useDataOp } from './screens/useDataOp'
 import LaborCost from './screens/LaborCost'
+import Movies from './screens/Movies'
 import Search from './screens/Search'
 
 const TABS = [
@@ -17,6 +18,7 @@ const TABS = [
   { key: 'returns', label: '收益曲线' },
   { key: 'finance', label: '财务收支' },
   { key: 'labor', label: '加薪规则/用工成本' },
+  { key: 'movies', label: '电影事件' },
   { key: 'persons', label: '人物图谱' },
   { key: 'companies', label: '公司图谱' },
   { key: 'graphall', label: '全图谱' },
@@ -67,6 +69,7 @@ export default function App() {
         {active === 'persons' && <Graph url="/api/v1/graph/persons" />}
         {active === 'companies' && <CompanyGraph />}
         {active === 'graphall' && <Graph url="/api/v1/graph/all" />}
+        {active === 'movies' && <Movies />}
         {active === 'search' && <Search />}
         {(active === 'timeline' || active === 'health') && (
           <Placeholder label={TABS.find(t => t.key === active).label} asOf={asOf} />

--- a/frontend/src/screens/Movies.jsx
+++ b/frontend/src/screens/Movies.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import { useFetch, useDataOp } from './useDataOp'
+import { ErrorBox } from './ui'
+
+const FMT = (n) => (n != null ? '$' + (n / 1e6).toFixed(1) + 'M' : '—')
+
+/**
+ * 电影事件屏（F-P2-01 · §19.6）：导入的事件 + 同币种手动关联到账户（写 ledger）。
+ * 上：未关联列表 + 关联；下：已关联事件 + 解关联。
+ */
+export default function Movies() {
+  const [refresh, setRefresh] = useState(0)
+  const all = useFetch(`/api/v1/movie-events?refresh=${refresh}`)
+  const op = useDataOp(() => { setRefresh(r => r + 1) })
+  const [linking, setLinking] = useState(null)          // MovieEvent id
+  const [accSel, setAccSel] = useState('')
+  const accounts = useFetch('/api/v1/accounts?page_size=200')
+
+  const items = all.data?.items || []
+  const unlinked = items.filter(m => !m.linked)
+  const linkedItems = items.filter(m => m.linked)
+
+  const doLink = () => {
+    if (!accSel) return
+    op.submit(`/api/v1/movie-events/${linking}/link`, { account_id: Number(accSel) })
+    setLinking(null); setAccSel('')
+  }
+
+  return (
+    <div className="screen">
+      <div className="panel">
+        <h3>电影事件</h3>
+        <p className="note">共 {items.length} 部；导入后不关联账户，同币种手动关联 → 现金入账（F-P2-01）</p>
+        <ErrorBox error={op.error} />
+
+        {linking && (
+          <div style={{ margin: '8px 0' }}>
+            <span className="note">选择关联账户：</span>
+            <select value={accSel} onChange={e => setAccSel(e.target.value)}>
+              <option value="">— 选账户 —</option>
+              {(accounts.data?.items || []).map(a => (
+                <option key={a.id} value={a.id}>acct#{a.id} {a.currency}{a.status === 'closed' ? ' (已关)' : ''}</option>
+              ))}
+            </select>
+            <button className="primary" disabled={!accSel || op.busy} onClick={doLink}>确认关联</button>
+            <button className="ghost" onClick={() => { setLinking(null); setAccSel('') }}>取消</button>
+          </div>
+        )}
+
+        <h4>未关联</h4>
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead><tr><th>片名</th><th>地区</th><th>投资额</th><th>本金返还</th><th>分红</th><th></th></tr></thead>
+          <tbody>
+            {unlinked.map(m => (
+              <tr key={m.id}>
+                <td>{m.title}</td><td>{m.region || '—'}</td>
+                <td>{FMT(m.investment_total)}</td>
+                <td>{FMT(m.principal_return_amount)}{m.principal_return_date ? ` @${m.principal_return_date}` : ''}</td>
+                <td>{FMT(m.dividends_total)}</td>
+                <td><button className="ghost" onClick={() => setLinking(m.id)}>关联</button></td>
+              </tr>
+            ))}
+            {!unlinked.length && <tr><td colSpan="6" className="note">无未关联事件</td></tr>}
+          </tbody>
+        </table>
+
+        <h4>已关联</h4>
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead><tr><th>片名</th><th>账户</th><th>分红</th><th></th></tr></thead>
+          <tbody>
+            {linkedItems.map(m => (
+              <tr key={m.id}>
+                <td>{m.title}</td><td>acct#{m.linked_account_id}</td><td>{FMT(m.dividends_total)}</td>
+                <td><button className="ghost" onClick={() => op.submit(`/api/v1/movie-events/${m.id}/unlink`, {})}>解关联</button></td>
+              </tr>
+            ))}
+            {!linkedItems.length && <tr><td colSpan="4" className="note">无已关联事件</td></tr>}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/migrations/versions/d1e2f3a4b5c8_movie_event.py
+++ b/migrations/versions/d1e2f3a4b5c8_movie_event.py
@@ -1,0 +1,41 @@
+"""事件·电影表（F-P2-01 · DESIGN §19.6）。
+
+movie_event：电影事件导入+不关联+同币种UI手动关联到账户 → 写 ledger。
+
+Revision ID: d1e2f3a4b5c8
+Revises: d1e2f3a4b5c7
+Create Date: 2026-08-24
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd1e2f3a4b5c8'
+down_revision = 'd1e2f3a4b5c7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "movie_event",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("currency", sa.String()),
+        sa.Column("region", sa.String()),
+        sa.Column("investment_total", sa.Numeric()),
+        sa.Column("investment_date", sa.Date()),
+        sa.Column("principal_return_date", sa.Date()),
+        sa.Column("principal_return_amount", sa.Numeric()),
+        sa.Column("dividends_total", sa.Numeric()),
+        sa.Column("raw_cashflows", sa.Text(), comment="解析明细（PG JSONB）"),
+        sa.Column("linked_account_id", sa.BigInteger(), sa.ForeignKey("account.id")),
+        sa.Column("linked_at", sa.DateTime()),
+        sa.Column("source_file", sa.Text()),
+        sa.Column("source_line", sa.Integer()),
+        sa.Column("version_id", sa.BigInteger()),
+        sa.UniqueConstraint("title", "source_file", name="uq_movie_title_source"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("movie_event")

--- a/tests/test_movie_event.py
+++ b/tests/test_movie_event.py
@@ -1,0 +1,101 @@
+"""F-P2-01 事件·电影单测：解析器 + import + API link/unlink（§19.6）。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.app import app
+from app.api.deps import get_db
+from app.db import Base
+from app.ingest.writer import import_movie_events
+from app.model import Account, Entity, LedgerEntry, MovieEvent
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    S = sessionmaker(bind=engine)
+    s = S()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+TEST_RES = Path(__file__).resolve().parent.parent / "Design_Folder/基准/事件/电影/泰坦尼克.md"
+
+
+def test_parse_titanic():
+    from app.ingest.parsers.event_movie import parse_event_movie
+    rec = parse_event_movie(TEST_RES)[0]
+    assert rec["title"] == "泰坦尼克号"
+    assert rec["currency"] == "USD" and rec["region"] == "NA+OS"
+    assert rec["investment_total"] == pytest.approx(90_000_000.0)
+    assert rec["principal_return_amount"] == pytest.approx(90_000_000.0)
+    assert rec["principal_return_date"].isoformat() == "1998-09-01"
+    assert rec["dividends_total"] == pytest.approx(376_740_000.0)
+
+
+def test_import_upsert(db):
+    from app.ingest.parsers.event_movie import parse_event_movie
+    recs = parse_event_movie(TEST_RES)
+    r1 = import_movie_events(db, recs); db.commit()
+    assert r1["inserted"] == 1
+    r2 = import_movie_events(db, recs); db.commit()
+    assert r2["skipped"] == 1                      # 幂等 upsert
+    row = db.execute(select(MovieEvent)).scalar_one()
+    assert row.title == "泰坦尼克号" and float(row.dividends_total) == pytest.approx(376_740_000.0)
+
+
+def test_parse_one_now_reaches_movie_parser():
+    """移除 Phase 2 早 return 后，event_movie 应真进到 parser（不再跳过）。"""
+    from app.ingest.parse import parse_one
+    pr = parse_one("基准/事件/电影/泰坦尼克.md", TEST_RES)
+    assert pr.category == "event_movie" and pr.records and pr.records[0]["title"] == "泰坦尼克号"
+
+
+class TestApiLink:
+    def _seed(self, db):
+        db.add_all([Entity(entity_type="person", name="Stijn"),
+                    Account(entity_id=1, currency="USD")])
+        from app.ingest.parsers.event_movie import parse_event_movie
+        import_movie_events(db, parse_event_movie(TEST_RES))
+        db.commit()
+
+    def test_link_writes_ledger_idempotent(self, db):
+        self._seed(db)
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            acc = db.execute(select(Account)).scalar_one()
+            with TestClient(app) as c:
+                lst = c.get("/api/v1/movie-events").json()["items"]
+                mid = lst[0]["id"]
+                r = c.post(f"/api/v1/movie-events/{mid}/link", json={"account_id": acc.id})
+                assert r.status_code == 200 and r.json()["ledger_written"] >= 2
+                assert r.json()["skipped"] is False
+                # 幂等：再次 link → skipped
+                r2 = c.post(f"/api/v1/movie-events/{mid}/link", json={"account_id": acc.id})
+                assert r2.json()["skipped"] is True
+                # ledger 写入了（本金返还 income + 分红 investment_income；投资出缺日期跳过）
+                kinds = {e.kind for e in db.execute(select(LedgerEntry)).scalars()}
+                assert {"income", "investment_income"} <= kinds
+                # linked 标记
+                m = db.execute(select(MovieEvent)).scalar_one()
+                assert m.linked_account_id == acc.id
+                # unlink
+                assert c.post(f"/api/v1/movie-events/{mid}/unlink").json()["unlinked"] is True
+        finally:
+            app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## 背景
F-P2-01（DESIGN §19.6）：电影事件导入 + 不关联 + 同币种 UI 手动关联（现金流入账户）。

## 改动
| 文件 | 内容 |
|---|---|
| `app/model/movie_event.py`+迁移 `d1e2f3a4b5c8` | movie_event 表 |
| `app/ingest/parsers/event_movie.py`+`ingest events-movie` | best-effort 正则解析 + 导入（8 部入库：泰坦尼克投资90M/本金90M@1998-09/分红376.74M 全中） |
| `app/ingest/parse.py` | 移除 Phase 2 早 return，事件类别真进 parser（event_stock 仍桩留 F-P2-02） |
| `app/api/movie_events.py` | GET/POST /movie-events(+/link/unlink)：关联写 投资出/本金返还/分红 ledger，幂等；解关联只清标记 |
| `frontend Movies.jsx`+App.jsx | 「电影事件」屏（未关联列表 + 同币种账户关联 + 已关联/解关联） |
| tests + DESIGN §20 F-P2-01 ✅ + CHANGELOG | |

## 验证
- 全量 `299 passed`；前端 vite build 通过。
- API 实测：关联泰坦尼克 → ledger 写 本金返还(income 90M)+分红(investment_income 376.74M) = 466.74M；幂等跳过；解关联/ linked 过滤正常。

## 说明/取舍
- 解析是 best-effort（部分文件缺字段留空，源 md 保留供数据调整员补字段）；投资出因部分文件缺投资日期未入账。
- 分红记全周期总分红（md 给的是累计值）。