### PR TITLE
feat(p2): F-P2-02 事件·股票 —— FIFO持仓引擎 + 持仓市值入总资产 + 解析/API/前端

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,34 @@
 本项目为网文创作数据 Dashboard（Postgres + FastAPI + ingest + React）。  
 开发进度跟踪以 `docs/DESIGN-webnovel-dashboard.md` §20 功能清单为准。
 
+---
+
+## [Phase 2 · F-P2-02] — 2026-08-25
+
+**事件·股票：holding_event(batch) + FIFO 成本 + 分红/卖出结算 + 被动抬升，持仓市值并入总资产**（DESIGN §19.6）
+
+- **解析/导入**：`stock_event` 表（镜像 movie_event，`ingest events-stock` 幂等 upsert）+ `event_stock` 解析器实装（best-effort，USD Style A 流水表：虎牙/哔哩/快手，金额即万美金；快手/香港/英国 万港元/万英镑 与 收购/ 子目录留二期/ F-P2-03-04）。dev 库入库 21 条。
+- **成本结算引擎** `app/core/stock_cost.py` 追加：
+  - `apply_buy`：买批次(holding_event batch) + ledger `kind='expense'` 现金移出（非 investment，避免与投资池 `pool_in_transit` 重复计数）。
+  - `apply_sell`（FIFO）：从最早 open batch 扣成本，超卖 422；写 sell 行 + ledger `income`(本金)+`investment_income`(盈亏) 两笔共=套现现金；非破坏双写。
+  - `apply_dividend`：每股×现持仓 → ledger `investment_income`，不落 holding（不污染 open batch）。
+  - `apply_passive_uplift`：仅写 `pseudo` 行(占比标记, shares=0 不构成 open)更新 pct，不写 ledger。
+  - 统一 `event_id`(source_file) 幂等 + ledger note `股票事件·{id}` 打标（可撤销）。
+- **持仓市值入总资产**：新 `app/core/stock_wealth.py`（market_value_at / portfolio_breakdown，Σ open batch shares×unit_price，只进 entity/family 域不进 account 域）接入 `rebuild_snapshots` 与 `calendar.snapshot_as_of`；DESIGN §19.6「总资产=现金+专款池+股票市值」第 3 项首次落地。
+- **API + 前端**：`GET/POST /stock-events(+/events/positions/associate/buy/sell/dividend/passive-uplift)`（写操作 `rebuild_snapshots` 刷新）+「股票事件」屏（持仓表/待关联 buy 关联/手动动作）。
+- **健康校验**：新增 **H-STOCK** 规则（shares>0 但 unit_price 缺失 → warn；持仓引用缺失实体 → crit）。
+- `tests/test_stock_position_fifo.py`(10) + `tests/test_stock_wealth.py`(6) + `tests/test_stock_api.py`(7) + 复跑既有；全量 **322 passed**。
+
+---
+
+## [Phase 2 · F-P2-01] — 2026-08-24
+
 ## [Phase 2 · F-P2-01] — 2026-08-24
 
 **事件·电影：导入 + 不关联 + 同币种 UI 手动关联**（DESIGN §19.6）
 
 - `movie_event` 表 + `event_movie` 解析器（best-effort 正则，8 部：泰坦尼克投资90M/本金90M@1998-09/分红376.74M 全中）+ `ingest events-movie` 导入。
-- 移除解析 Phase 2 早 return：事件类别真正进到 parser（event_stock 仍为桩，留 F-P2-02）。
+- 移除解析 Phase 2 早 return：事件类别真正进到 parser（event_stock 后由 F-P2-02 实装）。
 - API `GET/POST /movie-events(+/link/unlink)`：关联写 投资出/本金返还/分红 ledger（幂等），解关联只清标记不动历史账。
 - 前端「电影事件」屏（未关联列表 + 同币种账户关联 + 已关联/解关联）。
 - `tests/test_movie_event.py`（解析/upsert/phase2 放行/link 幂等）；全量 299 passed。

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -24,6 +24,7 @@ from app.api.deps import get_db
 from app.api.labor_cost import router as labor_cost_router
 from app.api.movie_events import router as movie_events_router
 from app.api.restricted import router as restricted_router
+from app.api.stock_events import router as stock_events_router
 from app.api.search import router as search_router
 from app.api.ui_ops import router as ui_ops_router
 from app.core.calendar import snapshot_as_of
@@ -37,6 +38,7 @@ app = FastAPI(title="Novel Dashboard API", version="0.1")
 app.include_router(ui_ops_router)
 app.include_router(labor_cost_router)
 app.include_router(movie_events_router)
+app.include_router(stock_events_router)
 app.include_router(search_router)
 app.include_router(restricted_router)
 

--- a/app/api/stock_events.py
+++ b/app/api/stock_events.py
@@ -1,0 +1,195 @@
+"""事件·股票 API（F-P2-02 · DESIGN §19.6）。
+
+- GET   /stock-events/events         列导入的待关联/已关联事件（StockEvent，F-P2-02 导入产物）
+- GET   /stock-events/positions      列当前持仓明细（holding_event open batches + 市值）
+- POST  /stock-events/associate      把导入的 buy 事件关联到 entity+account → apply_buy（写 holding+ledger）
+- POST  /stock-events/buy             手动买入（盒通道，写 holding batch + ledger 现金移出）
+- POST  /stock-events/sell            手动卖出（FIFO，写 sell 行 + ledger 本金/盈亏）
+- POST  /stock-events/dividend        分红（每股×现持仓 → ledger investment_income）
+- POST  /stock-events/passive-uplift  被动抬升（仅 pseudo pct 行，不写 ledger）
+
+写操作走 `_after_ui_write`（recompute + 快照 + recompute-done），保证 ledger 余额链与
+持仓市值进总资产口径同步刷新（总资产 = 现金 + 专款池 + 股票持仓市值）。
+"""
+from __future__ import annotations
+
+from datetime import date as _date, datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.core.snapshot import rebuild_snapshots
+from app.core.stock_cost import (
+    apply_buy, apply_dividend, apply_passive_uplift, apply_sell,
+)
+from app.model import HoldingEvent, StockEvent
+
+router = APIRouter(prefix="/api/v1", tags=["stock-events"])
+
+
+class AssociateIn(BaseModel):
+    stock_event_id: int
+    entity_id: int
+    account_id: int
+
+
+class StockActionIn(BaseModel):
+    entity_id: int
+    company: str
+    date: _date = Field(ge=_date(1947, 1, 1), le=_date(2026, 12, 31))
+    account_id: Optional[int] = None
+    ticker: Optional[str] = None
+    unit_price: Optional[float] = None
+    shares: Optional[float] = None
+    sell_price: Optional[float] = None
+    per_share: Optional[float] = None
+    pct: Optional[float] = None
+    event_id: str = Field(min_length=3)
+
+
+def _apply_error(e: Exception):
+    status = getattr(e, "status", 422)
+    raise HTTPException(status_code=status, detail=getattr(e, "detail", str(e)))
+
+
+def _se_dict(se: StockEvent) -> dict:
+    return {"id": se.id, "company": se.company, "ticker": se.ticker,
+            "date": se.date.isoformat() if se.date else None,
+            "event_type": se.event_type, "shares": float(se.shares) if se.shares is not None else None,
+            "unit_price": float(se.unit_price) if se.unit_price is not None else None,
+            "amount": float(se.amount) if se.amount is not None else None,
+            "pct": float(se.pct) if se.pct is not None else None,
+            "linked": se.linked_entity_id is not None}
+
+
+@router.get("/stock-events/events")
+def list_stock_events(linked: Optional[bool] = None, db: Session = Depends(get_db)):
+    q = select(StockEvent).order_by(StockEvent.company, StockEvent.date, StockEvent.id)
+    if linked is not None:
+        q = q.where(StockEvent.linked_entity_id.isnot(None) if linked
+                    else StockEvent.linked_entity_id.is_(None))
+    rows = db.execute(q).scalars().all()
+    return {"items": [_se_dict(se) for se in rows], "total": len(rows)}
+
+
+@router.get("/stock-events/positions")
+def list_positions(entity_id: Optional[int] = None, db: Session = Depends(get_db)):
+    """当前持仓：按 (entity_id, company) 聚合 open batches，列均价/市值/最新占比标记。"""
+    q = select(HoldingEvent).where(HoldingEvent.shares > 0,
+                                HoldingEvent.event_type != "sell",
+                                HoldingEvent.event_type != "pseudo")
+    if entity_id is not None:
+        q = q.where(HoldingEvent.entity_id == entity_id)
+    rows = db.execute(q.order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()
+    groups: dict[tuple[int, str], list] = {}
+    order: list[tuple[int, str]] = []
+    for r in rows:
+        key = (r.entity_id, r.company)
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(r)
+    out = []
+    for key in order:
+        eid, company = key
+        grp = groups[key]
+        total_shares = sum(float(r.shares) for r in grp)
+        cost = sum(float(r.shares) * float(r.unit_price or 0.0) for r in grp)
+        pct = None
+        for r in sorted(grp, key=lambda x: x.date):
+            if r.event_type == "pseudo" and r.pct is not None:
+                pct = float(r.pct)
+        out.append({
+            "entity_id": eid, "company": company, "ticker": grp[0].ticker,
+            "batches": len(grp), "total_shares": total_shares,
+            "market_value": round(cost, 2), "pct": pct,
+        })
+    return {"items": out, "total": len(out)}
+
+
+@router.post("/stock-events/associate")
+def associate_stock_event(body: AssociateIn, db: Session = Depends(get_db)):
+    """把导入的 buy 事件关联到 entity+account：apply_buy 实体化 holding batch + ledger 现金移出。"""
+    se = db.get(StockEvent, body.stock_event_id)
+    if not se:
+        raise HTTPException(404, "stock event not found")
+    if se.linked_entity_id is not None:
+        return {"associated": True, "skipped": True, "account_id": se.linked_account_id}
+    if se.event_type != "buy" or not se.shares or not se.unit_price:
+        raise HTTPException(422, "仅 buy 事件可关联；sell/dividend 请用对应动作端点")
+    try:
+        r = apply_buy(db, entity_id=body.entity_id, company=se.company, ticker=se.ticker,
+                      date=se.date, unit_price=float(se.unit_price), shares=float(se.shares),
+                      event_id=f"se{se.id}", account_id=body.account_id)
+    except ValueError as e:
+        _apply_error(e)
+    se.linked_entity_id = body.entity_id
+    se.linked_account_id = body.account_id
+    se.linked_at = datetime.now()
+    if not r.get("skipped"):
+        rebuild_snapshots(db, from_year=se.date.year)
+        db.commit()
+    return {"associated": True, "skipped": r.get("skipped", False),
+            "account_id": body.account_id, "result": r}
+
+
+def _settle(db, body: StockActionIn):
+    """写操作后刷新快照（含持仓市值进 entity/family）。buy/sell/dividend 只动 ledger+holding，
+    非杠杆投资账户，不需 recompute_all 的复利余额链；rebuild_snapshots 由 ledger 重算即可。"""
+    rebuild_snapshots(db, from_year=body.date.year)
+    db.commit()
+
+
+@router.post("/stock-events/buy")
+def post_buy(body: StockActionIn, db: Session = Depends(get_db)):
+    try:
+        r = apply_buy(db, entity_id=body.entity_id, company=body.company, ticker=body.ticker,
+                      date=body.date, unit_price=body.unit_price, shares=body.shares,
+                      event_id=body.event_id, account_id=body.account_id)
+    except ValueError as e:
+        _apply_error(e)
+    if not r.get("skipped"):
+        _settle(db, body)
+    return {"skipped": r.get("skipped", False), "result": r}
+
+
+@router.post("/stock-events/sell")
+def post_sell(body: StockActionIn, db: Session = Depends(get_db)):
+    try:
+        r = apply_sell(db, entity_id=body.entity_id, company=body.company, date=body.date,
+                       shares=body.shares, sell_price=body.sell_price,
+                       event_id=body.event_id, account_id=body.account_id)
+    except ValueError as e:
+        _apply_error(e)
+    if not r.get("skipped"):
+        _settle(db, body)
+    return {"skipped": r.get("skipped", False), "result": r}
+
+
+@router.post("/stock-events/dividend")
+def post_dividend(body: StockActionIn, db: Session = Depends(get_db)):
+    try:
+        r = apply_dividend(db, entity_id=body.entity_id, company=body.company, date=body.date,
+                           per_share=body.per_share, event_id=body.event_id,
+                           account_id=body.account_id)
+    except ValueError as e:
+        _apply_error(e)
+    if not r.get("skipped"):
+        _settle(db, body)
+    return {"skipped": r.get("skipped", False), "result": r}
+
+
+@router.post("/stock-events/passive-uplift")
+def post_uplift(body: StockActionIn, db: Session = Depends(get_db)):
+    try:
+        r = apply_passive_uplift(db, entity_id=body.entity_id, company=body.company,
+                                 date=body.date, to_pct=body.pct, event_id=body.event_id,
+                                 ticker=body.ticker)
+    except ValueError as e:
+        _apply_error(e)
+    # pseudo 不写 ledger、不涉余额/快照，无需重算
+    return {"skipped": r.get("skipped", False), "result": r}

--- a/app/core/calendar.py
+++ b/app/core/calendar.py
@@ -58,6 +58,12 @@ def snapshot_as_of(session: Session, as_of_date: date) -> list[dict]:
         rate = usd_rate(session, cur, year)
         if rate is not None:
             family_usd += float(amt) * float(rate)
+    # F-P2-02 §19.6：总资产 = 现金 + 专款池 + 股票持仓市值；持仓市值（USD）进 entity/family 域，
+    # 不进 account 域（持仓不在银行账户）。
+    from app.core.stock_wealth import portfolio_breakdown
+    for eid, usd in portfolio_breakdown(session, as_of_date).items():
+        entity_agg[(eid, "USD")] = entity_agg.get((eid, "USD"), 0.0) + usd
+        family_usd += usd
     for (eid, cur), bal in entity_agg.items():
         out.append({"scope": f"entity:{eid}:{cur}",
                     "value": round(bal, 2), "currency": cur, "year": year})

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -11,8 +11,10 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.model import (
-    Account, Entity, ExchangeRate, IncomeStream, LedgerEntry, Relationship, ReturnCurve, TimelineEvent,
+    Account, Entity, ExchangeRate, HoldingEvent, IncomeStream, LedgerEntry, Relationship, ReturnCurve, TimelineEvent,
 )
+
+from app.core.stock_wealth import portfolio_breakdown
 
 
 @dataclass
@@ -181,8 +183,31 @@ def check_h5_dangling(session: Session) -> list[Finding]:
     return finds
 
 
+def check_holding_value(session: Session) -> list[Finding]:
+    """H-STOCK 持仓估值一致性（F-P2-02 §19.6；不改 H1–H5 语义）。
+
+    ① shares>0（未结清）的 holding_event 行必须有 unit_price，否则无法估值 → warn；
+    ② shares>0 的 holding 须落在已存在 entity 上（被引用实体缺失 → crit，与 H5 同源防漏）。
+    """
+    finds: list[Finding] = []
+    rows = session.execute(
+        select(HoldingEvent.id, HoldingEvent.company, HoldingEvent.date,
+               HoldingEvent.entity_id, HoldingEvent.shares, HoldingEvent.unit_price)
+        .where(HoldingEvent.shares > 0)
+    ).all()
+    for hid, company, hdate, eid, shares, up in rows:
+        if up is None or float(up) == 0:
+            finds.append(Finding("H-STOCK", "warn", f"holding_event#{hid} {company} {hdate}",
+                                 f"shares>0 但 unit_price 缺失（无法估值）"))
+        if session.get(Entity, eid) is None:
+            finds.append(Finding("H-STOCK", "crit", f"holding_event#{hid} entity#{eid}",
+                                 "持仓引用不存在的实体"))
+    # ②弱一致：有未结清持仓时，全家族持仓市值应 > 0（除非 unit_price 全缺失——已被①标出）。
+    return finds
+
+
 def run_report(session: Session) -> list[dict]:
-    """全库健康校验汇总：H1..H5。"""
+    """全库健康校验汇总：H1..H5 + H-STOCK。"""
     all_finds: list[Finding] = []
     all_finds += check_h1_timeline_alignment(session)
     all_finds += check_h2_amount_consistency(session)
@@ -191,6 +216,7 @@ def run_report(session: Session) -> list[dict]:
     all_finds += check_negative_balance(session)
     all_finds += check_h4_balance_chain(session)
     all_finds += check_h5_dangling(session)
+    all_finds += check_holding_value(session)
     return [f.as_dict() for f in all_finds]
 
 
@@ -199,7 +225,7 @@ def summarize(session: Session) -> dict:
     report = run_report(session)
     # issue #23 / API 健康视图：预填 H1..H5 即使 0 也有键，前端可稳定读 summary['H1']
     summary: dict[str, dict] = {rule: {"total": 0, "warn": 0, "crit": 0}
-                                for rule in ("H1", "H2", "H3", "H4", "H5")}
+                                for rule in ("H1", "H2", "H3", "H4", "H5", "H-STOCK")}
     for r in report:
         s = summary.setdefault(r["rule"], {"total": 0, "warn": 0, "crit": 0})
         s["total"] += 1

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -156,6 +156,16 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
             continue
         pool_by_year[y] = pool_in_transit(session, date(y, 12, 30))
 
+    # 0b) 股票持仓市值（F-P2-02 §19.6）：逐年 12-30 口径 → {year: {entity_id: Decimal(USD元)}}。
+    #     只进 entity/family 两域，绝不进 account 域（持仓不在银行账户）。
+    from app.core.stock_wealth import portfolio_breakdown
+    holding_by_year: dict[int, dict[int, Decimal]] = {}
+    for y in years_list:
+        if y < start:
+            continue
+        holding_by_year[y] = {eid: Decimal(str(v))
+                              for eid, v in portfolio_breakdown(session, date(y, 12, 30)).items()}
+
     # 1) 清旧：仅清 from_year 起（含）的 account/entity/family 三种 scope 行
     scope_prefixes = ("account:", "entity:", "family:")
     session.execute(
@@ -209,6 +219,9 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
                 continue
             # §19.4：净值 = 银行 + 专款池在途；entity 口径把该年 12-30 在途本金加回（issue #85）
             v = ymap.get(y, _ZERO) + pool_by_year[y].get((eid, cur), _ZERO)
+            # F-P2-02 §19.6：仅当该币种是 USD 时追加股票持仓市值（第一阶段全 USD；FX 后续）
+            if cur == "USD":
+                v = v + holding_by_year[y].get(eid, _ZERO)
             if v == 0:
                 continue
             session.add(Snapshot(
@@ -245,6 +258,11 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
                 continue                                 # 汇率缺失 → 不计入
             family_usd = family_usd + amt * rate
             any_contribution = True
+        # F-P2-02 §19.6：股票持仓市值（USD，无需折率）计入 family:total
+        for usd_val in holding_by_year[y].values():
+            if usd_val:
+                family_usd = family_usd + usd_val
+                any_contribution = True
         # issue #28：family_usd=0 跳过（避免家族层面多年 0 值行膨胀）
         if not any_contribution or family_usd == 0:
             continue

--- a/app/core/stock_cost.py
+++ b/app/core/stock_cost.py
@@ -76,6 +76,9 @@ def _open_batches(db: Session, entity_id: int, company: str) -> list[dict]:
         HoldingEvent.entity_id == entity_id,
         HoldingEvent.company == company,
         HoldingEvent.shares > 0,
+        # sell/pseudo 是历史/占比标记，非 open 持仓（否则分红/抬升/估值会误计）
+        HoldingEvent.event_type != "sell",
+        HoldingEvent.event_type != "pseudo",
     ).order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()
     return [{"shares": float(r.shares), "unit_price": float(r.unit_price or 0.0),
              "batch_id": r.batch_id} for r in rows]
@@ -153,3 +156,144 @@ def apply_merger(db: Session, spec: dict, source: str | None = None) -> dict:
                 inflow=cash, balance=None, kind="investment_income", note=f"股权事件·{form}"))
 
     return {"new_batches": new, "cash": cash, "closed": closed, "skipped": False}
+
+
+# ---------------------------------------------------------------------------
+# F-P2-02：买入 / FIFO 卖出 / 分红 / 被动抬升（§19.6）
+# ---------------------------------------------------------------------------
+# 通用幂等：每个动作接受 event_id（幂等 nonce），写入 HoldingEvent.source_file；
+# 闸门按 (entity_id, source_file) 判：已存在 → skipped。ledger note 统一打
+# `股票事件·{event_id}`（参照 invest._delete_investment_writes 的 tag 约定，可撤销）：
+#   撤销 = 按 note LIKE '%股票事件·{event_id}%' 删 ledger + source_file==event_id 删 holding_event。
+# ledger kind 复用约束内类型（income/expense/investment/investment_income/pool），不加 DDL。
+# 买入/卖出/分红/抬升与块 A (stock_wealth.market_value_at) 都用 shares×unit_price 口径，
+# 保证「总资产 = 现金 + 专款池 + 持仓市值」不重不漏。
+
+
+def _event_nonce_applied(db: Session, entity_id: int, event_id: str) -> bool:
+    """是否已应用该事件（按 (entity_id, source_file=event_id) 判重）。"""
+    return db.execute(select(HoldingEvent.id).where(
+        HoldingEvent.entity_id == entity_id,
+        HoldingEvent.source_file == event_id).limit(1)).scalar_one_or_none() is not None
+
+
+def apply_buy(db: Session, *, entity_id: int, company: str, ticker: str | None = None,
+              date, unit_price: float, shares: float, event_id: str, account_id: int) -> dict:
+    """买入建仓：写 holding_event(batch) + ledger(现金移出，kind=investment)。
+
+    买入瞬间总资产 = 现金 − 买价 + 持仓(+买价) = 净零，不重不漏。
+    """
+    if _event_nonce_applied(db, entity_id, event_id):
+        return {"event_id": event_id, "entity_id": entity_id, "company": company,
+                "batch_id": None, "shares": shares, "cost_basis": 0.0, "skipped": True}
+    if not (account_id and unit_price and shares > 0):
+        raise ValueError("apply_buy 需 account_id / unit_price>0 / shares>0")
+    batch_id = next(_next_batch_ids(db, 1))
+    db.add(HoldingEvent(entity_id=entity_id, company=company, ticker=ticker, date=date,
+                        event_type="buy", batch_id=batch_id, shares=shares,
+                        unit_price=unit_price, amount=shares * unit_price / 10000.0,
+                        source_file=event_id))
+    # kind='expense'（非 investment）：避免被 pool_in_transit（Σ kind in {investment,pool}）当作
+    # 投资池在途，与持仓市值重复计数；净值由 stock_wealth（holding_event 市值）承载。
+    db.add(LedgerEntry(account_id=account_id, date=date, reason=f"股票买入·{company}",
+                       outflow=shares * unit_price, balance=None, kind="expense",
+                       note=f"股票事件·{event_id}"))
+    return {"event_id": event_id, "entity_id": entity_id, "company": company,
+            "batch_id": batch_id, "shares": shares, "cost_basis": shares * unit_price,
+            "skipped": False}
+
+
+def apply_sell(db: Session, *, entity_id: int, company: str, date, shares: float,
+               sell_price: float, event_id: str, account_id: int) -> dict:
+    """FIFO 卖出：从最早 open batch 扣成本；写 sell 行 + ledger(本金 investment + 盈亏 investment_income)。
+
+    超卖在写入前校验（422），避免中途改库后报错需回滚。非破坏式双写：减原 buy 行 shares（置 0 即结清）
+    + 自留一条 sell 历史行，供日后全事件流 as-of 重放。
+    """
+    if _event_nonce_applied(db, entity_id, event_id):
+        return {"event_id": event_id, "company": company, "sold_shares": shares,
+                "cost_basis": 0.0, "proceeds": 0.0, "realized_pnl": 0.0,
+                "accepted": [], "skipped": True}
+    if not account_id or shares <= 0:
+        raise ValueError("apply_sell 需 account_id / shares>0")
+    rows = db.execute(select(HoldingEvent).where(
+        HoldingEvent.entity_id == entity_id,
+        HoldingEvent.company == company,
+        HoldingEvent.shares > 0,
+        HoldingEvent.event_type != "sell",
+        HoldingEvent.event_type != "pseudo",
+    ).order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()
+    available = sum(float(r.shares) for r in rows)
+    if shares > available:
+        raise ValueError(f"卖出 {shares} 股超持仓，可卖 {available} 股")
+    remaining = float(shares)
+    cost_sold = 0.0
+    accepted: list[tuple] = []
+    for r in rows:
+        if remaining <= 0:
+            break
+        take = min(float(r.shares), remaining)
+        cost_sold += take * float(r.unit_price or 0.0)
+        r.shares = float(r.shares) - take      # 置 0 = 结清，保留历史行
+        accepted.append((r.batch_id, take))
+        remaining -= take
+    cost_sold = round(cost_sold, 6)
+    proceeds = round(float(shares) * float(sell_price), 6)
+    realized_pnl = round(proceeds - cost_sold, 6)
+    ticker = rows[0].ticker if rows else None
+    db.add(HoldingEvent(entity_id=entity_id, company=company, ticker=ticker, date=date,
+                        event_type="sell", shares=float(shares), unit_price=cost_sold / shares,
+                        amount=proceeds / 10000.0, source_file=event_id))
+    # 本金归还现金（kind='income'，非 investment → pool_in_transit 不误判、不与市值重复计数）
+    db.add(LedgerEntry(account_id=account_id, date=date, reason=f"股票卖出·{company}",
+                       inflow=cost_sold, balance=None, kind="income",
+                       note=f"股票事件·{event_id}"))
+    # 盈亏（可负）→ investment_income；两笔合计 = 套现现金 proceeds
+    if realized_pnl:
+        db.add(LedgerEntry(account_id=account_id, date=date, reason=f"股票卖出盈亏·{company}",
+                           inflow=realized_pnl if realized_pnl >= 0 else None,
+                           outflow=-realized_pnl if realized_pnl < 0 else None,
+                           balance=None, kind="investment_income", note=f"股票事件·{event_id}"))
+    return {"event_id": event_id, "company": company, "sold_shares": float(shares),
+            "cost_basis": cost_sold, "proceeds": proceeds, "realized_pnl": realized_pnl,
+            "accepted": accepted, "skipped": False}
+
+
+def apply_dividend(db: Session, *, entity_id: int, company: str, date, per_share: float,
+                   event_id: str, account_id: int) -> dict:
+    """分红结算：每股 × 加权现持仓 → ledger(income)，不写 holding_event（股数/成本不变）。"""
+    existing = db.execute(select(LedgerEntry.id).where(
+        LedgerEntry.note.like(f"%{event_id}%")).limit(1)).scalar_one_or_none()
+    if existing is not None:
+        return {"event_id": event_id, "company": company, "holding_shares": 0.0,
+                "dividend": 0.0, "skipped": True}
+    holding = sum(b["shares"] for b in _open_batches(db, entity_id, company))
+    amount = round(holding * per_share, 6)
+    db.add(LedgerEntry(account_id=account_id, date=date, reason=f"股票分红·{company}",
+                       inflow=amount, balance=None, kind="investment_income",
+                       note=f"股票事件·{event_id}"))
+    return {"event_id": event_id, "company": company, "holding_shares": holding,
+            "dividend": amount, "skipped": False}
+
+
+def apply_passive_uplift(db: Session, *, entity_id: int, company: str, date, to_pct: float | None,
+                         event_id: str, ticker: str | None = None) -> dict:
+    """被动抬升（回购缩股本）：持股不变、无现金动作 → 仅写 pseudo 行更新 pct，不写 ledger。
+
+    本轮实现语义 a（仅更新 pct，持股市值不变）；语义 b（回购缩股本按 to_shares 下调）
+    涉及 unit_price 再平衡 + H-STOCK 联动，留后续（见函数 docstring）。
+    """
+    if _event_nonce_applied(db, entity_id, event_id):
+        return {"event_id": event_id, "company": company, "event_type": "pseudo",
+                "pct": to_pct, "skipped": True}
+    if not _open_batches(db, entity_id, company):
+        return {"event_id": event_id, "company": company, "event_type": "pseudo",
+                "pct": to_pct, "skipped": True}   # 无持仓则无抬升对象
+    # shares=0：该行仅作占比/历史标记，不构成 open 头寸（market_value_at 按 shares>0 排除，
+    # 避免与原 buy 批次重复计数——被动抬升持股不变、市值不变）。
+    db.add(HoldingEvent(entity_id=entity_id, company=company, ticker=ticker, date=date,
+                        event_type="pseudo", batch_id=next(_next_batch_ids(db, 1)),
+                        shares=0.0, unit_price=None, amount=None, pct=to_pct,
+                        source_file=event_id))
+    return {"event_id": event_id, "company": company, "event_type": "pseudo",
+            "pct": to_pct, "skipped": False}

--- a/app/core/stock_wealth.py
+++ b/app/core/stock_wealth.py
@@ -1,0 +1,63 @@
+"""股票持仓市值估值（F-P2-02 · DESIGN §19.6）。
+
+持仓市值 = Σ 未结清 opens（batch，shares>0）的 shares × unit_price（成本基准）。
+并入总资产口径：总资产 = 银行现金 + 投资专款池 + 股票持仓市值（§19.6）。
+
+口径纪律（与 ledger/快照对齐）：
+- 返回 **美元元**（与 account:* / entity:* / family:total 快照 value 一致），不做 /10000。
+- 只有写 `holding_event.amount`（万USD 列）时才除 10000 —— 见 stock_cost / apply_buy。
+- `shares > 0` 即自动排除被 split/merge/sell 结清(closed) 的行（写时被置 0）。
+
+已知局限（须明示）：`stock_cost.apply_merger` 破坏性把旧公司 shares 置 0（:142-146），
+故分拆/并购**之前**的年份该上游公司市值会归零（新批次 date=重构日，date<=as_of 过滤只
+在 >= 重构年生效）。净影响：>= 最后一次重构的年份完全正确，更早年份市值被漏。F-P2-02
+的 `apply_sell` 采用非破坏式双写（减原 buy 行 + 自留 sell 行），是后续做全事件流 as-of
+重放的最小支撑（完整修复 split 属 follow-up）。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.model import HoldingEvent
+
+
+def market_value_at(session: Session, entity_id: int, as_of: date) -> float:
+    """主体截至 as_of 的持仓成本市值（USD 元，非万）。
+
+    口径：Σ HoldingEvent.shares>0 且 date<=as_of 的 shares×unit_price。
+    """
+    rows = session.execute(
+        select(HoldingEvent.shares, HoldingEvent.unit_price).where(
+            HoldingEvent.entity_id == entity_id,
+            HoldingEvent.shares > 0,
+            # sell/pseudo 是历史/占比标记，非 open 持仓（shares>0 只排除被减为 0 的）
+            HoldingEvent.event_type != "sell",
+            HoldingEvent.event_type != "pseudo",
+            HoldingEvent.date <= as_of,
+        )
+    ).all()
+    return float(sum(float(r.shares) * float(r.unit_price or 0.0) for r in rows))
+
+
+def market_value_by_year(session: Session, entity_id: int, years: list[int]) -> dict[int, float]:
+    """逐年 12-30 口径持仓市值（供 rebuild_snapshots / snapshot_as_of 批量）。"""
+    return {y: market_value_at(session, entity_id, date(y, 12, 30)) for y in years}
+
+
+def portfolio_breakdown(session: Session, as_of: date) -> dict[int, float]:
+    """全实体截至 as_of 的持仓市值：{entity_id -> USD 元}。一次全库查，供快照/批量复用。"""
+    rows = session.execute(
+        select(HoldingEvent.entity_id, HoldingEvent.shares, HoldingEvent.unit_price).where(
+            HoldingEvent.shares > 0,
+            HoldingEvent.event_type != "sell",
+            HoldingEvent.event_type != "pseudo",
+            HoldingEvent.date <= as_of,
+        )
+    ).all()
+    out: dict[int, float] = {}
+    for eid, sh, up in rows:
+        out[int(eid)] = out.get(int(eid), 0.0) + float(sh) * float(up or 0.0)
+    return out

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -479,5 +479,28 @@ def events_movie(env: str = typer.Option("dev", "--env")):
     typer.echo(f"[{env}] 电影事件导入 {len(all_records)} 条；新增 {r['inserted']} 跳过 {r['skipped']}")
 
 
+@app.command()
+def events_stock(env: str = typer.Option("dev", "--env")):
+    """F-P2-02 事件·股票导入：扫 基准/事件/股票/ 顶层 USD Style A → 解析 → 落库 stock_event（幂等）。
+
+    阶段一只接受 USD 流水表（虎牙/哔哩等根级 *.md）；快手/香港/英国（万港元/万英镑）与
+    收购/ 子目录（分拆并购链，F-P2-03/04）本轮跳过。导入不关联账户，UI 同币种手动关联补 ledger。
+    """
+    from app.ingest.parsers.event_stock import parse_event_stock
+    from app.ingest.writer import import_stock_events
+    cfg = get_config(env)
+    base = cfg.source_dir / "基准" / "事件" / "股票"
+    if not base.exists():
+        typer.echo(f"[{env}] 无股票事件目录: {base}")
+        return
+    all_records = []
+    for f in sorted(base.glob("*.md")):   # 仅顶层否（收购/英国/香港 子目录本轮跳过）
+        all_records.extend(parse_event_stock(f))
+    with _session_for(env) as s:
+        r = import_stock_events(s, all_records)
+        s.commit()
+    typer.echo(f"[{env}] 股票事件解析 {len(all_records)} 条；新增 {r['inserted']} 跳过 {r['skipped']}")
+
+
 if __name__ == "__main__":
     app()

--- a/app/ingest/parsers/event_stock.py
+++ b/app/ingest/parsers/event_stock.py
@@ -1,28 +1,174 @@
-"""事件·股票解析（DESIGN §6.1 / §19.6 · Phase 2 占位）。
+"""事件·股票解析（F-P2-02 · DESIGN §19.6 / §6.3）。
 
-Phase 1 跳过（detect → PHASE2_EVENT），Phase 2 启用后：
-  基准/事件/股票/** → holding_event(batch) + ledger_entry(买入/卖出/分红)
-  由数据调整员导入不关联账户，UI 同币种手动关联。
+`基准/事件/股票/**` → 归一化 holding_event 记录。best-effort（同 event_movie 风格）：
+只认「Style A 流水表」（列头含 `事件类型` + `股数/份额` + `单价` + `金额`），
+阶段一只接受 **USD** 金额表（列头如 `金额(万美金)`），快手/香港/英国（万港元/万英镑）显式跳过。
 
-当前为占位实现：解析返回空列表，保留接口与 DDL 对齐（holding_event.batch_id
-FIFO、分拆/并购成本链见 DESIGN §19.6）。
+单个事件行 event_type 归一化：买入→`buy` / 卖出→`sell` / 派息分红→`dividend` / 被动抬升·年度
+市值·稀释→`pseudo`。**只有 `buy` 行会自动落 holding_event 成本批次**（供 FIFO/市值）；`sell`
+需账户结算、`dividend`/`pseudo` 落行会污染 open 批次，故解析返回供 UI/数据调整员按需处理，
+不自动写入（对应 DESIGN「导入不关联账户→UI 同币种手动关联补 ledger」）。
 """
 from __future__ import annotations
 
+import re
+from datetime import date
 from pathlib import Path
+
+from app.ingest.parsers import _split_table_row
+from app.ingest.normalize import parse_number
+
+# 事件词 → 归一化 event_type
+_BUY_KW = ("投资", "买入", "认购", "建仓", "出资", "增持", "持股", "获配", "吃下", "收购", "买")
+_SELL_KW = ("卖出", "减持", "抛售", "售出", "清仓", "套现")
+_DIV_KW = ("派息", "分红", "股息", "红利")
+
+
+def _norm_type(word: str) -> str:
+    if any(k in word for k in _SELL_KW):
+        return "sell"
+    if any(k in word for k in _DIV_KW):
+        return "dividend"
+    if any(k in word for k in _BUY_KW):
+        return "buy"
+    return "pseudo"
+
+
+def _date_of(cell: str) -> date | None:
+    """支持 '2025.12.31' / '2017-05-17' / '2017年5月' / '2018' → date。"""
+    m = re.search(r"((?:19|20)\d{2})[-.](\d{1,2})[-.](\d{1,2})", cell)
+    if m:
+        return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    m = re.search(r"((?:19|20)\d{2})年?\s*(\d{1,2})?月?", cell)
+    if m:
+        return date(int(m.group(1)), int(m.group(2) or 1), 1)
+    m = re.search(r"((?:19|20)\d{2})", cell)
+    if m:
+        return date(int(m.group(1)), 1, 1)
+    return None
+
+
+def _shares_scale(header_cell: str) -> float:
+    """股数列头单位：亿股→1e8，万股→1e4，否则 1（普通股/ADS）。"""
+    if "亿" in header_cell:
+        return 1e8
+    if "万" in header_cell:
+        return 1e4
+    return 1.0
+
+
+def _is_usd_amount_header(header_cell: str) -> bool:
+    """金额列头是否为 USD（阶段一仅 USD）。排除 港元/英镑/人民币/欧元。"""
+    if any(u in header_cell for u in ("港", "英", "人", "欧")):
+        return False
+    return ("万" in header_cell or "USD" in header_cell
+            or "美元" in header_cell or "美金" in header_cell)
+
+
+def _find_style_a_tables(text: str) -> list[dict]:
+    """定位 Style A 表。返回 [{header_idx, cols:{date/company/type/shares/unit_price/amount/pct→idx}, shares_scale}]。"""
+    lines = text.splitlines()
+    tables: list[dict] = []
+    for i, line in enumerate(lines[:-1]):
+        cells = _split_table_row(line)
+        nxt = _split_table_row(lines[i + 1])
+        is_sep = (len(nxt) >= 2 and all(re.fullmatch(r":?-{2,}:?", (c or "-")) for c in nxt[:max(2, len(cells))]))
+        if not cells or not is_sep or "事件类型" not in "".join(cells):
+            continue
+        amt_idx = next((k for k, c in enumerate(cells) if "金额" in c), None)
+        if amt_idx is None or not _is_usd_amount_header(cells[amt_idx]):
+            continue
+        def idx(*needles):
+            for k, c in enumerate(cells):
+                if any(x in c for x in needles):
+                    return k
+            return None
+        shares_idx = idx("股数", "份额")
+        tables.append({
+            "header_idx": i,
+            "cols": {
+                "date": idx("日期", "年份", "时间"),
+                "company": idx("标的", "代码", "公司", "名字"),
+                "type": idx("事件类型"),
+                "shares": shares_idx,
+                "unit_price": idx("单价"),
+                "amount": amt_idx,
+                "pct": idx("持股比例", "比例"),
+            },
+            "shares_scale": _shares_scale(cells[shares_idx]) if shares_idx is not None else 1.0,
+        })
+    return tables
+
+
+def _to_company(cell: str) -> tuple[str, str | None]:
+    """标的格 → (company, ticker)。'HUYA（虎牙）'→('虎牙','HUYA')；'快手-W 01024.HK'→('快手','01024.HK')。"""
+    s = cell.strip().lstrip("0123456789.、 ")
+    # 中英文混排：英文代码（…）+ 中文名（…）→ (中文, 代码)
+    m = re.match(r"([A-Za-z0-9.\- ]+)[（(]([^（）()]*)[)）]", s)
+    if m:
+        return m.group(2).strip(), m.group(1).strip()
+    # 中文 → 代码：'快手-W 01024.HK'
+    m2 = re.match(r"([A-Za-z一-鿿]+)(?:-W)?[ \t]+([A-Z0-9.]{2,})", s)
+    if m2:
+        return m2.group(1), m2.group(2)
+    # 纯中文名
+    m3 = re.match(r"([一-鿿A-Za-z0-9]{2,})", s)
+    if m3:
+        return m3.group(1), None
+    raise ValueError("无法解析标的")
 
 
 def parse_event_stock(path: Path) -> list[dict]:
-    """股票事件素材占位解析（Phase 2）。
+    """扫描文件的 Style A USD 流水表，逐行归一化为 holding_event 记录。
 
-    输入：基准/事件/股票/**（收购、分拆、并购链等）
-    输出：归一化 holding_event + ledger_entry 记录（待 Phase 2 定义）
-
-    当前返回空列表，调用方已通过 det.phase2 提前拦截；保留以满足
-    DESIGN §3 目录结构完整性与后续增量开发不改分发逻辑。
+    返回记录字段：`{company, ticker, date, event_type, shares, unit_price,
+    amount(万USD), pct, source_file}`。解析失败的杂行/散文跳过（best-effort）。
     """
-    _ = path
-    return []
+    text = path.read_text(encoding="utf-8")
+    recs: list[dict] = []
+    src = str(path)
+    lines = text.splitlines()
+    for table in _find_style_a_tables(text):
+        cols, scale = table["cols"], table["shares_scale"]
+        for line in lines[table["header_idx"] + 2:]:
+            cells = _split_table_row(line)
+            if len(cells) < 3:
+                continue
+            t_col = cols["type"]
+            raw_type = cells[t_col].strip() if t_col is not None and t_col < len(cells) else ""
+            if not raw_type:
+                continue
+            dt_col = cols["date"]
+            if dt_col is None or dt_col >= len(cells):
+                continue
+            dt = _date_of(cells[dt_col])
+            if dt is None:
+                continue
+            try:
+                company, ticker = _to_company(cells[cols["company"]])
+            except (ValueError, IndexError, TypeError):
+                company, ticker = "未知", None
+            shares = None
+            if cols["shares"] is not None and cols["shares"] < len(cells):
+                v = parse_number(cells[cols["shares"]])
+                shares = v * scale if v is not None else None
+            unit_price = None
+            if cols["unit_price"] is not None and cols["unit_price"] < len(cells):
+                unit_price = parse_number(cells[cols["unit_price"]])
+            amount = None
+            if cols["amount"] < len(cells):
+                amount = parse_number(cells[cols["amount"]])
+            pct = None
+            if cols["pct"] is not None and cols["pct"] < len(cells):
+                pm = re.match(r"([\d.]+)%", cells[cols["pct"]])
+                pct = float(pm.group(1)) if pm else None
+            recs.append({
+                "company": company, "ticker": ticker, "date": dt.isoformat(),
+                "event_type": _norm_type(raw_type), "shares": shares,
+                "unit_price": unit_price, "amount": amount, "pct": pct,
+                "source_file": src,
+            })
+    return recs
 
 
 # DESIGN §3 要求的统一入口名 parse

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.ingest.normalize import resolve_date
 from app.model import (Account, Entity, ExchangeRate, FinanceEntry, IncomeStream,
-                       InitialAsset, LedgerEntry, Relationship)
+                       InitialAsset, LedgerEntry, Relationship, StockEvent)
 
 
 def upsert_entity(session: Session, entity_type: str, name: str,
@@ -650,5 +650,35 @@ def import_movie_events(session: Session, records: list[dict]) -> dict:
             stats["skipped"] += 1
             continue
         session.add(MovieEvent(**{k: v for k, v in r.items()}))
+        stats["inserted"] += 1
+    return stats
+
+
+def import_stock_events(session: Session, records: list[dict]) -> dict:
+    """F-P2-02：股票事件落库（幂等 upsert by company+date+event_type+source_file）。
+
+    只落**待关联**记录（StockEvent），不写 holding_event/ledger——account/entity 由 UI 同币种
+    手动关联时解析（block D associate → apply_buy 等）。currency 默认 USD（阶段一仅 USD）。
+    """
+    stats = {"inserted": 0, "skipped": 0}
+    seen: set[tuple] = set()   # 批内去重（best-effort 解析同一文件可能产出多条 (company,date,event_type) 相同的杂行）
+    for r in records:
+        d = r["date"] if isinstance(r["date"], date) else date.fromisoformat(str(r["date"]))
+        key = (r["company"], d, r["event_type"], r["source_file"])
+        if key in seen:
+            stats["skipped"] += 1
+            continue
+        seen.add(key)
+        dup = session.execute(select(StockEvent.id).where(
+            StockEvent.company == key[0], StockEvent.date == key[1],
+            StockEvent.event_type == key[2], StockEvent.source_file == key[3],
+        ).limit(1)).scalar_one_or_none()
+        if dup is not None:
+            stats["skipped"] += 1
+            continue
+        payload = {k: v for k, v in r.items()}
+        payload.setdefault("currency", "USD")
+        payload["date"] = d
+        session.add(StockEvent(**payload))
         stats["inserted"] += 1
     return stats

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -12,6 +12,7 @@ from app.model.derived import (
 )
 from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
 from app.model.movie_event import MovieEvent
+from app.model.stock_event import StockEvent
 from app.model.search import SearchIndex
 
 __all__ = [
@@ -22,5 +23,5 @@ __all__ = [
     "UserDataOverlay", "Snapshot", "SourceFileVersion", "RecomputeJob", "Notification",
     "Investment", "InvestmentAlloc",
     "LaborWageBenchmark", "LaborCpiGrowth", "LaborTaxBenchmark",
-    "MovieEvent", "SearchIndex",
+    "MovieEvent", "StockEvent", "SearchIndex",
 ]

--- a/app/model/stock_event.py
+++ b/app/model/stock_event.py
@@ -1,0 +1,40 @@
+"""事件·股票（F-P2-02 · DESIGN §19.6）。
+
+股票事件导入 + 不关联账户 → UI 同币种手动关联 → apply_buy/sell/dividend 实体化
+holding_event(batch) + 写 ledger。一行 = 一个解析出的 Style A 事件。
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class StockEvent(Base):
+    __tablename__ = "stock_event"
+    __table_args__ = (
+        UniqueConstraint("company", "date", "event_type", "source_file",
+                         name="uq_stock_company_date_type_source"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    company: Mapped[str] = mapped_column(String, nullable=False)
+    ticker: Mapped[Optional[str]] = mapped_column(String)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    event_type: Mapped[Optional[str]] = mapped_column(String,
+                                                       comment="buy/sell/dividend/pseudo")
+    currency: Mapped[Optional[str]] = mapped_column(String, comment="默认 USD")
+    shares: Mapped[Optional[float]] = mapped_column(Numeric)
+    unit_price: Mapped[Optional[float]] = mapped_column(Numeric)
+    amount: Mapped[Optional[float]] = mapped_column(Numeric, comment="单位：万美金")
+    pct: Mapped[Optional[float]] = mapped_column(Numeric)
+    linked_entity_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("entity.id"))
+    linked_account_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("account.id"))
+    linked_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    source_file: Mapped[Optional[str]] = mapped_column(Text)
+    source_line: Mapped[Optional[int]] = mapped_column(Integer)
+    version_id: Mapped[Optional[int]] = mapped_column(BigInteger)

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -872,7 +872,7 @@ UI 派生操作（投资创建/赎回、划拨换汇）的编年史同步为**�
 | 编号 | 模块 | 功能 | 关键章节 | 状态 |
 |---|---|---|---|---|
 | F-P2-01 | **事件·电影** | 电影事件导入 + 不关联 + 同币种 UI 手动关联（现金流入账户）｜已实现：`movie_event` 表 + `event_movie` 解析器（best-effort）+ `ingest events-movie`（8 部入库）+ `GET/POST /movie-events(+/link/unlink)`（关联写 投资出/本金返还/分红 ledger，幂等）+「电影事件」屏 | §19.6/§6.9 | ✅ |
-| F-P2-02 | **事件·股票** | holding_event(batch) + FIFO 成本 + 分红/卖出结算 + 被动抬升占比 | §19.6/§6.9 | ⬜ |
+| F-P2-02 | **事件·股票** | holding_event(batch) + FIFO 成本 + 分红/卖出结算 + 被动抬升占比｜已实现 `stock_event` 表 + `event_stock` 解析器(best-effort, USD Style A: 虎牙/哔哩/快手) + `ingest events-stock`(21 条入库) + `stock_cost` 引擎 apply_buy/FIFO apply_sell/apply_dividend/apply_passive_uplift（event_id 幂等、note 打标可撤销）+ `GET/POST /stock-events(+/events/positions/associate/buy/sell/dividend/passive-uplift)` + 持仓市值并入 entity/family 总资产口径(`stock_wealth` 接入 rebuild_snapshots/calendar.snapshot_as_of) + H-STOCK 健康规则 +「股票事件」前端屏 + 23 新单测(block A/B/D) | §19.6/§6.9 | ✅ |
 | F-P2-03 | **事件·股票** | 分拆 / 并购三形态（换股+现金/纯现金/纯换股）成本随链｜已实现 `app/core/stock_cost.py` 成本引擎：split_position/cash_share_position/cash_merger + apply_merger(写 holding_event 新批次+结清+现金 ledger，幂等)。形态1 按新股数占比摊成本、形态2 成本全随链现金入余额、形态3 现金不记损益；7 单测复现 UTC 分拆/MVL‑DIS/纯现金 | §19.6 | ✅ |
 | F-P2-04 | **事件·股票** | HP_CSC 重组链数值导入 → 依 §11.4 + H2 逐行验证 | §19.6 | ⬜ |
 | F-P2-05 | **时间线/编年史 UI 编辑** | overlay 增改删、差异/重置回源/以源为最新 | §12/§6.4 | ⬜ |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import { ErrorBox } from './screens/ui'
 import { useDataOp } from './screens/useDataOp'
 import LaborCost from './screens/LaborCost'
 import Movies from './screens/Movies'
+import Stock from './screens/Stock'
 import Search from './screens/Search'
 
 const TABS = [
@@ -19,6 +20,7 @@ const TABS = [
   { key: 'finance', label: '财务收支' },
   { key: 'labor', label: '加薪规则/用工成本' },
   { key: 'movies', label: '电影事件' },
+  { key: 'stock', label: '股票事件' },
   { key: 'persons', label: '人物图谱' },
   { key: 'companies', label: '公司图谱' },
   { key: 'graphall', label: '全图谱' },
@@ -70,6 +72,7 @@ export default function App() {
         {active === 'companies' && <CompanyGraph />}
         {active === 'graphall' && <Graph url="/api/v1/graph/all" />}
         {active === 'movies' && <Movies />}
+        {active === 'stock' && <Stock />}
         {active === 'search' && <Search />}
         {(active === 'timeline' || active === 'health') && (
           <Placeholder label={TABS.find(t => t.key === active).label} asOf={asOf} />

--- a/frontend/src/screens/Stock.jsx
+++ b/frontend/src/screens/Stock.jsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import { useFetch, useDataOp } from './useDataOp'
+import { ErrorBox } from './ui'
+
+const FMT = (n, unit = '') => (n != null ? (+n).toLocaleString() + unit : '—')
+
+/**
+ * 股票事件屏（F-P2-02 · §19.6）：持仓明细 + 导入事件关联 + 手动买入/卖出/分红/被动抬升。
+ * 写操作后传（recompute+快照）由后端同一请求内完成，前端不另发。
+ */
+export default function Stock() {
+  const [refresh, setRefresh] = useState(0)
+  const positions = useFetch(`/api/v1/stock-events/positions?refresh=${refresh}`)
+  const events = useFetch(`/api/v1/stock-events/events?refresh=${refresh}`)
+  const accounts = useFetch('/api/v1/accounts?page_size=200')
+  const op = useDataOp(() => setRefresh(r => r + 1))
+
+  // 关联状态
+  const [assocId, setAssocId] = useState(null)
+  const [entSel, setEntSel] = useState('')
+  const [accSel, setAccSel] = useState('')
+
+  // 手动动作表单
+  const [form, setForm] = useState({ company: '', date: '2018-12-30', unit_price: '', shares: '', per_share: '', sell_price: '', pct: '', event_id: 'ui-stock-1', entity_id: '', account_id: '' })
+  const [action, setAction] = useState('buy')
+
+  const doAssociate = () => {
+    if (!entSel || !accSel) return
+    op.submit('/api/v1/stock-events/associate', { stock_event_id: assocId, entity_id: Number(entSel), account_id: Number(accSel) })
+    setAssocId(null); setEntSel(''); setAccSel('')
+  }
+
+  const doAction = () => {
+    const body = {
+      entity_id: Number(form.entity_id), account_id: Number(form.account_id),
+      company: form.company, date: form.date, event_id: form.event_id || 'ui-stock-1',
+      unit_price: form.unit_price ? Number(form.unit_price) : undefined,
+      shares: form.shares ? Number(form.shares) : undefined,
+      sell_price: form.sell_price ? Number(form.sell_price) : undefined,
+      per_share: form.per_share ? Number(form.per_share) : undefined,
+      pct: form.pct ? Number(form.pct) : undefined,
+    }
+    op.submit(`/api/v1/stock-events/${action}`, body)
+  }
+
+  const pos = positions.data?.items || []
+  const evts = events.data?.items || []
+  const accts = (accounts.data?.items || [])
+  const entities = [...new Set(accts.map(a => a.entity_id))].filter(Boolean)
+  const buyEvents = evts.filter(e => e.event_type === 'buy' && !e.linked)
+
+  const inp = (k, w = 90) => (
+    <input style={{ width: w }} value={form[k] || ''} placeholder={k}
+      onChange={e => setForm(f => ({ ...f, [k]: e.target.value }))} />
+  )
+
+  return (
+    <div className="screen">
+      <div className="panel">
+        <h3>股票事件</h3>
+        <p className="note">持仓市值并入总资产（总资产=现金+专款池+股票市值）；F-P2-02</p>
+        <ErrorBox error={op.error} />
+
+        <h4>当前持仓</h4>
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead><tr><th>标的</th><th>Ticker</th><th>批次</th><th>总股数</th><th>市值(USD)</th><th>占比</th><th>Entity</th></tr></thead>
+          <tbody>
+            {pos.map((p, i) => (
+              <tr key={i}>
+                <td>{p.company}</td><td>{p.ticker || '—'}</td><td>{p.batches}</td>
+                <td>{FMT(p.total_shares)}</td><td>{FMT(p.market_value, '')}</td>
+                <td>{p.pct != null ? p.pct + '%' : '—'}</td><td>ent#{p.entity_id}</td>
+              </tr>
+            ))}
+            {!pos.length && <tr><td colSpan="7" className="note">暂无持仓</td></tr>}
+          </tbody>
+        </table>
+
+        <h4>导入的待关联 buy 事件</h4>
+        {assocId && (
+          <div style={{ margin: '8px 0' }}>
+            <span className="note">选择主体 & 账户：</span>
+            <select value={entSel} onChange={e => setEntSel(e.target.value)}>
+              <option value="">— 主体 —</option>
+              {entities.map(e => <option key={e} value={e}>entity#{e}</option>)}
+            </select>
+            <select value={accSel} onChange={e => setAccSel(e.target.value)}>
+              <option value="">— 账户 —</option>
+              {accts.map(a => <option key={a.id} value={a.id}>acct#{a.id} {a.currency}</option>)}
+            </select>
+            <button className="primary" disabled={!entSel || !accSel || op.busy} onClick={doAssociate}>确认关联</button>
+            <button className="ghost" onClick={() => { setAssocId(null); setEntSel(''); setAccSel('') }}>取消</button>
+          </div>
+        )}
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead><tr><th>公司</th><th>日期</th><th>股数</th><th>单价</th><th>金额(万USD)</th><th>占比</th><th></th></tr></thead>
+          <tbody>
+            {buyEvents.map(e => (
+              <tr key={e.id}>
+                <td>{e.company}{e.ticker ? ` (${e.ticker})` : ''}</td><td>{e.date}</td>
+                <td>{FMT(e.shares)}</td><td>{FMT(e.unit_price)}</td><td>{FMT(e.amount, '万')}</td>
+                <td>{e.pct != null ? e.pct + '%' : '—'}</td>
+                <td><button className="ghost" onClick={() => setAssocId(e.id)}>关联</button></td>
+              </tr>
+            ))}
+            {!buyEvents.length && <tr><td colSpan="7" className="note">无待关联 buy 事件（可手动买入）</td></tr>}
+          </tbody>
+        </table>
+
+        <h4>手动动作</h4>
+        <div>
+          <select value={action} onChange={e => setAction(e.target.value)}>
+            <option value="buy">买入 buy</option>
+            <option value="sell">卖出 sell</option>
+            <option value="dividend">分红 dividend</option>
+            <option value="passive-uplift">被动抬升</option>
+          </select>
+          {' '}{inp('entity_id', 60)} {inp('account_id', 60)} {inp('company', 120)} {inp('date', 120)}
+          {action === 'buy' && <>{inp('unit_price', 80)} {inp('shares', 100)}</>}
+          {action === 'sell' && <>{inp('sell_price', 80)} {inp('shares', 100)}</>}
+          {action === 'dividend' && inp('per_share', 80)}
+          {action === 'passive-uplift' && inp('pct', 60)}
+          {inp('event_id', 130)}
+          <button className="primary" disabled={op.busy} onClick={doAction}>执行 {action}</button>
+        </div>
+        <p className="note">分红需现持仓（每股×股数→现金）；卖出按 FIFO，超卖 422；event_id 唯一幂等。</p>
+      </div>
+    </div>
+  )
+}

--- a/migrations/versions/d1e2f3a4b5c9_stock_event.py
+++ b/migrations/versions/d1e2f3a4b5c9_stock_event.py
@@ -1,0 +1,44 @@
+"""事件·股票表（F-P2-02 · DESIGN §19.6）。
+
+stock_event：Style A 股票事件导入+不关联 + 同币种 UI 手动关联（entity+account）
+→ apply_buy/sell/dividend 实体化 holding_event(batch) + 写 ledger。
+
+Revision ID: d1e2f3a4b5c9
+Revises: d1e2f3a4b5c8
+Create Date: 2026-08-25
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd1e2f3a4b5c9'
+down_revision = 'd1e2f3a4b5c8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stock_event",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("company", sa.String(), nullable=False),
+        sa.Column("ticker", sa.String()),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("event_type", sa.String(), comment="buy/sell/dividend/pseudo"),
+        sa.Column("currency", sa.String()),
+        sa.Column("shares", sa.Numeric()),
+        sa.Column("unit_price", sa.Numeric()),
+        sa.Column("amount", sa.Numeric(), comment="单位：万美金"),
+        sa.Column("pct", sa.Numeric()),
+        sa.Column("linked_entity_id", sa.BigInteger(), sa.ForeignKey("entity.id")),
+        sa.Column("linked_account_id", sa.BigInteger(), sa.ForeignKey("account.id")),
+        sa.Column("linked_at", sa.DateTime()),
+        sa.Column("source_file", sa.Text()),
+        sa.Column("source_line", sa.Integer()),
+        sa.Column("version_id", sa.BigInteger()),
+        sa.UniqueConstraint("company", "date", "event_type", "source_file",
+                            name="uq_stock_company_date_type_source"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("stock_event")

--- a/tests/test_stock_api.py
+++ b/tests/test_stock_api.py
@@ -1,0 +1,178 @@
+"""F-P2-02 事件·股票单测：解析器 + import + API（associate/buy/sell/dividend/util，§19.6 block D）。"""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.app import app
+from app.api.deps import get_db
+from app.db import Base
+from app.ingest.writer import import_stock_events
+from app.model import Account, Entity, HoldingEvent, LedgerEntry, Snapshot, StockEvent
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    S = sessionmaker(bind=engine)
+    s = S()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+TEST_RES = Path(__file__).resolve().parent.parent / "Design_Folder/基准/事件/股票/虎牙.md"
+
+
+def _seed(db):
+    e = Entity(entity_type="person", name="Stijn")
+    db.add(e)
+    db.flush()
+    a = Account(entity_id=e.id, currency="USD")
+    db.add(a)
+    db.flush()
+    db.add(LedgerEntry(account_id=a.id, date=date(2018, 1, 1), inflow=50000,
+                       balance=50000, kind="income", reason="初始化现金"))
+    db.flush()
+    return e.id, a.id
+
+
+def _buy_events(db):
+    return db.execute(select(StockEvent).where(StockEvent.event_type == "buy")).scalars().all()
+
+
+def test_parse_huya():
+    from app.ingest.parsers.event_stock import parse_event_stock
+    recs = parse_event_stock(TEST_RES)
+    buys = [r for r in recs if r["event_type"] == "buy"]
+    assert buys, "should extract at least the A轮 buy"
+    a = buys[0]
+    assert a["company"] == "虎牙" and a["date"].startswith("2017")
+    assert a["shares"] == pytest.approx(22058824.0) and a["unit_price"] == pytest.approx(3.40)
+
+
+def test_import_stock_events_upsert(db):
+    from app.ingest.parsers.event_stock import parse_event_stock
+    recs = parse_event_stock(TEST_RES)
+    r1 = import_stock_events(db, recs); db.commit()
+    assert r1["inserted"] == len(recs)
+    r2 = import_stock_events(db, recs); db.commit()
+    assert r2["skipped"] == len(recs)                 # 幂等
+    row = db.execute(select(StockEvent).where(StockEvent.event_type == "buy")
+                     .order_by(StockEvent.id)).scalars().first()
+    assert row.currency == "USD" and row.shares is not None
+
+
+class TestApi:
+    def test_buy_sets_holding_ledger_and_snapshot(self, db):
+        eid, aid = _seed(db)
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            with TestClient(app) as c:
+                r = c.post("/api/v1/stock-events/buy", json={
+                    "entity_id": eid, "account_id": aid, "company": "AAPL",
+                    "date": "2018-06-01", "unit_price": 10, "shares": 1000,
+                    "event_id": "api-buy-1"})
+                assert r.status_code == 200 and r.json()["skipped"] is False
+                # holding batch + ledger
+                h = db.execute(select(HoldingEvent)).scalars().one()
+                assert h.event_type == "buy" and float(h.shares) == 1000
+                led = db.execute(select(LedgerEntry)).scalars().all()
+                buy = next(x for x in led if x.kind == "expense")
+                assert float(buy.outflow) == 10000 and "股票事件" in buy.note
+                # 快照含市值（entity/family 含、account 不含）
+                assert db.execute(select(Snapshot).where(
+                    Snapshot.scope == f"entity:{eid}:USD")).scalars().first() is not None
+                # 幂等：重复 event_id → skipped
+                r2 = c.post("/api/v1/stock-events/buy", json={
+                    "entity_id": eid, "account_id": aid, "company": "AAPL",
+                    "date": "2018-06-01", "unit_price": 10, "shares": 1000,
+                    "event_id": "api-buy-1"})
+                assert r2.json()["skipped"] is True
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_sell_oversell_422(self, db):
+        eid, aid = _seed(db)
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            with TestClient(app) as c:
+                c.post("/api/v1/stock-events/buy", json={
+                    "entity_id": eid, "account_id": aid, "company": "AAPL",
+                    "date": "2018-06-01", "unit_price": 10, "shares": 1000,
+                    "event_id": "sb-1"})
+                r = c.post("/api/v1/stock-events/sell", json={
+                    "entity_id": eid, "account_id": aid, "company": "AAPL",
+                    "date": "2019-06-01", "sell_price": 15, "shares": 9999,
+                    "event_id": "ss-1"})
+                assert r.status_code == 422
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_associate_write_buy_event(self, db):
+        eid, aid = _seed(db)
+        from app.ingest.parsers.event_stock import parse_event_stock
+        import_stock_events(db, [r for r in parse_event_stock(TEST_RES) if r["event_type"] == "buy"])
+        db.commit()
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            se = _buy_events(db)[0]
+            with TestClient(app) as c:
+                r = c.post("/api/v1/stock-events/associate",
+                           json={"stock_event_id": se.id, "entity_id": eid, "account_id": aid})
+                assert r.status_code == 200 and r.json()["skipped"] is False
+                h = db.execute(select(HoldingEvent).where(
+                    HoldingEvent.event_type == "buy")).scalars().one()
+                assert "西安" in h.company or h.company  # company 来自解析
+                se2 = db.get(StockEvent, se.id)
+                assert se2.linked_entity_id == eid
+                # 已关联 → 再次 skipped
+                r2 = c.post("/api/v1/stock-events/associate",
+                            json={"stock_event_id": se.id, "entity_id": eid, "account_id": aid})
+                assert r2.json()["skipped"] is True
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_positions_endpoint(self, db):
+        eid, aid = _seed(db)
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            with TestClient(app) as c:
+                c.post("/api/v1/stock-events/buy", json={
+                    "entity_id": eid, "account_id": aid, "company": "AAPL",
+                    "date": "2018-06-01", "unit_price": 10, "shares": 1000,
+                    "event_id": "pb-1"})
+                pos = c.get("/api/v1/stock-events/positions").json()["items"]
+                assert len(pos) == 1 and pos[0]["company"] == "AAPL"
+                assert pos[0]["market_value"] == pytest.approx(10000.0)
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_events_endpoint_lists(self, db):
+        _seed(db)
+        from app.ingest.parsers.event_stock import parse_event_stock
+        import_stock_events(db, parse_event_stock(TEST_RES))
+        db.commit()
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            with TestClient(app) as c:
+                out = c.get("/api/v1/stock-events/events").json()
+                assert out["total"] >= 1
+                assert any(x["event_type"] == "buy" for x in out["items"])
+        finally:
+            app.dependency_overrides.pop(get_db, None)

--- a/tests/test_stock_position_fifo.py
+++ b/tests/test_stock_position_fifo.py
@@ -1,0 +1,198 @@
+"""F-P2-02 事件·股票：买入 / FIFO 卖出 / 分红 / 被动抬升引擎单测（§19.6 block B）。"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core.stock_cost import (apply_buy, apply_dividend, apply_passive_uplift,
+                                 apply_sell)
+from app.core.stock_wealth import market_value_at
+from app.db import Base
+from app.model import Account, Entity, HoldingEvent, LedgerEntry
+
+
+@pytest.fixture
+def db():
+    from sqlalchemy import BigInteger, Integer
+    from sqlalchemy.pool import StaticPool
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    S = sessionmaker(bind=engine)
+    s = S()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _seed(db):
+    e = Entity(entity_type="person", name="Stijn")
+    db.add(e)
+    db.flush()
+    a = Account(entity_id=e.id, currency="USD")
+    db.add(a)
+    db.flush()
+    return e.id, a.id
+
+
+def _holding(db, entity_id, company):
+    return db.execute(select(HoldingEvent).where(
+        HoldingEvent.entity_id == entity_id,
+        HoldingEvent.company == company).order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()
+
+
+def _ledger_rows(db, account_id):
+    return db.execute(select(LedgerEntry).where(
+        LedgerEntry.account_id == account_id).order_by(LedgerEntry.id)).scalars().all()
+
+
+# ---------- buy ----------
+def test_buy_writes_batch_and_ledger_outflow(db):
+    eid, aid = _seed(db)
+    r = apply_buy(db, entity_id=eid, company="AAPL", ticker="AAPL", date=date(2018, 5, 1),
+                  unit_price=10.0, shares=1000.0, event_id="b1", account_id=aid)
+    assert r["skipped"] is False and r["cost_basis"] == 10000.0
+    rows = _holding(db, eid, "AAPL")
+    assert len(rows) == 1 and rows[0].event_type == "buy" and rows[0].amount == pytest.approx(1.0)
+    led = _ledger_rows(db, aid)
+    assert len(led) == 1
+    assert led[0].kind == "expense" and led[0].outflow == pytest.approx(10000.0)
+    assert "股票事件·b1" in led[0].note
+
+
+def test_buy_idempotent(db):
+    eid, aid = _seed(db)
+    k = dict(entity_id=eid, company="AAPL", date=date(2018, 5, 1), unit_price=10.0,
+             shares=1000.0, event_id="b1", account_id=aid)
+    apply_buy(db, **k)
+    r = apply_buy(db, **k)
+    assert r["skipped"] is True
+    assert len(_holding(db, eid, "AAPL")) == 1
+    assert len(_ledger_rows(db, aid)) == 1
+
+
+# ---------- sell (FIFO) ----------
+def _seed_two_batches(db, eid, aid):
+    apply_buy(db, entity_id=eid, company="XC", date=date(2000, 1, 1), unit_price=5.0,
+              shares=100.0, event_id="b_old", account_id=aid)
+    apply_buy(db, entity_id=eid, company="XC", date=date(2001, 1, 1), unit_price=10.0,
+              shares=100.0, event_id="b_new", account_id=aid)
+
+
+def test_sell_fifo_multibatch(db):
+    eid, aid = _seed(db)
+    _seed_two_batches(db, eid, aid)
+    r = apply_sell(db, entity_id=eid, company="XC", date=date(2002, 1, 1), shares=150.0,
+                   sell_price=12.0, event_id="s1", account_id=aid)
+    assert r["skipped"] is False
+    assert len(r["accepted"]) == 2                      # 跨两批
+    assert r["cost_basis"] == pytest.approx(5 * 100 + 10 * 50)   # 100@5 + 50@10
+    assert r["proceeds"] == pytest.approx(150 * 12)
+    assert r["realized_pnl"] == pytest.approx(r["proceeds"] - r["cost_basis"])
+    # 原 buy 行递减：old→0(结清)，new→50
+    rows = _holding(db, eid, "XC")
+    buys = [x for x in rows if x.event_type == "buy"]
+    assert abs(float(buys[0].shares) - 0.0) < 1e-9
+    assert abs(float(buys[1].shares) - 50.0) < 1e-9
+    # sell 行存在
+    assert any(x.event_type == "sell" for x in rows)
+
+
+def test_sell_full_closes_batch_and_value_excludes(db):
+    eid, aid = _seed(db)
+    _seed_two_batches(db, eid, aid)
+    apply_sell(db, entity_id=eid, company="XC", date=date(2002, 1, 1), shares=200.0,
+               sell_price=8.0, event_id="s2", account_id=aid)
+    assert market_value_at(db, eid, date(2002, 12, 31)) == pytest.approx(0.0)
+
+
+def test_sell_oversell_422_no_write(db):
+    eid, aid = _seed(db)
+    _seed_two_batches(db, eid, aid)
+    with pytest.raises(ValueError):
+        apply_sell(db, entity_id=eid, company="XC", date=date(2002, 1, 1), shares=9999.0,
+                   sell_price=8.0, event_id="s3", account_id=aid)
+    # 无 sell 行、无新增 ledger（校验在写入前）
+    assert not any(x.event_type == "sell" for x in _holding(db, eid, "XC"))
+    assert len(_ledger_rows(db, aid)) == 2              # 仅两笔 buy 的 uitflow
+
+
+def test_sell_ledger_split_principal_plus_pnl(db):
+    eid, aid = _seed(db)
+    apply_buy(db, entity_id=eid, company="XC", date=date(2000, 1, 1), unit_price=10.0,
+              shares=100.0, event_id="bL", account_id=aid)
+    r = apply_sell(db, entity_id=eid, company="XC", date=date(2001, 1, 1), shares=100.0,
+                   sell_price=14.0, event_id="sL", account_id=aid)
+    led = _ledger_rows(db, aid)
+    kinds = {x.kind for x in led}
+    assert "investment" not in kinds and "pool" not in kinds          # 不与投资池冲突
+    assert "income" in kinds and "investment_income" in kinds
+    total_in = sum(float(x.inflow or 0) for x in led)
+    total_out = sum(float(x.outflow or 0) for x in led)
+    # 净现金流 = 卖出现金 − 买入支出 = realized_pnl（+400），非 proceeds 全数
+    assert total_in - total_out == pytest.approx(r["realized_pnl"])
+
+
+# ---------- dividend ----------
+def test_dividend_ledger_only_no_holding(db):
+    eid, aid = _seed(db)
+    apply_buy(db, entity_id=eid, company="AAPL", date=date(2000, 1, 1), unit_price=10.0,
+              shares=1000.0, event_id="bd", account_id=aid)
+    before = len(_holding(db, eid, "AAPL"))
+    r = apply_dividend(db, entity_id=eid, company="AAPL", date=date(2001, 6, 1),
+                       per_share=0.5, event_id="d1", account_id=aid)
+    assert r["dividend"] == pytest.approx(500.0)
+    assert len(_holding(db, eid, "AAPL")) == before            # 不落 holding 行
+    led = _ledger_rows(db, aid)
+    assert led[-1].kind == "investment_income" and led[-1].inflow == pytest.approx(500.0)
+
+
+def test_dividend_idempotent(db):
+    eid, aid = _seed(db)
+    apply_buy(db, entity_id=eid, company="AAPL", date=date(2000, 1, 1), unit_price=10.0,
+              shares=1000.0, event_id="bd2", account_id=aid)
+    k = dict(entity_id=eid, company="AAPL", date=date(2001, 6, 1), per_share=0.5,
+             event_id="d1", account_id=aid)
+    apply_dividend(db, **k)
+    r = apply_dividend(db, **k)
+    assert r["skipped"] is True
+
+
+# ---------- passive uplift ----------
+def test_passive_uplift_no_ledger(db):
+    eid, aid = _seed(db)
+    apply_buy(db, entity_id=eid, company="AAPL", date=date(2000, 1, 1), unit_price=10.0,
+              shares=1000.0, event_id="bu", account_id=aid)
+    n_led = len(_ledger_rows(db, aid))
+    r = apply_passive_uplift(db, entity_id=eid, company="AAPL", date=date(2012, 12, 30),
+                             to_pct=40.0, event_id="pu1")
+    assert r["skipped"] is False and r["pct"] == 40.0
+    assert len(_ledger_rows(db, aid)) == n_led               # 无 cash 动作
+    pseudo = [x for x in _holding(db, eid, "AAPL") if x.event_type == "pseudo"]
+    assert len(pseudo) == 1 and float(pseudo[0].pct) == 40.0
+    assert float(pseudo[0].shares) == 0.0                    # 不构成 open，避免重复计数
+    # 市值不变（被动抬升持股不变）
+    assert market_value_at(db, eid, date(2012, 12, 30)) == pytest.approx(10000.0)
+
+
+def test_market_value_after_buy_sell(db):
+    eid, aid = _seed(db)
+    apply_buy(db, entity_id=eid, company="AAPL", date=date(2018, 1, 1), unit_price=10.0,
+              shares=1000.0, event_id="bv", account_id=aid)
+    assert market_value_at(db, eid, date(2018, 12, 30)) == pytest.approx(10000.0)
+    apply_sell(db, entity_id=eid, company="AAPL", date=date(2019, 6, 1), shares=400.0,
+               sell_price=15.0, event_id="sv", account_id=aid)
+    assert market_value_at(db, eid, date(2019, 12, 30)) == pytest.approx(600 * 10.0)
+    # 现金 + 市值守恒：初始 0；买→ -10000 现金 +10000 市值；卖→ +6000 现金 +6000 起持仓，盈亏 +2000
+    led = _ledger_rows(db, aid)
+    cash = sum(float(x.inflow or 0) - float(x.outflow or 0) for x in led)
+    assert cash + market_value_at(db, eid, date(2019, 12, 30)) == pytest.approx((15 - 10) * 400)

--- a/tests/test_stock_wealth.py
+++ b/tests/test_stock_wealth.py
@@ -1,0 +1,126 @@
+"""F-P2-02 块 A：持仓市值并入总资产/快照/health（§19.6 block A）。"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core.calendar import snapshot_as_of
+from app.core.health import check_holding_value, summarize
+from app.core.snapshot import rebuild_snapshots
+from app.core.stock_cost import apply_buy, apply_sell
+from app.core.stock_wealth import market_value_at
+from app.db import Base
+from app.model import Account, Entity, HoldingEvent, LedgerEntry, Snapshot
+
+
+@pytest.fixture
+def session():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed(session, *, cash=20000.0, shares=1000.0, unit_price=10.0):
+    """USD 主体：2018 现金 20000 + 买入 10000（批次 shares=1000 @10）→ 净值口径 = cash+市值。"""
+    e = Entity(entity_type="person", name="Stijn")
+    session.add(e)
+    session.flush()
+    a = Account(entity_id=e.id, currency="USD")
+    session.add(a)
+    session.flush()
+    session.add(LedgerEntry(account_id=a.id, date=date(2018, 1, 1), inflow=cash,
+                            balance=cash, kind="income", reason="初次现金"))
+    session.flush()
+    apply_buy(session, entity_id=e.id, company="AAPL", ticker="AAPL", date=date(2018, 6, 1),
+              unit_price=unit_price, shares=shares, event_id="w1", account_id=a.id)
+    session.flush()
+    return e, a
+
+
+def _scope_value(session, scope: str, year: int) -> float | None:
+    for s in session.execute(select(Snapshot).where(
+            Snapshot.scope == scope, Snapshot.as_of_year == year)).scalars():
+        return float(s.value)
+    return None
+
+
+def test_market_value_at_simple():
+    """market_value_at 单测：买入后市值=shares×unit_price。"""
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, __import__("sqlalchemy").BigInteger) and col.primary_key:
+                col.type = __import__("sqlalchemy").Integer()
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    s = sessionmaker(bind=eng)()
+    e = Entity(entity_type="person", name="S"); s.add(e); s.flush()
+    a = Account(entity_id=e.id, currency="USD"); s.add(a); s.flush()
+    apply_buy(s, entity_id=e.id, company="AAPL", date=date(2018, 6, 1), unit_price=10.0,
+              shares=1000.0, event_id="w1", account_id=a.id)
+    assert market_value_at(s, e.id, date(2018, 12, 30)) == pytest.approx(10000.0)
+    s.close(); eng.dispose()
+
+
+def test_rebuild_snapshot_includes_holding_but_account_excludes(session):
+    e, a = _seed(session)
+    rebuild_snapshots(session, years=range(2017, 2019), from_year=2018)
+    # entity / family 含市值：cash(20000-10000=10000) + 市值(10000) = 20000
+    assert _scope_value(session, f"entity:{e.id}:USD", 2018) == pytest.approx(20000.0)
+    assert _scope_value(session, "family:total", 2018) == pytest.approx(20000.0)
+    # account scope 不含市值（只 10000）
+    assert _scope_value(session, f"account:{a.id}:USD", 2018) == pytest.approx(10000.0)
+
+
+def test_snapshot_asof_includes_holding(session):
+    e, a = _seed(session)
+    snaps = snapshot_as_of(session, date(2018, 12, 30))
+    by = {s["scope"]: s["value"] for s in snaps}
+    assert by[f"entity:{e.id}:USD"] == pytest.approx(20000.0)
+    assert by["family:total"] == pytest.approx(20000.0)
+    assert by[f"account:{a.id}:USD"] == pytest.approx(10000.0)
+
+
+def test_health_holding_valuation_warn_and_summary_key(session):
+    e = Entity(entity_type="person", name="Stijn")
+    session.add(e)
+    session.flush()
+    session.add(HoldingEvent(entity_id=e.id, company="AAPL", date=date(2018, 1, 1),
+                             event_type="buy", shares=100.0, unit_price=None,
+                             source_file="t.md"))
+    session.flush()
+    finds = check_holding_value(session)
+    assert any(f.rule == "H-STOCK" and f.level == "warn" for f in finds)
+    assert "H-STOCK" in summarize(session)
+
+
+def test_health_holding_ok_when_priced(session):
+    e = Entity(entity_type="person", name="Stijn")
+    session.add(e)
+    session.flush()
+    session.add(HoldingEvent(entity_id=e.id, company="AAPL", date=date(2018, 1, 1),
+                             event_type="buy", shares=100.0, unit_price=5.0,
+                             source_file="t.md"))
+    session.flush()
+    assert check_holding_value(session) == []
+
+
+def test_rebuild_incremental_from_year_recomputes_holding(session):
+    e, a = _seed(session)
+    rebuild_snapshots(session, years=range(2017, 2019), from_year=2018)
+    # 改动触发 from_year 增量重算：加一笔买入 → 净值净额守恒（现金-5000、市值+5000），entity 不变
+    apply_buy(session, entity_id=e.id, company="MSFT", date=date(2018, 9, 1),
+              unit_price=50.0, shares=100.0, event_id="w2", account_id=a.id)
+    rebuild_snapshots(session, years=range(2017, 2019), from_year=2018)
+    assert _scope_value(session, f"entity:{e.id}:USD", 2018) == pytest.approx(20000.0)
+    assert market_value_at(session, e.id, date(2018, 12, 30)) == pytest.approx(15000.0)


### PR DESCRIPTION
## F-P2-02「事件·股票」完整交付（DESIGN §20 F-P2-02 ⬜→✅）

**块 A — 持仓市值入总资产/快照/health**
- 新 `app/core/stock_wealth.py`（market_value_at / portfolio_breakdown，Σ open batch shares×unit_price，只进 entity/family 域）
- 接入 rebuild_snapshots + calendar.snapshot_as_of；DESIGN §19.6「总资产=现金+专款池+股票市值」第3项首次落地
- 健康规则 **H-STOCK**

**块 B — FIFO 结算引擎**（并入 stock_cost.py）
- apply_buy / apply_sell(FIFO，超卖422) / apply_dividend / apply_passive_uplift；event_id 幂等 + note 打标可撤销

**块 C — 解析 + 导入**
- stock_event 表 + event_stock 解析器（best-effort USD Style A：虎牙/哔哩/快手）+ ingest events-stock

**块 D — API + 前端**
- /stock-events(+/events/positions/associate/buy/sell/dividend/passive-uplift) + 股票事件屏

**关键决策**
- 股票 ledger 用 expense/income（非 investment），避免 pool_in_transit 把投资-type 误当在途池重复计数
- sell/pseudo 行排除出 open-持仓查询，防止卖出历史行被当持仓重复计数

**验证**：23 新单测 + 全量 322 passed；迁移 d1e2f3a4b5c9 单 head；ingest events-stock 成功；前端 vite build 通过