### PR TITLE
feat(p2): F-P2-03 follow-up —— holding_event 结清窗口化(closed_on)，修复分拆/并购前年份市值漏记

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 
 ---
 
+## [Phase 2 · F-P2-02/03 follow-up] — 2026-08-25
+
+**分拆/并购市值漏记修复：`holding_event` 结清窗口化（closed_on 列）**（DESIGN §19.6）
+
+- `holding_event` 加 `closed_on`（结清日，可空）——迁移 `d1e2f3a4b5ca`。
+- `stock_cost.apply_merger` 对旧公司由「破坏性 `shares=0`」改为「标 `closed_on=重构日`」：保留股数/成本历史，
+  使**分拆/并购前年份**市值正确计入旧公司（此前恒为 0，漏记），重构后年份计入新公司且不重复。
+- `stock_wealth.market_value_at` / `portfolio_breakdown` 改 `closed_on` 时间窗求值（`closed_on IS NULL OR closed_on > as_of`）；
+  `_open_batches` / `apply_sell` / API `positions` / 健康 `check_holding_value` 均追加 `closed_on IS NULL`（排除已结清行）。
+- 残余局限注明于 docstring：`apply_sell` 部分卖出仍递减原 buy 行（非全事件流重放），留待后续。
+- `tests/test_stock_cost.py` 结清断言改 `closed_on is not None`；`tests/test_stock_wealth.py` 新增 3 回归
+  （预重构年市值=旧 UTX、重构后新三家且排除 UTX、`_open_batches` 排除结清、rebuild 预/重构年 entity 含市值）。
+- 全量 **325 passed**；dev 库迁移应用、health 无新增异常。
+
+---
+
 ## [Phase 2 · F-P2-02] — 2026-08-25
 
 **事件·股票：holding_event(batch) + FIFO 成本 + 分红/卖出结算 + 被动抬升，持仓市值并入总资产**（DESIGN §19.6）

--- a/app/api/stock_events.py
+++ b/app/api/stock_events.py
@@ -81,7 +81,8 @@ def list_positions(entity_id: Optional[int] = None, db: Session = Depends(get_db
     """当前持仓：按 (entity_id, company) 聚合 open batches，列均价/市值/最新占比标记。"""
     q = select(HoldingEvent).where(HoldingEvent.shares > 0,
                                 HoldingEvent.event_type != "sell",
-                                HoldingEvent.event_type != "pseudo")
+                                HoldingEvent.event_type != "pseudo",
+                                HoldingEvent.closed_on.is_(None))
     if entity_id is not None:
         q = q.where(HoldingEvent.entity_id == entity_id)
     rows = db.execute(q.order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -193,7 +193,7 @@ def check_holding_value(session: Session) -> list[Finding]:
     rows = session.execute(
         select(HoldingEvent.id, HoldingEvent.company, HoldingEvent.date,
                HoldingEvent.entity_id, HoldingEvent.shares, HoldingEvent.unit_price)
-        .where(HoldingEvent.shares > 0)
+        .where(HoldingEvent.shares > 0, HoldingEvent.closed_on.is_(None))
     ).all()
     for hid, company, hdate, eid, shares, up in rows:
         if up is None or float(up) == 0:

--- a/app/core/stock_cost.py
+++ b/app/core/stock_cost.py
@@ -71,7 +71,7 @@ def cash_merger(batches: list[dict], cash_per_share: float) -> float:
 #         "cash_per_share":float, "cash_account_id":int|None}
 
 def _open_batches(db: Session, entity_id: int, company: str) -> list[dict]:
-    """读未结清（shares>0）的旧公司批次，依日期归并为批次。"""
+    """读未结清（shares>0 且 closed_on IS NULL）的公司批次，依日期归并为批次。"""
     rows = db.execute(select(HoldingEvent).where(
         HoldingEvent.entity_id == entity_id,
         HoldingEvent.company == company,
@@ -79,6 +79,8 @@ def _open_batches(db: Session, entity_id: int, company: str) -> list[dict]:
         # sell/pseudo 是历史/占比标记，非 open 持仓（否则分红/抬升/估值会误计）
         HoldingEvent.event_type != "sell",
         HoldingEvent.event_type != "pseudo",
+        # 已结清（分拆/并购/全量卖出标记 closed_on）不再视为 open
+        HoldingEvent.closed_on.is_(None),
     ).order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()
     return [{"shares": float(r.shares), "unit_price": float(r.unit_price or 0.0),
              "batch_id": r.batch_id} for r in rows]
@@ -141,12 +143,14 @@ def apply_merger(db: Session, spec: dict, source: str | None = None) -> dict:
                 shares=nb["shares"], unit_price=nb["unit_price"],
                 amount=nb["shares"] * nb["unit_price"] / 10000.0,  # 万USD 口径
                 source_file=source))
-        # 结清旧行
+        # 结清旧行：标记 closed_on（保留 shares/unit_price 历史供重构前年份 as-of 估值），
+        # 而非销毁 shares=0（否则分拆/并购前年份市值漏记）。估值按 closed_on 时间窗求值。
         for r in db.execute(select(HoldingEvent).where(
                 HoldingEvent.entity_id == entity_id,
                 HoldingEvent.company == old_company,
-                HoldingEvent.shares > 0)).scalars().all():
-            r.shares = 0
+                HoldingEvent.shares > 0,
+                HoldingEvent.closed_on.is_(None))).scalars().all():
+            r.closed_on = event_date
 
         # 现金腿 → ledger
         if cash and spec.get("cash_account_id"):
@@ -222,6 +226,7 @@ def apply_sell(db: Session, *, entity_id: int, company: str, date, shares: float
         HoldingEvent.shares > 0,
         HoldingEvent.event_type != "sell",
         HoldingEvent.event_type != "pseudo",
+        HoldingEvent.closed_on.is_(None),
     ).order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()
     available = sum(float(r.shares) for r in rows)
     if shares > available:

--- a/app/core/stock_wealth.py
+++ b/app/core/stock_wealth.py
@@ -1,18 +1,20 @@
-"""股票持仓市值估值（F-P2-02 · DESIGN §19.6）。
+"""股票持仓市值估值（F-P2-02 · DESIGN §19.6；F-P2-03 follow-up 结清窗口化）。
 
-持仓市值 = Σ 未结清 opens（batch，shares>0）的 shares × unit_price（成本基准）。
+持仓市值 = Σ 在 as_of 时刻**未结清**的批次（open，shares>0 且 closed_on 未到或未过 as_of）
+的 shares × unit_price（成本基准）。
 并入总资产口径：总资产 = 银行现金 + 投资专款池 + 股票持仓市值（§19.6）。
 
 口径纪律（与 ledger/快照对齐）：
 - 返回 **美元元**（与 account:* / entity:* / family:total 快照 value 一致），不做 /10000。
 - 只有写 `holding_event.amount`（万USD 列）时才除 10000 —— 见 stock_cost / apply_buy。
-- `shares > 0` 即自动排除被 split/merge/sell 结清(closed) 的行（写时被置 0）。
+- open 判定 = `shares > 0 AND closed_on IS NULL OR closed_on > as_of`：
+  - 分拆/并购用 `closed_on` 标记结清（`stock_cost.apply_merger`，保留 shares/unit_price 历史），
+    因此 **重构前年份正确计入旧公司市值、重构后计入新公司**，历史不丢失。
+  - `sell`/`pseudo` 行是历史/占比标记，恒排除（不构成 open）。
 
-已知局限（须明示）：`stock_cost.apply_merger` 破坏性把旧公司 shares 置 0（:142-146），
-故分拆/并购**之前**的年份该上游公司市值会归零（新批次 date=重构日，date<=as_of 过滤只
-在 >= 重构年生效）。净影响：>= 最后一次重构的年份完全正确，更早年份市值被漏。F-P2-02
-的 `apply_sell` 采用非破坏式双写（减原 buy 行 + 自留 sell 行），是后续做全事件流 as-of
-重放的最小支撑（完整修复 split 属 follow-up）。
+已知残余局限（须明示）：`apply_sell` 的**部分卖出**仍会递减原 buy 行 shares（非全事件流
+重放），故部分卖出之前的年份 as-of 为近似；完整按事件流重放（买卖/并购逐事件回滚）留待
+后续改造。全量卖出/分拆/并购已走 `closed_on`，历史不丢。
 """
 from __future__ import annotations
 
@@ -24,19 +26,24 @@ from sqlalchemy.orm import Session
 from app.model import HoldingEvent
 
 
+def _open_window(as_of: date):
+    """open 时间窗：closed_on IS NULL 或 晚于 as_of（分拆/并购前年份计入、之后排除）。"""
+    return HoldingEvent.closed_on.is_(None) | (HoldingEvent.closed_on > as_of)
+
+
 def market_value_at(session: Session, entity_id: int, as_of: date) -> float:
     """主体截至 as_of 的持仓成本市值（USD 元，非万）。
 
-    口径：Σ HoldingEvent.shares>0 且 date<=as_of 的 shares×unit_price。
+    口径：Σ open 批次（shares>0、date<=as_of、closed_on 窗口未过、排除 sell/pseudo）× unit_price。
     """
     rows = session.execute(
         select(HoldingEvent.shares, HoldingEvent.unit_price).where(
             HoldingEvent.entity_id == entity_id,
             HoldingEvent.shares > 0,
-            # sell/pseudo 是历史/占比标记，非 open 持仓（shares>0 只排除被减为 0 的）
             HoldingEvent.event_type != "sell",
             HoldingEvent.event_type != "pseudo",
             HoldingEvent.date <= as_of,
+            _open_window(as_of),
         )
     ).all()
     return float(sum(float(r.shares) * float(r.unit_price or 0.0) for r in rows))
@@ -55,6 +62,7 @@ def portfolio_breakdown(session: Session, as_of: date) -> dict[int, float]:
             HoldingEvent.event_type != "sell",
             HoldingEvent.event_type != "pseudo",
             HoldingEvent.date <= as_of,
+            _open_window(as_of),
         )
     ).all()
     out: dict[int, float] = {}

--- a/app/model/core.py
+++ b/app/model/core.py
@@ -159,6 +159,7 @@ class HoldingEvent(Base):
     unit_price: Mapped[Optional[float]] = mapped_column(Numeric, comment="该批次成本价（FIFO）")
     amount: Mapped[Optional[float]] = mapped_column(Numeric, comment="单位：万美金")
     pct: Mapped[Optional[float]] = mapped_column(Numeric)
+    closed_on: Mapped[Optional[date]] = mapped_column(Date, comment="结清日；NULL=未结清(open)")
     source_file: Mapped[Optional[str]] = mapped_column(Text)
     source_line: Mapped[Optional[int]] = mapped_column(Integer)
     version_id: Mapped[Optional[int]] = mapped_column(BigInteger)

--- a/migrations/versions/d1e2f3a4b5ca_holding_event_closed_on.py
+++ b/migrations/versions/d1e2f3a4b5ca_holding_event_closed_on.py
@@ -1,0 +1,26 @@
+"""holding_event 加 closed_on 结清日（F-P2-03 follow-up）。
+
+apply_merger 对旧公司改「标记结清」而非销毁 shares=0，使分拆/并购前年份的持仓市值
+不再漏记；估值按 closed_on 时间窗求值（model/core.py HoldingEvent.closed_on）。
+
+Revision ID: d1e2f3a4b5ca
+Revises: d1e2f3a4b5c9
+Create Date: 2026-08-25
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd1e2f3a4b5ca'
+down_revision = 'd1e2f3a4b5c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("holding_event",
+                  sa.Column("closed_on", sa.Date(), nullable=True,
+                            comment="结清日；NULL=未结清(open)"))
+
+
+def downgrade() -> None:
+    op.drop_column("holding_event", "closed_on")

--- a/tests/test_stock_cost.py
+++ b/tests/test_stock_cost.py
@@ -101,9 +101,9 @@ def test_apply_split_writes_batches_and_closes(db):
     for n in new:
         tot[n.company] += float(n.shares)
     assert tot["CARR"] == 48053700 and tot["OTIS"] == 24026850
-    # 旧 UTX 结清
+    # 旧 UTX 结清（标记 closed_on 而非销毁 shares，保留重构前年份市值历史）
     old = db.execute(select(HoldingEvent).where(HoldingEvent.company == "UTX")).scalars().all()
-    assert all(o.shares == 0 for o in old)
+    assert all(o.closed_on is not None for o in old)
     # 幂等：再 apply → skipped
     r2 = apply_merger(db, spec); db.commit()
     assert r2["skipped"] is True

--- a/tests/test_stock_wealth.py
+++ b/tests/test_stock_wealth.py
@@ -11,7 +11,7 @@ from app.core.calendar import snapshot_as_of
 from app.core.health import check_holding_value, summarize
 from app.core.snapshot import rebuild_snapshots
 from app.core.stock_cost import apply_buy, apply_sell
-from app.core.stock_wealth import market_value_at
+from app.core.stock_wealth import market_value_at, portfolio_breakdown
 from app.db import Base
 from app.model import Account, Entity, HoldingEvent, LedgerEntry, Snapshot
 
@@ -124,3 +124,59 @@ def test_rebuild_incremental_from_year_recomputes_holding(session):
     rebuild_snapshots(session, years=range(2017, 2019), from_year=2018)
     assert _scope_value(session, f"entity:{e.id}:USD", 2018) == pytest.approx(20000.0)
     assert market_value_at(session, e.id, date(2018, 12, 30)) == pytest.approx(15000.0)
+
+
+# ---------- F-P2-03 follow-up：分拆/并购市值漏记修复（closed_on 结清窗口） ----------
+def _seed_utx(session, entity_id=None, shares=48053700.0, unit_price=5.0):
+    from app.core.stock_cost import _next_batch_ids
+    if entity_id is None:
+        e = Entity(entity_type="person", name="Stijn"); session.add(e); session.flush()
+        entity_id = e.id
+    b = next(_next_batch_ids(session, 1))
+    session.add(HoldingEvent(entity_id=entity_id, company="UTX", date=date(2000, 12, 31),
+                             event_type="buy", batch_id=b, shares=shares,
+                             unit_price=unit_price, amount=shares * unit_price / 10000.0))
+    session.flush()
+    return entity_id
+
+
+def _split_utx(session, eid):
+    from app.core.stock_cost import apply_merger
+    return apply_merger(session, {"entity_id": eid, "date": "2020-04-03", "old_company": "UTX",
+                                  "form": "split",
+                                  "legs": [{"company": "CARR", "per_old_share": 1.0},
+                                           {"company": "OTIS", "per_old_share": 0.5},
+                                           {"company": "RTX", "per_old_share": 1.0}]})
+
+
+def test_split_preserves_pre_merger_value(session):
+    utx_val = 48053700.0 * 5.0                      # 4805.37万股 × 5 成本 = 240M USD
+    eid = _seed_utx(session)
+    _split_utx(session, eid); session.flush()
+    # 重构前年份：旧 UTX 仍计入（修复前恒为 0 → 漏记）
+    assert market_value_at(session, eid, date(2010, 12, 30)) == pytest.approx(utx_val)
+    # 重构后年份：新三家计入、UTX 已结清不重复计数；成本随链 → 总额仍 = utx_val
+    assert market_value_at(session, eid, date(2021, 12, 30)) == pytest.approx(utx_val)
+    assert portfolio_breakdown(session, date(2021, 12, 30))[eid] == pytest.approx(utx_val)
+
+
+def test_merge_closed_hidden_from_open_batches(session):
+    from app.core.stock_cost import _open_batches
+    eid = _seed_utx(session)
+    _split_utx(session, eid); session.flush()
+    assert _open_batches(session, eid, "UTX") == []     # 结清后不再视为 open（FIFO/分红/后续并购）
+
+
+def test_rebuild_split_years_include_upstream_value(session):
+    e = Entity(entity_type="person", name="Stijn"); session.add(e); session.flush()
+    a = Account(entity_id=e.id, currency="USD"); session.add(a); session.flush()
+    session.add(LedgerEntry(account_id=a.id, date=date(2010, 1, 1), inflow=10000, balance=10000,
+                            kind="income", reason="cash"))
+    utx_val = 48053700.0 * 5.0
+    _seed_utx(session, entity_id=e.id)
+    _split_utx(session, e.id); session.flush()
+    rebuild_snapshots(session, years=range(2009, 2022), from_year=2010)
+    # 分拆前年（2015）：entity = 银行 10000 + UTX 市值（修复前漏记→只有 10000）
+    assert _scope_value(session, f"entity:{e.id}:USD", 2015) == pytest.approx(10000.0 + utx_val)
+    # 分拆后年（2021）：entity = 银行 10000 + 新三家市值（= 旧 UTX 市值，成本随链）
+    assert _scope_value(session, f"entity:{e.id}:USD", 2021) == pytest.approx(10000.0 + utx_val)


### PR DESCRIPTION
## F-P2-03 follow-up：分拆/并购市值漏记修复

**根因**：`apply_merger`（F-P2-03 原 bug）对旧公司破坏性 `shares=0`，市值模型为 `shares>0 AND date<=as_of` 点状窗口 → **分拆/并购前年份旧公司市值归零**（当年明明持有却显示 0）。

**修法：holding_event 结清窗口化**
- 新增 `closed_on`（结清日，可空，沿用 Account.closed_on 命名）+ 迁移 `d1e2f3a4b5ca`
- `apply_merger` 对旧公司由「shares=0 销毁」改「closed_on=重构日」，保留股数/成本历史
- `stock_wealth.market_value_at` / `portfolio_breakdown` 改 closed_on 时间窗求值（`IS NULL OR > as_of`）
- `_open_batches` / `apply_sell` / API `positions` / 健康 `check_holding_value` 追加 `closed_on IS NULL`

**效果**：分拆前年份计入旧公司（UTX）、重构后计入新三家且不重复；`rebuild_snapshots` 逐年正确。

**验证**：`test_stock_cost` 结清断言更新 + `test_stock_wealth` 3 新回归（预重构年=旧UTX市值、重构后三家且排除UTX、open_batches 排除结清、rebuild 预/重构年 entity 含市值）；全量 **325 passed**；dev 迁移应用、health 无新增异常。