### PR TITLE
fix(p0): 数据安全红线 —— force 重导/归属名归一/标签词边界（#135 #136 #137）

### DIFF
--- a/app/core/demand.py
+++ b/app/core/demand.py
@@ -22,10 +22,10 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core.invest import ValidationError, _entity_kind
+from app.core.invest import ValidationError, _entity_kind, delete_derived_by_tag
 from app.model import Account, FinanceEntry, LedgerEntry, TimelineEvent
 from app.model.types import SourceKind
 
@@ -111,10 +111,8 @@ def accrue_demand_interest(session: Session, year: int) -> dict:
         raise ValidationError(f"活期结息须在结算日 {settle} 之后操作（当前 {date.today()}）")
 
     tag = _tag(year)
-    session.execute(delete(LedgerEntry).where(LedgerEntry.note.like(f"%{tag}%")))
-    session.execute(delete(FinanceEntry).where(FinanceEntry.label.like(f"%{tag}%")))
-    session.execute(delete(TimelineEvent).where(
-        TimelineEvent.note.like(f"%{tag}%"), TimelineEvent.overlay.is_(True)))
+    # issue #137：词边界抹除复用 invest.delete_derived_by_tag（demand#{year} 不得命中他年）
+    delete_derived_by_tag(session, tag=tag)
 
     quotes = quote_demand_interest(session, year)
     total_by_cur: dict[str, Decimal] = {}

--- a/app/core/entity_merge.py
+++ b/app/core/entity_merge.py
@@ -1,0 +1,133 @@
+"""职称别名 person 实体合并（issue #136 存量修复）。
+
+背景：writer 修复前，收益/薪资文件曾把 holder 职称（养祖父/养父…）原样 upsert 成
+别名 person 实体，与人物档案的规范实体（Henri Peeters/Joren Peeters…）形成
+「同一人账务锚分裂」——收益挂别名、账户挂规范名，且 conflict H2 按规范 id
+查不到既有行、失配告警不可达。
+
+writer 侧已接 TITLE_ENTITY 归一（issue #136 前半），本模块负责存量收口：
+把别名实体的全部引用改挂规范实体后删除别名行。
+
+- 引用表：account / initial_asset / income_stream / holding_event /
+  finance_entry / investment_alloc / relationship(from,to)
+- account UNIQUE(entity_id, currency, bank) 冲突时：ledger 并入规范同名账户后删别名账户
+- 合并完成后由调用方重算 + 重建快照（CLI 已自动执行）
+- 幂等：二次运行无别名可并 → 全零统计；identity 映射名（养祖母→养祖母）不视为别名
+
+安全边界：仅接受 TITLE_ENTITY **精确**键命中，或「职称（资产归属注解）」变体
+（源文件惠民租房.md 的 持有人物 列形态，注解描述资产归属、租金仍归持有人本人）；
+不做通用前缀模糊匹配，防止误吞普通人物名。
+"""
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.ingest.holders import TITLE_ENTITY
+from app.model import (Account, Entity, FinanceEntry, HoldingEvent, IncomeStream,
+                       InitialAsset, InvestmentAlloc, LedgerEntry, Relationship)
+
+
+def _resolve_alias_name(name: str) -> str | None:
+    """别名判定：精确键命中，或「职称（资产归属注解）」变体（如 养祖母（资产归…））。
+
+    只接受这两种形态，不做通用前缀模糊匹配，防止误吞普通人物名。
+    返回规范名；非别名返回 None。
+    """
+    n = (name or "").strip()
+    canon = TITLE_ENTITY.get(n)
+    if canon and canon != n:
+        return canon
+    base = n.split("（", 1)[0].strip()
+    if base != n:
+        canon = TITLE_ENTITY.get(base)
+        if canon and canon != n:
+            return canon
+    return None
+
+
+def _alias_persons(session) -> list[Entity]:
+    """别名 person 列表（精确键或括号注解变体）。"""
+    out = []
+    for e in session.execute(
+            select(Entity).where(Entity.entity_type == "person")).scalars().all():
+        if _resolve_alias_name(e.name):
+            out.append(e)
+    return out
+
+
+def merge_alias_persons(session, log=None, dry_run: bool = False) -> dict:
+    """把别名 person 的引用并入规范实体并删除别名；返回统计。
+
+    dry_run=True 只报告将合并的名单，不做任何写操作。
+    """
+    log = log or (lambda m: None)
+    aliases = _alias_persons(session)
+    if dry_run:
+        return {"dry_run": True,
+                "would_merge": [{"alias": a.name,
+                                 "canonical": _resolve_alias_name(a.name)}
+                                for a in aliases]}
+
+    stats = {"merged": 0, "accounts_moved": 0, "ledger_moves": 0, "initial_assets": 0,
+             "income_streams": 0, "holding_events": 0, "finance_entries": 0,
+             "allocs": 0, "relationships": 0}
+    for alias in aliases:
+        canon_name = _resolve_alias_name(alias.name)
+        canon = session.execute(
+            select(Entity).where(Entity.entity_type == "person", Entity.name == canon_name)
+        ).scalar_one_or_none()
+        if canon is None:
+            canon = Entity(entity_type="person", name=canon_name)
+            session.add(canon)
+            session.flush()
+        if canon.id == alias.id:            # 理论不可达（canon != alias.name）
+            continue
+
+        # —— 账户：唯一键冲突则并入规范同名账户 ——
+        for acc in session.execute(
+                select(Account).where(Account.entity_id == alias.id)).scalars().all():
+            twin = session.execute(
+                select(Account).where(Account.entity_id == canon.id,
+                                      Account.currency == acc.currency,
+                                      Account.bank == acc.bank).limit(1)
+            ).scalar_one_or_none()
+            if twin is None or twin.id == acc.id:
+                acc.entity_id = canon.id
+                stats["accounts_moved"] += 1
+            else:
+                n = session.execute(
+                    select(LedgerEntry).where(LedgerEntry.account_id == acc.id)
+                ).scalars().all()
+                for le in n:
+                    le.account_id = twin.id
+                stats["ledger_moves"] += len(n)
+                session.delete(acc)
+
+        # —— 其余 FK 批量改挂 ——
+        for model, col, key in (
+                (InitialAsset, InitialAsset.entity_id, "initial_assets"),
+                (IncomeStream, IncomeStream.entity_id, "income_streams"),
+                (HoldingEvent, HoldingEvent.entity_id, "holding_events"),
+                (FinanceEntry, FinanceEntry.entity_id, "finance_entries"),
+                (InvestmentAlloc, InvestmentAlloc.entity_id, "allocs")):
+            n = session.query(model).filter(col == alias.id).update(
+                {col: canon.id}, synchronize_session=False)
+            stats[key] += n
+        n = session.query(Relationship).filter(
+            Relationship.from_entity_id == alias.id).update(
+            {Relationship.from_entity_id: canon.id}, synchronize_session=False)
+        n2 = session.query(Relationship).filter(
+            Relationship.to_entity_id == alias.id).update(
+            {Relationship.to_entity_id: canon.id}, synchronize_session=False)
+        stats["relationships"] += n + n2
+        # 改挂后可能产生自环（别名↔规范互指）→ 删除
+        for rel in session.execute(
+                select(Relationship).where(Relationship.from_entity_id ==
+                                           Relationship.to_entity_id)).scalars().all():
+            session.delete(rel)
+
+        session.delete(alias)
+        stats["merged"] += 1
+        log(f"   ♻ 别名实体「{alias.name}」→「{canon_name}」并入完成")
+    session.flush()
+    return stats

--- a/app/core/invest.py
+++ b/app/core/invest.py
@@ -20,6 +20,7 @@ issue #82：赎回按笔防重——redeemed_at 非空即 409（不再按年扫�
 """
 from __future__ import annotations
 
+import re
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
@@ -146,19 +147,42 @@ def _rate(session: Session, region: str, risk_lvl: str, year: int) -> Optional[D
     return Decimal(row[0]) if row and row[0] is not None else None
 
 
+def delete_derived_by_tag(session: Session, *, tag: str) -> None:
+    """按定位标签整笔抹除 UI 派生写入（ledger.note / finance.label / timeline.note）。
+
+    issue #137 词边界加固：LIKE 只做粗筛，再以正则 `tag(?!\\d)` 复核——
+    `inv#1` 不得命中 `inv#10~19`（解锁低 id 投资误删高 id 投资的派生行）。
+    不直接用 SQL REGEXP：SQLite 测试库无 regexp 函数，Python 侧过滤保证跨库一致。
+    demand.py 的 `demand#{year}` 幂等抹除复用本函数。
+    """
+    rx = re.compile(re.escape(tag) + r"(?!\d)")
+
+    def _hit(text: Optional[str]) -> bool:
+        return bool(text and rx.search(text))
+
+    for row in session.execute(
+            select(LedgerEntry).where(LedgerEntry.note.like(f"%{tag}%"))).scalars().all():
+        if _hit(row.note):
+            session.delete(row)
+    for row in session.execute(
+            select(FinanceEntry).where(FinanceEntry.label.like(f"%{tag}%"))).scalars().all():
+        if _hit(row.label):
+            session.delete(row)
+    for row in session.execute(
+            select(TimelineEvent).where(TimelineEvent.note.like(f"%{tag}%"),
+                                        TimelineEvent.overlay.is_(True))).scalars().all():
+        if _hit(row.note):
+            session.delete(row)
+    session.flush()
+
+
 def _delete_investment_writes(session: Session, inv: Investment) -> None:
     """整笔抹除该投资落下的全部派生写入（issue #81）：ledger 划出/赎回、finance_entry、
-    overlay 时间线条目——按 note/label 标签 `inv#{id}` 精确定位，避免误删他人数据。
+    overlay 时间线条目——按 note/label 标签 `inv#{id}` 定位（词边界精确，issue #137）。
 
     调用方（解锁/覆盖）须随后 recompute + rebuild_snapshots，恢复账户 to 投资前。
     """
-    tag = _inv_tag(inv)
-    session.execute(delete(LedgerEntry).where(LedgerEntry.note.like(f"%{tag}%")))
-    session.execute(delete(FinanceEntry).where(FinanceEntry.label.like(f"%{tag}%")))
-    session.execute(delete(TimelineEvent).where(
-        TimelineEvent.note.like(f"%{tag}%"),
-        TimelineEvent.overlay.is_(True),
-    ))
+    delete_derived_by_tag(session, tag=_inv_tag(inv))
 
 
 def unlock_investment(session: Session, investment: Investment) -> Investment:

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -208,18 +208,16 @@ def import_all(session, source_dir, log=None, force: bool = False, force_files=N
             bypass = force or bool(force_files and r.file in force_files)
             if not bypass and _skip_by_state(session, r, source_dir, log, force_files):
                 continue
-            if bypass:
-                # issue #114 --force / F-P2-06 force_files（采纳新版本）：先按 source_file
-                # 清除旧派生行（income_stream + finance 镜像；salary 同样只涉这两表）再重导
-                purged = _purge_income_derived(session, r.file)
-                log(f"   ♻ {r.file}: 清除旧派生行 {purged} 条后重导")
+            if force and r.category == "salary":
+                # issue #114：--force 仅支持四类收益文件（只落 income_stream+finance 镜像，
+                # 可按 source_file 安全清除）；salary 涉及账务镜像，维持整文件跳过。
+                # force_files（F-P2-06 版本采纳）不受此限——采纳新版本必须重导。
+                log(f"   ⏭ {r.file}: --force 不支持薪资文件（涉及 ledger 行），跳过")
                 continue
-            if force:
-                # issue #114：force 仅支持四类收益文件（只落 income_stream+finance 镜像，
-                # 可按 source_file 安全清除）；salary 涉及 ledger 行，维持跳过。
-                if r.category == "salary":
-                    log(f"   ⏭ {r.file}: --force 不支持薪资文件（涉及 ledger 行），跳过")
-                    continue
+            if bypass:
+                # issue #135 回归修复：清场后必须继续走下方冲突检测+重导。
+                # 此前 purge 后直接 continue，--force(#114) 重浇灌与 F-P2-06「采纳新版本」
+                # 均退化为「只删不补」的数据清零事故。
                 purged = _purge_income_derived(session, r.file)
                 log(f"   ♻ {r.file}: 清除旧派生行 {purged} 条后重导")
             crep = conflict.check_income_stream_conflict(
@@ -620,6 +618,32 @@ def finance_backfill(env: str = typer.Option(None, "--env")):
         s.commit()
         typer.echo(f"[{_resolved_env(env)}] 财务收支回填：收入 {r['income']}、支出 {r['expense']}"
                    f"（跳过 收入{r['skipped_income']}/支出{r['skipped_expense']}）")
+
+
+@app.command("merge-alias-persons")
+def merge_alias_persons_cmd(env: str = typer.Option(None, "--env"),
+                            dry_run: bool = typer.Option(False, "--dry-run",
+                                                         help="只报告将合并的名单，不写库")):
+    """issue #136 存量修复：职称别名 person（养祖父/养父…）引用并入规范实体后删别名。
+
+    writer 已接 TITLE_ENTITY 归一；本命令收口历史数据（收益挂别名、账户挂规范名的分裂）。
+    合并 >0 时自动重算 + 重建快照。
+    """
+    from app.core.entity_merge import merge_alias_persons
+    with _session_for(env) as s:
+        r = merge_alias_persons(s, log=typer.echo, dry_run=dry_run)
+        if dry_run:
+            typer.echo(f"[{_resolved_env(env)}] {r}")
+            return
+        merged = r.get("merged", 0)
+        if merged:
+            from app.core.recompute import recompute_all
+            from app.core.snapshot import rebuild_snapshots
+            recompute_all(s, 1947)
+            rebuild_snapshots(s, range(1947, 2026), from_year=1947)
+        s.commit()
+    typer.echo(f"[{_resolved_env(env)}] 别名实体合并完成：{r}"
+               + ("；已重算+重建快照" if merged else ""))
 
 
 @app.command()

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -12,9 +12,20 @@ from decimal import Decimal
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.ingest.holders import holder_entity_name
 from app.ingest.normalize import resolve_date
 from app.model import (Account, Entity, ExchangeRate, FinanceEntry, IncomeStream,
                        InitialAsset, LedgerEntry, Relationship, StockEvent)
+
+
+def _canonical_person(session: Session, holder: str) -> Entity:
+    """职称/登记名 → 规范 person entity（issue #136）。
+
+    与 conflict._resolve_entity_id 同源消费 holders.TITLE_ENTITY 归一，
+    杜绝「收益挂账锚（职称别名实体）≠ 银行账户锚（规范实体）」的账务分裂；
+    未知名字（不在映射表）原样落档，交由 conflict H2/H5 与 ingest_report 兜底。
+    """
+    return upsert_entity(session, "person", holder_entity_name(holder) or holder)
 
 
 def upsert_entity(session: Session, entity_type: str, name: str,
@@ -129,7 +140,7 @@ def import_initial_assets(session: Session, records: list[dict], cash_year: int 
     """
     stats = {"asset": 0, "cash": 0, "cash_skipped": 0, "asset_skipped": 0}
     for rec in records:
-        ent = upsert_entity(session, "person", rec["entity_name"])
+        ent = _canonical_person(session, rec["entity_name"])
         if rec["asset_type"] == "cash":
             # 现金 → 账户 + 首笔存款
             cur = rec["currency"]
@@ -202,7 +213,7 @@ def import_income_security(session: Session, records: list[dict],
         holder = rec.get("holder")
         if not holder:
             continue
-        ent = upsert_entity(session, "person", holder)
+        ent = _canonical_person(session, holder)
         rate = rec.get("rate_pct") or 0.0
         amount = (rec.get("face_value") or 0.0) * rate / 100.0
         if not amount:
@@ -232,7 +243,7 @@ def import_income_property(session: Session, records: list[dict],
     from app.core.factors import property_factor
     stats = {"stream": 0}
     for rec in records:
-        ent = upsert_entity(session, "person", rec["holder"])
+        ent = _canonical_person(session, rec["holder"])
         base = rec.get("base1974") or 0.0
         for y in range(years[0], years[1] + 1):
             if y < 1974:
@@ -255,7 +266,7 @@ def import_income_shop(session: Session, records: list[dict]) -> dict:
     """开店 → 逐年 income_stream（时段内取 合并税后落袋 均值，挂 Henri Peeters）。"""
     stats = {"stream": 0}
     for rec in records:
-        ent = upsert_entity(session, "person", rec["holder"])
+        ent = _canonical_person(session, rec["holder"])
         for y in range(rec["y0"], rec["y1"] + 1):
             label = "祖父开店 · 合并税后落袋"
             session.add(IncomeStream(
@@ -354,21 +365,25 @@ def import_timeline(session: Session, records: list[dict]) -> dict:
 
 
 def import_salary(session: Session, records: list[dict]) -> dict:
-    """薪资 → 逐年 income_stream(salary)，各归各（养父/养母），取文件税后值。"""
+    """薪资 → 逐年 income_stream(salary)，各归各（养父→Joren/养母→Johanna），取文件税后值。
+
+    issue #136：holder 经 TITLE_ENTITY 归一挂规范实体；group_key/label 同用规范名，
+    保证与账户锚同源。
+    """
     from app.model.types import StreamType
     stats = {"stream": 0}
     for rec in records:
-        ent = upsert_entity(session, "person", rec["holder"])
+        ent = _canonical_person(session, rec["holder"])
         if rec.get("after_tax") is None:
             continue
         session.add(IncomeStream(
-            entity_id=ent.id, stream_type=StreamType.SALARY.value, group_key=f"{rec['holder']}薪资",
+            entity_id=ent.id, stream_type=StreamType.SALARY.value, group_key=f"{ent.name}薪资",
             currency=rec.get("currency"), year=rec["year"], amount=rec["after_tax"],
-            label=f"{rec['holder']}薪资税后", source_file=rec.get("source_file"),
+            label=f"{ent.name}薪资税后", source_file=rec.get("source_file"),
         ))
         _mirror_to_finance(session, entity=ent, cur=rec.get("currency"),
                            year=rec["year"], amount=rec["after_tax"],
-                           label=f"{rec['holder']}薪资税后", source_file=rec.get("source_file"))
+                           label=f"{ent.name}薪资税后", source_file=rec.get("source_file"))
         stats["stream"] += 1
     return stats
 
@@ -381,7 +396,7 @@ def import_household_expense(session: Session, records: list[dict]) -> dict:
     """
     stats = {"n": 0, "skipped": 0}
     for rec in records:
-        ent = upsert_entity(session, "person", rec["holder"])
+        ent = _canonical_person(session, rec["holder"])
         cur = rec.get("currency") or "BEF"
         acc = get_or_create_account(session, ent.id, cur)
         d = resolve_date(rec["year"])
@@ -447,8 +462,8 @@ def import_bank(session: Session, segments: list[dict], source_file: str | None 
         if not cur:
             stats["skipped"] += 1
             continue
-        # entity + account（唯一键：entity × currency × bank）
-        ent = upsert_entity(session, "person", holder)
+        # entity + account（唯一键：entity × currency × bank）；issue #136：holder 归一规范名
+        ent = _canonical_person(session, holder)
         acc = session.execute(
             select(Account).where(
                 Account.entity_id == ent.id, Account.currency == cur, Account.bank == bank)
@@ -573,11 +588,13 @@ def import_income_rent(session: Session, records: list[dict],
     """惠民租房 → 逐年租金 income_stream（单套年租金×套数×分段复利系数）。
 
     issue #69：分段复利系数外置 app/core/factors.py（数值与源文件说明段一致）。
+    窗口 (1974, 2007) = 惠民租房.md §一.2 明文测算周期「1974 起租至 2007 年末，
+    合计 34 年」（issue #144：口径来源注记，非遗漏）。
     """
     from app.core.factors import rent_factor
     stats = {"stream": 0}
     for rec in records:
-        ent = upsert_entity(session, "person", rec["holder"])
+        ent = _canonical_person(session, rec["holder"])
         base = (rec.get("unit_rent") or 0.0) * (rec.get("units") or 0.0)
         for y in range(years[0], years[1] + 1):
             if y < (rec.get("start") or 1974):

--- a/tests/test_issue135_force_reimport.py
+++ b/tests/test_issue135_force_reimport.py
@@ -1,0 +1,102 @@
+"""issue #135 回归：--force / force_files 清场后必须重导。
+
+合并事故（aaa50bf）：bypass 分支 purge 后 continue 吞掉了冲突检测+导入，
+--force(#114 重浇灌) 与 F-P2-06「采纳新版本」均退化为「只删不补」。
+本文件断言：
+1. --force 对四类收益文件：purge 后行数恢复（不归零）；
+2. --force 对 salary：整文件跳过、不清场（#114 原约束保留）；
+3. force_files（版本采纳）：同样必须重导恢复。
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine, func, select
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.ingest.main import import_all
+from app.ingest.parse import IngestReport, ParseResult
+from app.model import FinanceEntry, IncomeStream
+
+SEC_FILE = "基准/收益表/祖产股票债券收益.md"
+SAL_FILE = "基准/薪资/养父薪资.md"
+
+
+@pytest.fixture
+def session():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _sec_report() -> IngestReport:
+    recs = [{"holder": "养祖父", "name": "测试券", "face_value": 1000.0,
+             "currency": "BEF", "rate_pct": 4.0, "source_file": SEC_FILE}]
+    return IngestReport(results=[
+        ParseResult(file=SEC_FILE, category="income_security", records=recs)])
+
+
+def _sal_report() -> IngestReport:
+    recs = [{"holder": "养父", "year": 1990, "after_tax": 100.0,
+             "currency": "BEF", "source_file": SAL_FILE}]
+    return IngestReport(results=[
+        ParseResult(file=SAL_FILE, category="salary", records=recs)])
+
+
+def _count(session, model) -> int:
+    return session.execute(select(func.count()).select_from(model)).scalar()
+
+
+def _mk_src(tmp_path, rel: str):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("stub\n", encoding="utf-8")
+
+
+def test_force_reirrigates_after_purge(session, monkeypatch, tmp_path):
+    _mk_src(tmp_path, SEC_FILE)
+    monkeypatch.setattr("app.ingest.main.run_ingest", lambda d: _sec_report())
+    import_all(session, tmp_path, log=lambda m: None)
+    n1 = _count(session, IncomeStream)
+    assert n1 > 0
+    assert _count(session, FinanceEntry) == n1
+    session.commit()
+
+    # 回归点：--force 清场后必须重导回同等行数（修复前 purge+continue → 0）
+    import_all(session, tmp_path, log=lambda m: None, force=True)
+    n2 = _count(session, IncomeStream)
+    assert n2 == n1 > 0
+    assert _count(session, FinanceEntry) == n2
+
+
+def test_force_files_adopt_reimports(session, monkeypatch, tmp_path):
+    """F-P2-06「采纳新版本」走 force_files 路径，同样不得只删不补。"""
+    _mk_src(tmp_path, SEC_FILE)
+    monkeypatch.setattr("app.ingest.main.run_ingest", lambda d: _sec_report())
+    import_all(session, tmp_path, log=lambda m: None)
+    n1 = _count(session, IncomeStream)
+    session.commit()
+
+    import_all(session, tmp_path, log=lambda m: None, force_files={SEC_FILE})
+    assert _count(session, IncomeStream) == n1 > 0
+
+
+def test_force_skips_salary_without_purge(session, monkeypatch, tmp_path):
+    """#114 原约束：--force 不支持薪资文件——不清场也不重导。"""
+    _mk_src(tmp_path, SAL_FILE)
+    monkeypatch.setattr("app.ingest.main.run_ingest", lambda d: _sal_report())
+    import_all(session, tmp_path, log=lambda m: None)
+    assert _count(session, IncomeStream) == 1
+    session.commit()
+
+    logs: list[str] = []
+    import_all(session, tmp_path, log=logs.append, force=True)
+    assert _count(session, IncomeStream) == 1          # 未被 purge（修复前归零）
+    assert any("--force 不支持薪资文件" in m for m in logs)

--- a/tests/test_issue136_alias_merge.py
+++ b/tests/test_issue136_alias_merge.py
@@ -1,0 +1,159 @@
+"""issue #136 回归：收益归属名经 TITLE_ENTITY 归一 + 存量别名实体合并。
+
+writer 侧：holder 职称（养祖父/养父…）必须挂规范实体（Henri Peeters/Joren Peeters），
+不再新建职称别名 person；merge_alias_persons 把历史别名引用并入规范实体后删除别名，
+account UNIQUE 冲突时并入同名账户，且幂等。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core.entity_merge import merge_alias_persons
+from app.db import Base
+from app.ingest import writer
+from app.model import (Account, Entity, FinanceEntry, IncomeStream, InitialAsset,
+                       LedgerEntry, Relationship)
+
+
+@pytest.fixture
+def session():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _names(session) -> set[str]:
+    return {e.name for e in session.execute(select(Entity)).scalars().all()}
+
+
+def test_writer_canonicalizes_security_holder(session):
+    recs = [{"holder": "养祖父", "name": "测试券", "face_value": 1000.0,
+             "currency": "BEF", "rate_pct": 4.0, "source_file": "f.md"}]
+    stats = writer.import_income_security(session, recs, years=(1980, 1980))
+    assert stats["stream"] == 1
+    assert "养祖父" not in _names(session)
+    henri = session.execute(
+        select(Entity).where(Entity.name == "Henri Peeters")).scalar_one()
+    row = session.execute(select(IncomeStream)).scalar_one()
+    assert row.entity_id == henri.id
+
+
+def test_writer_canonicalizes_salary_holder(session):
+    recs = [{"holder": "养父", "year": 1990, "after_tax": 120.0,
+             "currency": "BEF", "source_file": "s.md"}]
+    writer.import_salary(session, recs)
+    assert "养父" not in _names(session)
+    joren = session.execute(
+        select(Entity).where(Entity.name == "Joren Peeters")).scalar_one()
+    row = session.execute(select(IncomeStream)).scalar_one()
+    assert row.entity_id == joren.id
+    assert row.group_key == "Joren Peeters薪资"
+    fin = session.execute(select(FinanceEntry)).scalar_one()
+    assert fin.label == "Joren Peeters薪资税后"
+
+
+def test_writer_canonicalizes_bank_account_anchor(session):
+    segs = [{"holder": "养父", "currency": "BEF", "bank": None, "rows": []}]
+    st = writer.import_bank(session, segs, source_file="b.md")
+    assert st["account"] == 1
+    assert "养父" not in _names(session)
+    joren = session.execute(
+        select(Entity).where(Entity.name == "Joren Peeters")).scalar_one()
+    acc = session.execute(select(Account)).scalar_one()
+    assert acc.entity_id == joren.id
+
+
+def test_identity_mapped_person_not_touched(session):
+    session.add(Entity(entity_type="person", name="养祖母"))
+    session.flush()
+    r = merge_alias_persons(session, log=lambda m: None)
+    assert r["merged"] == 0
+    assert "养祖母" in _names(session)
+
+
+def test_merge_parenthetical_variant(session):
+    """「职称（资产归…）」变体（惠民租房.md 持有人物列）：并入同名规范实体。"""
+    session.add(Entity(entity_type="person", name="养祖母"))
+    session.flush()
+    canon = session.execute(
+        select(Entity).where(Entity.name == "养祖母")).scalar_one()
+    variant = Entity(entity_type="person", name="养祖母（资产归Henri Peeters）")
+    session.add(variant)
+    session.flush()
+    session.add(IncomeStream(entity_id=variant.id, stream_type="rent",
+                             group_key="瑞典惠民租", currency="SEK", year=1980,
+                             amount=1, label="l", source_file="rent.md"))
+    session.flush()
+
+    r = merge_alias_persons(session, log=lambda m: None)
+    assert r["merged"] == 1
+    assert session.get(Entity, variant.id) is None
+    row = session.execute(select(IncomeStream)).scalar_one()
+    assert row.entity_id == canon.id
+
+
+def test_merge_alias_persons_repoints_deletes_idempotent(session):
+    henri = Entity(entity_type="person", name="Henri Peeters")
+    session.add(henri)
+    session.flush()
+    alias = Entity(entity_type="person", name="养祖父")
+    session.add(alias)
+    session.flush()
+    acc_alias = Account(entity_id=alias.id, currency="BEF", bank=None)
+    acc_henri = Account(entity_id=henri.id, currency="BEF", bank=None)
+    session.add_all([acc_alias, acc_henri])
+    session.flush()
+    session.add(LedgerEntry(account_id=acc_alias.id, date=date(1990, 1, 1),
+                            reason="x", inflow=10, kind="income"))
+    session.add(IncomeStream(entity_id=alias.id, stream_type="security", group_key="g",
+                             currency="BEF", year=1980, amount=1, label="l",
+                             source_file="f.md"))
+    session.add(FinanceEntry(entity_id=alias.id, entity_kind="person", year=1980,
+                             kind="income", amount=1, currency="BEF", label="l"))
+    session.add(InitialAsset(entity_id=alias.id, asset_type="bond", currency="BEF",
+                             name="债券包", face_value=100))
+    session.add(Relationship(from_entity_id=alias.id, to_entity_id=henri.id,
+                             rel_type="member"))
+    session.flush()
+
+    r = merge_alias_persons(session, log=lambda m: None)
+    assert r["merged"] == 1
+    # 别名删除、引用全部改挂规范实体
+    assert session.get(Entity, alias.id) is None
+    assert "养祖父" not in _names(session)
+    inc = session.execute(select(IncomeStream)).scalar_one()
+    fin = session.execute(select(FinanceEntry)).scalar_one()
+    ia = session.execute(select(InitialAsset)).scalar_one()
+    assert (inc.entity_id, fin.entity_id, ia.entity_id) == (henri.id,) * 3
+    # account UNIQUE 冲突路径：ledger 并入 Henri 同名账户、别名账户删除
+    ledgers = session.execute(select(LedgerEntry)).scalars().all()
+    assert len(ledgers) == 1 and ledgers[0].account_id == acc_henri.id
+    assert session.execute(select(Account)).scalars().all()[0].entity_id == henri.id \
+        or len(session.execute(select(Account)).scalars().all()) == 1
+    # 改挂后的自环关系被清理
+    assert session.execute(select(Relationship)).scalars().all() == []
+
+    # 幂等：二次运行无可并别名
+    r2 = merge_alias_persons(session, log=lambda m: None)
+    assert r2["merged"] == 0
+
+
+def test_merge_dry_run_reports_only(session):
+    session.add(Entity(entity_type="person", name="Henri Peeters"))
+    session.add(Entity(entity_type="person", name="养祖父"))
+    session.flush()
+    r = merge_alias_persons(session, dry_run=True)
+    assert r["dry_run"] is True
+    assert r["would_merge"] == [{"alias": "养祖父", "canonical": "Henri Peeters"}]
+    assert "养祖父" in _names(session)

--- a/tests/test_issue137_tag_boundary.py
+++ b/tests/test_issue137_tag_boundary.py
@@ -1,0 +1,100 @@
+"""issue #137 回归：派生行标签抹除必须词边界精确。
+
+`inv#1` 的 LIKE %inv#1% 会命中 `inv#10~19`——解锁低 id 投资误删高 id 投资的
+ledger/finance/timeline 行。delete_derived_by_tag 以正则 `tag(?!\\d)` 复核边界；
+demand#{year} 幂等抹除同函数复用。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core.invest import delete_derived_by_tag, unlock_investment
+from app.db import Base
+from app.model import (Account, Entity, FinanceEntry, Investment, LedgerEntry,
+                       TimelineEvent)
+
+
+@pytest.fixture
+def session():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed_investment_pair(session):
+    e = Entity(entity_type="person", name="Henri Peeters")
+    session.add(e)
+    session.flush()
+    acc = Account(entity_id=e.id, currency="BEF", bank=None)
+    session.add(acc)
+    inv1 = Investment(id=1, year=1990, region="欧洲", risk_lvl="R3",
+                      start_date=date(1990, 6, 1), locked=True)
+    inv10 = Investment(id=10, year=1990, region="美国", risk_lvl="R3",
+                       start_date=date(1990, 6, 1), locked=True)
+    session.add_all([inv1, inv10])
+    session.flush()
+    # 各自的派生行（note/label 尾随 tag；timeline note 包裹在括号里）
+    for inv, outflow in ((inv1, 100), (inv10, 200)):
+        tag = f"inv#{inv.id}"
+        session.add(LedgerEntry(account_id=acc.id, date=date(1990, 6, 1),
+                                reason=f"划入专款池 R3", outflow=outflow,
+                                kind="investment", note=f"UI 投资划出 {tag}"))
+        session.add(FinanceEntry(entity_id=e.id, entity_kind="person", year=1990,
+                                 kind="investment", amount=outflow, currency="BEF",
+                                 label=f"投资 R3 {tag}", source="ui"))
+        session.add(TimelineEvent(event_year=1990, title=f"投资 {tag}",
+                                  note=f"投入专款池，年末赎回（{tag}）",
+                                  decade="1990s", overlay=True))
+    session.flush()
+    return inv1, inv10
+
+
+def test_unlock_inv1_keeps_inv10_derived_rows(session):
+    inv1, inv10 = _seed_investment_pair(session)
+
+    unlock_investment(session, inv1)
+
+    notes = {n for (n,) in session.execute(select(LedgerEntry.note))}
+    labels = {n for (n,) in session.execute(select(FinanceEntry.label))}
+    titles = {t for (t,) in session.execute(select(TimelineEvent.title))}
+    # inv#1 三类行全灭；inv#10 的派生行完好无损
+    assert notes == {"UI 投资划出 inv#10"}
+    assert labels == {"投资 R3 inv#10"}
+    assert titles == {"投资 inv#10"}
+    # inv10 本体未动
+    assert inv10.locked is True
+
+
+def test_demand_tag_boundary_exact_year(session):
+    e = Entity(entity_type="person", name="Henri Peeters")
+    session.add(e)
+    session.flush()
+    acc = Account(entity_id=e.id, currency="BEF", bank=None)
+    session.add(acc)
+    session.flush()
+    session.add(LedgerEntry(account_id=acc.id, date=date(2024, 12, 30),
+                            reason="活期结息", inflow=1, kind="income",
+                            note="UI 活期结息 demand#2024"))
+    session.add(LedgerEntry(account_id=acc.id, date=date(2023, 12, 30),
+                            reason="活期结息", inflow=1, kind="income",
+                            note="UI 活期结息 demand#202"))
+    session.flush()
+
+    # 抹除 2024 年：不得波及 demand#202（词边界）
+    delete_derived_by_tag(session, tag="demand#2024")
+    notes = {n for (n,) in session.execute(select(LedgerEntry.note))}
+    assert notes == {"UI 活期结息 demand#202"}
+
+    delete_derived_by_tag(session, tag="demand#202")
+    assert session.execute(select(LedgerEntry.note)).all() == []


### PR DESCRIPTION
## 二轮审计 P0 批次（跟踪索引 #146）

| Issue | 修复 |
|---|---|
| #135 | `ingest --force`/`force_files` 清场后落入冲突检测+重导（合并事故「只删不补」回退）；salary 维持跳过；死代码清理 |
| #136 | writer 六处接 `TITLE_ENTITY` 归一规范实体；新增 CLI `merge-alias-persons [--dry-run]`（括号注解变体/account 并账/幂等/自动重算） |
| #137 | `delete_derived_by_tag` 词边界正则：inv#1 不再误删 inv#10~19；demand 复用 |

**测试**：新增 3 个回归文件 13 用例；纯 P0 树 checkpoint 14 passed。
**注**：writer.py 租房窗口口径注记（属 #144 文档项）随该文件先行。

Refs #135 #136 #137 · 承 #146