### PR TITLE
feat(p1): 异步 job 资源方案A + restore 前置校验 + 健康范围化 + 日历上限收敛（#138–#141）

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
 from app.api.date_rules import router as date_rules_router
+from app.api.jobs import router as jobs_router
 from app.api.labor_cost import router as labor_cost_router
 from app.api.movie_events import router as movie_events_router
 from app.api.restricted import router as restricted_router
@@ -48,6 +49,7 @@ app.include_router(source_files_router)
 app.include_router(search_router)
 app.include_router(restricted_router)
 app.include_router(date_rules_router)
+app.include_router(jobs_router)   # issue #138：异步 job 资源（import-jobs / recompute-jobs）
 
 # issue #30：dist 直连部署时前端跨域失败；PRD §13 本地单机非安全边界，
 # 仅放行 vite dev server 默认端口（5173）的两个本地来源，不允许 * 通配。
@@ -206,7 +208,8 @@ def snapshots(
 
 # ---------------- 财富曲线 ----------------
 @app.get(API_PREFIX + "/wealth")
-def wealth(year_from: int = 1947, year_to: int = 2025, db: Session = Depends(get_db)):
+def wealth(year_from: int = 1947, year_to: int = None, db: Session = Depends(get_db)):
+    """issue #141：year_to 缺省跟随 config 日历上限。"""
     return wealth_series(db, year_from, year_to)
 
 

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -1,0 +1,141 @@
+"""异步 job 资源 API（issue #138 · DESIGN §14.2 方案A）。
+
+- POST/GET /api/v1/recompute-jobs、GET/DELETE /api/v1/recompute-jobs/{id}
+- POST/GET /api/v1/import-jobs、GET/DELETE /api/v1/import-jobs/{id}
+
+发起即建 job（202 Accepted），子操作 = 对该 job 的状态查询；后台执行由
+FastAPI BackgroundTasks 承担（core/jobs 单 worker 串行）。DELETE 仅 pending
+可取消（204），其余状态 409。
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.config import CALENDAR_MIN_YEAR, get_config
+from app.core import jobs
+from app.model import ImportJob, RecomputeJob
+
+router = APIRouter(prefix="/api/v1", tags=["jobs"])
+
+
+class RecomputeJobIn(BaseModel):
+    start_year: int | None = Field(default=CALENDAR_MIN_YEAR, ge=1947)
+    reason: str | None = None
+    files: list[str] | None = None
+
+
+class ImportJobIn(BaseModel):
+    provider: str
+    payload: dict | None = None
+
+
+def _recompute_dto(j: RecomputeJob) -> dict:
+    return {"id": j.id, "start_year": j.start_year, "reason": j.reason,
+            "files": j.files or [], "status": j.status,
+            "created_at": j.created_at.isoformat() if j.created_at else None,
+            "finished_at": j.finished_at.isoformat() if j.finished_at else None}
+
+
+def _import_dto(j: ImportJob) -> dict:
+    return {"id": j.id, "provider": j.provider, "payload": j.payload,
+            "status": j.status, "result": j.result, "error": j.error,
+            "created_at": j.created_at.isoformat() if j.created_at else None,
+            "finished_at": j.finished_at.isoformat() if j.finished_at else None}
+
+
+# ---------------- recompute-jobs ----------------
+@router.post("/recompute-jobs", status_code=202)
+def create_recompute_job(body: RecomputeJobIn, bg: BackgroundTasks,
+                         db: Session = Depends(get_db)):
+    """触发异步重算任务：建 pending → 后台执行 → GET 查询状态。"""
+    jid = jobs.create_recompute_job(db, body.start_year or CALENDAR_MIN_YEAR,
+                                    body.reason or "ui", body.files)
+    db.commit()
+    bg.add_task(jobs.execute_recompute_job, get_config().env, jid)
+    return {"id": jid, "status": "pending"}
+
+
+@router.get("/recompute-jobs")
+def list_recompute_jobs(status: Optional[str] = None,
+                        limit: int = Query(50, le=200), offset: int = Query(0, ge=0),
+                        db: Session = Depends(get_db)):
+    q = select(RecomputeJob).order_by(RecomputeJob.id.desc())
+    if status:
+        q = q.where(RecomputeJob.status == status)
+    rows = db.execute(q.limit(limit).offset(offset)).scalars().all()
+    return {"items": [_recompute_dto(x) for x in rows], "total": len(rows)}
+
+
+@router.get("/recompute-jobs/{jid}")
+def get_recompute_job(jid: int, db: Session = Depends(get_db)):
+    j = db.get(RecomputeJob, jid)
+    if j is None:
+        raise HTTPException(status_code=404, detail="recompute job not found")
+    dto = _recompute_dto(j)
+    # 附最近一次通知的健康摘要/明细（「查看影响」数据源）
+    from app.model import Notification
+    n = db.execute(select(Notification)
+                   .where(Notification.job_id == jid,
+                          Notification.kind == "recompute-done")
+                   .order_by(Notification.id.desc()).limit(1)).scalar_one_or_none()
+    if n is not None:
+        dto["health"] = (n.payload or {}).get("health")
+        dto["health_findings"] = (n.payload or {}).get("health_findings")
+        dto["health_error"] = (n.payload or {}).get("health_error")
+    return dto
+
+
+@router.delete("/recompute-jobs/{jid}", status_code=204)
+def cancel_recompute_job(jid: int, db: Session = Depends(get_db)):
+    if db.get(RecomputeJob, jid) is None:
+        raise HTTPException(status_code=404, detail="recompute job not found")
+    if not jobs.cancel_pending(db, RecomputeJob, jid):
+        raise HTTPException(status_code=409, detail="仅 pending 任务可取消")
+
+
+# ---------------- import-jobs ----------------
+@router.post("/import-jobs", status_code=202)
+def create_import_job(body: ImportJobIn, bg: BackgroundTasks,
+                      db: Session = Depends(get_db)):
+    """触发外部导入任务（provider ∈ {company-info, labor-cost}）。"""
+    jid, err = jobs.create_import_job(db, body.provider, body.payload)
+    if err:
+        raise HTTPException(status_code=422, detail=err)
+    db.commit()
+    bg.add_task(jobs.execute_import_job, get_config().env, jid)
+    return {"id": jid, "status": "pending", "provider": body.provider}
+
+
+@router.get("/import-jobs")
+def list_import_jobs(provider: Optional[str] = None, status: Optional[str] = None,
+                     limit: int = Query(50, le=200), offset: int = Query(0, ge=0),
+                     db: Session = Depends(get_db)):
+    q = select(ImportJob).order_by(ImportJob.id.desc())
+    if provider:
+        q = q.where(ImportJob.provider == provider)
+    if status:
+        q = q.where(ImportJob.status == status)
+    rows = db.execute(q.limit(limit).offset(offset)).scalars().all()
+    return {"items": [_import_dto(x) for x in rows], "total": len(rows)}
+
+
+@router.get("/import-jobs/{jid}")
+def get_import_job(jid: int, db: Session = Depends(get_db)):
+    j = db.get(ImportJob, jid)
+    if j is None:
+        raise HTTPException(status_code=404, detail="import job not found")
+    return _import_dto(j)
+
+
+@router.delete("/import-jobs/{jid}", status_code=204)
+def cancel_import_job(jid: int, db: Session = Depends(get_db)):
+    if db.get(ImportJob, jid) is None:
+        raise HTTPException(status_code=404, detail="import job not found")
+    if not jobs.cancel_pending(db, ImportJob, jid):
+        raise HTTPException(status_code=409, detail="仅 pending 任务可取消")

--- a/app/api/source_files.py
+++ b/app/api/source_files.py
@@ -63,12 +63,18 @@ def adopt_new_version(vid: int, db: Session = Depends(get_db)):
 
 @router.post("/source-files/{vid}/versions/{v2}/restore")
 def restore_version(vid: int, v2: int, db: Session = Depends(get_db)):
-    """回退到指定版本：复原 source_dir 磁盘文件 + 该版本置 is_current。"""
+    """回退到指定版本：复原 source_dir 磁盘文件 + 该版本置 is_current。
+
+    issue #139：磁盘内容已偏离当前生效版 → 409（前端引导刷新 diff 重决策）。
+    """
     rel = _rel(db, vid)
     try:
         r = versioning.restore_version(db, get_config(), rel, v2)
         db.commit()
         return r
+    except versioning.RestoreConflict as e:
+        db.rollback()
+        raise HTTPException(status_code=409, detail=e.detail)
     except KeyError as e:
         db.rollback()
         raise HTTPException(status_code=404, detail=str(e))

--- a/app/api/stock_events.py
+++ b/app/api/stock_events.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import apply_error, get_db
+from app.config import CALENDAR_MAX_YEAR as _YEAR_MAX  # issue #141
 from app.core.snapshot import rebuild_snapshots
 from app.core.stock_cost import (
     apply_buy, apply_dividend, apply_passive_uplift, apply_sell,
@@ -40,7 +41,7 @@ class AssociateIn(BaseModel):
 class StockActionIn(BaseModel):
     entity_id: int
     company: str
-    date: _date = Field(ge=_date(1947, 1, 1), le=_date(2026, 12, 31))
+    date: _date = Field(ge=_date(1947, 1, 1), le=_date(_YEAR_MAX, 12, 31))
     account_id: Optional[int] = None
     ticker: Optional[str] = None
     unit_price: Optional[float] = None

--- a/app/api/timeline.py
+++ b/app/api/timeline.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
+from app.config import CALENDAR_MAX_YEAR as _YEAR_MAX  # issue #141
 from app.core.overlay import (_is_user_overlay_row, create_overlay, delete_overlay,
                               diff_overlay, make_key, merge_overlay, restore_overlay,
                               source_as_latest, update_overlay)
@@ -37,7 +38,7 @@ def _after_timeline_write(db: Session, start_year: int) -> None:
 
 
 class TimelineCreate(BaseModel):
-    event_year: int = Field(ge=1947, le=2026)
+    event_year: int = Field(ge=1947, le=_YEAR_MAX)
     event_date: Optional[date] = None
     title: str = Field(min_length=1)
     note: Optional[str] = None
@@ -45,7 +46,7 @@ class TimelineCreate(BaseModel):
 
 
 class TimelinePatch(BaseModel):
-    event_year: Optional[int] = Field(default=None, ge=1947, le=2026)
+    event_year: Optional[int] = Field(default=None, ge=1947, le=_YEAR_MAX)
     event_date: Optional[date] = None
     title: Optional[str] = None
     note: Optional[str] = None
@@ -149,6 +150,10 @@ def post_timeline(body: TimelineCreate, response: Response,
                        title=body.title, note=body.note, decade=body.decade)
     db.commit()
     _after_timeline_write(db, body.event_year)
+    # issue #142：201 统一带 Location（#127 契约；此前声明 response 未用）
+    new_id = r.get("timeline_event_id") if isinstance(r, dict) else None
+    if new_id is not None:
+        response.headers["Location"] = f"/api/v1/timeline-events/{new_id}"
     return r
 
 

--- a/app/api/ui_ops.py
+++ b/app/api/ui_ops.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import apply_error, get_db
+from app.config import CALENDAR_MAX_YEAR as _YEAR_MAX  # issue #141
 from app.core.demand import accrue_demand_interest
 from app.core.invest import (
     create_investment, redeem_investment, region_start_years, unlock_investment,
@@ -34,7 +35,7 @@ class AllocIn(BaseModel):
 
 
 class InvestmentIn(BaseModel):
-    year: int = Field(ge=1947, le=2026)
+    year: int = Field(ge=1947, le=_YEAR_MAX)
     region: str
     risk_lvl: str
     start_date: date
@@ -46,7 +47,7 @@ class TransferIn(BaseModel):
     target_entity_id: int
     target_currency: str
     amount: float
-    year: int = Field(ge=1947, le=2026)
+    year: int = Field(ge=1947, le=_YEAR_MAX)
 
 
 _apply_error = apply_error   # issue #132：收敛到 deps 共享
@@ -188,7 +189,7 @@ def returns_regions():
 
 
 class DemandInterestIn(BaseModel):
-    year: int = Field(ge=1947, le=2026)
+    year: int = Field(ge=1947, le=_YEAR_MAX)
 
 
 @router.post("/demand-interest")

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,21 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+# ---- 日历年区间单一来源（issue #141 · DESIGN §6.2）----
+# 此前 2026/2025 上限散落 leverage/transfer/ui_ops/snapshot/main 等十余处，
+# 时间进入上限年即静默停滚。收敛为 config 常量：MIN=1947（最早数据年，固定）；
+# MAX 取 max(2026, 当前年+1) 动态留一年余量（随进程启动日期推进，无需跟版本赛跑）。
+# 各处滚动/重建/校验统一用 range(CALENDAR_MIN_YEAR, CALENDAR_MAX_YEAR + 1)。
+import datetime as _dt
+
+CALENDAR_MIN_YEAR = 1947
+CALENDAR_MAX_YEAR = max(2026, _dt.date.today().year + 1)
+
+
+def calendar_years() -> range:
+    """全日历覆盖区间（含端点），供快照重建/滚动等使用。"""
+    return range(CALENDAR_MIN_YEAR, CALENDAR_MAX_YEAR + 1)
+
 
 def _env_str(key: str, default: str) -> str:
     """LLM 配置环境变量覆盖（DESIGN §18.5）；未设时用缺省值。"""

--- a/app/core/calendar.py
+++ b/app/core/calendar.py
@@ -73,5 +73,6 @@ def snapshot_as_of(session: Session, as_of_date: date) -> list[dict]:
 
 
 def default_calendar_bounds() -> tuple[int, int]:
-    """日历年范围（DESIGN：1947 最早 – 2026 最晚）。"""
-    return 1947, 2026
+    """日历年范围（issue #141：收敛自 app.config，DESIGN §6.2 的 1947–最晚年）。"""
+    from app.config import CALENDAR_MIN_YEAR, CALENDAR_MAX_YEAR
+    return CALENDAR_MIN_YEAR, CALENDAR_MAX_YEAR

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -5,6 +5,7 @@ run_report(session) -> list[dict]，每条 = {rule, level, location, detail}。
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Optional
 
 from sqlalchemy import func, select
@@ -28,32 +29,40 @@ class Finding:
         return {"rule": self.rule, "level": self.level, "location": self.location, "detail": self.detail}
 
 
-def check_h1_timeline_alignment(session: Session) -> list[Finding]:
-    """H1 时间线对齐：timeline_event 年份 vs income_stream/return_curve 相关年份差异。"""
+def check_h1_timeline_alignment(session: Session, from_year: int | None = None) -> list[Finding]:
+    """H1 时间线对齐：timeline_event 年份 vs income_stream/return_curve 相关年份差异。
+
+    from_year（issue #140 · §9.2d 范围化）：仅检查该年及以后的时间线条目。
+    """
     finds: list[Finding] = []
     # 时间线事件年份集合 vs income_stream 年份范围：时间线有事件而该年无任何收益流 → warn（可能缺财务）
     income_years = set(session.execute(select(func.distinct(IncomeStream.year))).scalars().all())
-    tl_events = session.execute(select(TimelineEvent.event_year, TimelineEvent.title)).all()
-    for year, title in tl_events:
+    tl_rows = session.execute(select(TimelineEvent.event_year, TimelineEvent.title)).all()
+    for year, title in tl_rows:
+        if from_year is not None and year < from_year:
+            continue
         if income_years and year not in income_years:
             finds.append(Finding("H1", "warn", f"时间线 {year}「{title}」", "该年无对应收益流，可能未对齐"))
     return finds
 
 
-def check_h2_amount_consistency(session: Session) -> list[Finding]:
+def check_h2_amount_consistency(session: Session, from_year: int | None = None) -> list[Finding]:
     """H2 金额一致：income_stream 同 (entity, stream_type, label名, money year) 多来源金额不一致。
 
     用 label（含具体标的，如具体债券名）作为同类唯一键；同 label 同 year 唯一金额，多来源≠才是冲突。
+    from_year（issue #140）：仅统计该年及以后。
     """
     finds: list[Finding] = []
+    q = select(
+        IncomeStream.entity_id, IncomeStream.stream_type, IncomeStream.label,
+        IncomeStream.group_key, IncomeStream.currency, IncomeStream.year,
+        func.count(), func.min(IncomeStream.amount), func.max(IncomeStream.amount),
+    ).group_by(IncomeStream.entity_id, IncomeStream.stream_type, IncomeStream.label,
+               IncomeStream.group_key, IncomeStream.currency, IncomeStream.year)
+    if from_year is not None:
+        q = q.where(IncomeStream.year >= from_year)
     rows = session.execute(
-        select(
-            IncomeStream.entity_id, IncomeStream.stream_type, IncomeStream.label,
-            IncomeStream.group_key, IncomeStream.currency, IncomeStream.year,
-            func.count(), func.min(IncomeStream.amount), func.max(IncomeStream.amount),
-        ).group_by(IncomeStream.entity_id, IncomeStream.stream_type, IncomeStream.label,
-                   IncomeStream.group_key, IncomeStream.currency, IncomeStream.year)
-        .having(func.count() > 1, func.min(IncomeStream.amount) != func.max(IncomeStream.amount))
+        q.having(func.count() > 1, func.min(IncomeStream.amount) != func.max(IncomeStream.amount))
     ).all()
     for eid, st, label, gk, cur, year, cnt, mn, mx in rows:
         ent = session.get(Entity, eid)
@@ -94,7 +103,7 @@ def check_h3_fx_closure(session: Session) -> list[Finding]:
     return finds
 
 
-def check_h4_balance_chain(session: Session) -> list[Finding]:
+def check_h4_balance_chain(session: Session, from_year: int | None = None) -> list[Finding]:
     """H4 余额连续（复利感知，DESIGN §10「复利/杠杆自洽」口径，issue #113 连锁修正）。
 
     与 leverage.recompute_one 的年粒度滚动模型同构：
@@ -103,6 +112,8 @@ def check_h4_balance_chain(session: Session) -> list[Finding]:
       rate_calc 与 `_rate_for_account_year` 同源（地区×R级×杠杆）；
       无收益率的年份退化为 累计 + 净流入。
     - 首条前无结转 → 视 0（issue #22：不让首条失核逃逸）。
+    - from_year（issue #140 · §9.2d 范围化）：结转仍从全史滚出（保证口径一致），
+      但只报告该年及以后的失核。
     """
     from collections import defaultdict
 
@@ -137,6 +148,8 @@ def check_h4_balance_chain(session: Session) -> list[Finding]:
                 # 首条基数为年初结转 carry（与上一年年末校验值衔接）
                 run_prev = carry
                 for e in year_entries[:-1]:
+                    if from_year is not None and e.date.year < from_year:
+                        continue
                     if e.balance is None:
                         continue
                     expect = run_prev + float(e.inflow or 0) - float(e.outflow or 0)
@@ -161,7 +174,8 @@ def check_h4_balance_chain(session: Session) -> list[Finding]:
             else:
                 expect = carry + net_in
                 formula = f"{carry:.2f}+净流{net_in:.2f}"
-            if abs(float(last.balance) - expect) > 0.01:
+            if abs(float(last.balance) - expect) > 0.01 and (
+                    from_year is None or y >= from_year):
                 msg = f"年末余额 {last.balance} ≠ {formula}={expect:.2f}"
                 if last is entries[0]:
                     msg = f"首条余额 {last.balance} ≠ {formula}={expect:.2f}"
@@ -170,18 +184,20 @@ def check_h4_balance_chain(session: Session) -> list[Finding]:
     return finds
 
 
-def check_negative_balance(session: Session) -> list[Finding]:
+def check_negative_balance(session: Session, from_year: int | None = None) -> list[Finding]:
     """issue #22：负余额检查。账户余额为负数极可能是计算错误（DESIGN 数值纪律要求
     账户余额非负；个别场景如短贷可豁免但需 source 注释）。
 
     仅在 balance 列有非 None 值时检查。报 warn（不阻断重算，便于人工复核）。
+    from_year（issue #140）：仅检查该年 1 月 1 日起的余额行。
     """
     finds: list[Finding] = []
+    q = select(LedgerEntry.account_id, LedgerEntry.date, LedgerEntry.balance).where(
+        LedgerEntry.balance < 0)
+    if from_year is not None:
+        q = q.where(LedgerEntry.date >= date(from_year, 1, 1))
     neg_rows = session.execute(
-        select(LedgerEntry.account_id, LedgerEntry.date, LedgerEntry.balance)
-        .where(LedgerEntry.balance < 0)
-        .order_by(LedgerEntry.account_id, LedgerEntry.date)
-    ).all()
+        q.order_by(LedgerEntry.account_id, LedgerEntry.date)).all()
     for aid, dt, bal in neg_rows:
         acc = session.get(Account, aid)
         finds.append(Finding("H4", "warn",
@@ -293,24 +309,28 @@ def check_stock_h2(session: Session) -> list[Finding]:
     return finds
 
 
-def run_report(session: Session) -> list[dict]:
-    """全库健康校验汇总：H1..H5 + H-STOCK。"""
+def run_report(session: Session, from_year: int | None = None) -> list[dict]:
+    """全库健康校验汇总：H1..H5 + H-STOCK。
+
+    from_year（issue #140 · §9.2d）：范围限定——H1/H2/H4/负余额只报告该年及以后；
+    H3/H5/H-STOCK 为全局完整性规则（廉价且天然全局），不受影响。
+    """
     all_finds: list[Finding] = []
-    all_finds += check_h1_timeline_alignment(session)
-    all_finds += check_h2_amount_consistency(session)
+    all_finds += check_h1_timeline_alignment(session, from_year)
+    all_finds += check_h2_amount_consistency(session, from_year)
     all_finds += check_fx_coverage(session)
     all_finds += check_h3_fx_closure(session)
-    all_finds += check_negative_balance(session)
-    all_finds += check_h4_balance_chain(session)
+    all_finds += check_negative_balance(session, from_year)
+    all_finds += check_h4_balance_chain(session, from_year)
     all_finds += check_h5_dangling(session)
     all_finds += check_holding_value(session)
     all_finds += check_stock_h2(session)
     return [f.as_dict() for f in all_finds]
 
 
-def summarize(session: Session) -> dict:
-    """返回每规则计数（供 overview 汇总）。"""
-    report = run_report(session)
+def summarize(session: Session, from_year: int | None = None) -> dict:
+    """返回每规则计数（供 overview 汇总；from_year 语义同 run_report）。"""
+    report = run_report(session, from_year)
     # issue #23 / API 健康视图：预填 H1..H5 即使 0 也有键，前端可稳定读 summary['H1']
     summary: dict[str, dict] = {rule: {"total": 0, "warn": 0, "crit": 0}
                                 for rule in ("H1", "H2", "H3", "H4", "H5", "H-STOCK")}

--- a/app/core/jobs.py
+++ b/app/core/jobs.py
@@ -1,0 +1,170 @@
+"""异步 job 执行器（issue #138 · DESIGN §14.2 方案A：补齐 job 资源）。
+
+进程内单 worker（threading.Lock 串行化——本地单机语义）；每任务独立 session
+（按 env 构造，测试可注入 sessionmaker）。
+
+- recompute-jobs：create(pending) → 后台 running → recompute_all + rebuild_snapshots
+  + record_recompute_done(job_row=本任务行，含范围化健康复核与通知) → done/failed。
+- import-jobs：create(pending) → 后台 running → provider 分发：
+  · company-info → run_external_company_import（外部 API① 公司基础信息）
+  · labor-cost   → run_labor_cost（外部 API② 在岗岗位→用工成本落账；随后重算+快照）
+  → done(result) / failed(error)。
+
+状态机：pending → running → done | failed。DELETE 取消仅对 pending 有效（API 层）。
+"""
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from typing import Callable
+
+from app.config import CALENDAR_MIN_YEAR
+from app.db import make_sessionmaker
+
+PROVIDERS = ("company-info", "labor-cost")
+
+# 单 worker 锁：本地单机同一时刻至多一个后台任务在执行；后续任务在锁上排队。
+_job_lock = threading.Lock()
+
+
+def create_recompute_job(session, start_year: int, reason: str = "ui",
+                         files: list | None = None) -> int:
+    """建 pending recompute_job，返回 id（§9.2 步骤1 的资源化）。"""
+    from app.model import RecomputeJob
+    job = RecomputeJob(start_year=start_year, reason=reason,
+                       files=list(files or []), status="pending",
+                       created_at=datetime.now())
+    session.add(job)
+    session.flush()
+    return int(job.id)
+
+
+def create_import_job(session, provider: str, payload: dict | None = None):
+    """建 pending import_job；provider 非法返回 (None, 错误信息)。"""
+    if provider not in PROVIDERS:
+        return None, f"未知 provider {provider!r}，可选 {list(PROVIDERS)}"
+    from app.model import ImportJob
+    job = ImportJob(provider=provider, payload=dict(payload or {}), status="pending")
+    session.add(job)
+    session.flush()
+    return int(job.id), None
+
+
+def _default_runner(provider: str) -> Callable:
+    """provider → runner(session, payload) -> result dict（复用既有同步内核）。"""
+    if provider == "company-info":
+        from app.ingest.importers.company_info import run_external_company_import
+
+        def run(s, payload):
+            stats = run_external_company_import(
+                s, base_url=payload.get("base_url") or None)
+            return {"stats": stats}
+        return run
+    if provider == "labor-cost":
+        from app.ingest.importers.positions import run_labor_cost
+
+        def run(s, payload):
+            year = payload.get("year")
+            if year is None:
+                raise ValueError("labor-cost 需要 payload.year")
+            return run_labor_cost(s, int(year),
+                                  company_ids=payload.get("company_ids"))
+        return run
+    raise ValueError(f"未知 provider {provider!r}")
+
+
+def _finish_ok(session, job, result: dict | None = None):
+    job.status = "done"
+    job.finished_at = datetime.now()
+    if result is not None and hasattr(job, "result"):
+        job.result = result
+
+
+def _finish_failed(session, model, job_id, exc: Exception):
+    # 独立事务收尾：业务回滚后仍要留下 failed 痕迹
+    try:
+        session.rollback()
+        job = session.get(model, job_id)
+        if job is not None:
+            job.status = "failed"
+            job.error = f"{type(exc).__name__}: {exc}"[:500]
+            job.finished_at = datetime.now()
+            session.commit()
+    except Exception:  # noqa: BLE001 — 收尾失败不再抛（避免污染后台线程日志）
+        pass
+
+
+def execute_recompute_job(env: str, job_id: int, *, sessionmaker=None) -> None:
+    """后台执行重算任务（BackgroundTasks 入口；自管 session 与事务）。"""
+    from app.config import calendar_years
+    from app.core.recompute import recompute_all, record_recompute_done
+    from app.core.snapshot import rebuild_snapshots
+    from app.model import RecomputeJob
+
+    S = sessionmaker or make_sessionmaker(env)
+    with _job_lock:
+        with S() as s:
+            job = s.get(RecomputeJob, job_id)
+            if job is None or job.status != "pending":
+                return
+            start_year = int(job.start_year or CALENDAR_MIN_YEAR)
+            reason = job.reason or "recompute-job"
+            files = list(job.files or [])
+            job.status = "running"
+            s.commit()
+            try:
+                recompute_all(s, start_year)
+                rebuild_snapshots(s, calendar_years(), from_year=start_year)
+                record_recompute_done(s, start_year, reason=reason, files=files,
+                                      job_row=job)
+                s.commit()
+            except Exception as e:  # noqa: BLE001
+                _finish_failed(s, RecomputeJob, job_id, e)
+
+
+def execute_import_job(env: str, job_id: int, *, sessionmaker=None,
+                       runners: dict[str, Callable] | None = None) -> None:
+    """后台执行外部导入任务（provider 分发；labor 落账后同批重算+快照）。"""
+    from app.config import calendar_years
+    from app.core.recompute import recompute_all
+    from app.core.snapshot import rebuild_snapshots
+    from app.model import ImportJob
+
+    S = sessionmaker or make_sessionmaker(env)
+    with _job_lock:
+        provider = None
+        payload: dict = {}
+        with S() as s:
+            job = s.get(ImportJob, job_id)
+            if job is None or job.status != "pending":
+                return
+            provider = job.provider
+            payload = dict(job.payload or {})
+            job.status = "running"
+            s.commit()
+        try:
+            runner = (runners or {}).get(provider) or _default_runner(provider)
+            with S() as s:
+                result = runner(s, payload)
+                if provider == "labor-cost":
+                    year = int(payload.get("year") or CALENDAR_MIN_YEAR)
+                    recompute_all(s, year)
+                    rebuild_snapshots(s, calendar_years(), from_year=year)
+                job = s.get(ImportJob, job_id)
+                _finish_ok(s, job, result)
+                s.commit()
+        except Exception as e:  # noqa: BLE001 — 外部系统错误统一 failed 留痕（不透传上游码）
+            with S() as s:
+                _finish_failed(s, ImportJob, job_id, e)
+
+
+def cancel_pending(session, model, job_id: int) -> bool:
+    """取消 pending 任务（置 failed/已取消）；非 pending 返回 False（API→409）。"""
+    job = session.get(model, job_id)
+    if job is None or job.status != "pending":
+        return False
+    job.status = "failed"
+    job.error = "已取消（DELETE pending 任务）"
+    job.finished_at = datetime.now()
+    session.commit()
+    return True

--- a/app/core/leverage.py
+++ b/app/core/leverage.py
@@ -18,6 +18,7 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.config import CALENDAR_MAX_YEAR
 from app.core.regions import (
     CURRENCY_REGION, DEFAULT_RISK_LVL, REGION_COUNTRY,
     entity_region_override, entity_risk_override,
@@ -134,7 +135,7 @@ def recompute_one(session: Session, account_id: int, from_year: int) -> dict:
             year_in[e.date.year] += Decimal(e.inflow) if e.inflow is not None else _ZERO
             year_out[e.date.year] += Decimal(e.outflow) if e.outflow is not None else _ZERO
 
-    for y in range(from_year, 2026):
+    for y in range(from_year, CALENDAR_MAX_YEAR + 1):
         net_inflow = year_in.get(y, _ZERO) - year_out.get(y, _ZERO)
         rate = _rate_for_account_year(session, account, y)
         if rate is not None:

--- a/app/core/recompute.py
+++ b/app/core/recompute.py
@@ -53,29 +53,52 @@ def register_job(session: Session, start_year: int, reason: str, files: Optional
 
 
 def record_recompute_done(session: Session, start_year: int, reason: str = "manual",
-                          files: Optional[list] = None) -> dict:
+                          files: Optional[list] = None,
+                          job_row=None) -> dict:
     """DESIGN §9.2 步骤 3-4：写 recompute_job(status=done) → 建 recompute-done Notification。
 
-    §9.2d（issue #120）：通知 payload 附带重算后的健康摘要（H1-H5/H-STOCK 计数），
-    使「导入/UI 改动 → 重算 → 健康复核」链路自动闭环，无需手动跑 health。
+    §9.2d（issue #120/#140）：重算后按受影响起点（start_year）跑范围化健康复核——
+    payload 携带：
+    - health：H1-H5/H-STOCK 计数（from_year=start_year 范围口径）；
+    - health_findings：crit 优先的前 N 条明细（「查看影响」入口的数据源）；
+    - health_findings_total / health_error（校验自身异常时不再静默吞掉）。
+
+    job_row（issue #138 异步通道）：传入已存在的 pending/running 任务行则复用它
+    （收尾置 done），否则按旧路径新建 done 行。CLI 同步路径不受影响。
     返回 {"job_id": int, "notification_id": int}；session.flush 后由外层 commit。
     """
-    from app.core.health import summarize
-    from app.model import Notification
-    job_id = register_job(session, start_year, reason, files)
+    from app.core import health
+    from app.model import Notification, RecomputeJob
+    if job_row is not None:
+        job = job_row
+    else:
+        job_id_ = register_job(session, start_year, reason, files)
+        job = session.get(RecomputeJob, job_id_)
+    payload: dict = {"start_year": start_year, "files": files or [], "health": {}}
     try:
-        health_summary = summarize(session)
-    except Exception:  # noqa: BLE001 — 健康摘要失败不阻断重算完成通知
-        health_summary = {}
+        report = health.run_report(session, from_year=start_year)
+        summary: dict[str, dict] = {rule: {"total": 0, "warn": 0, "crit": 0}
+                                    for rule in ("H1", "H2", "H3", "H4", "H5", "H-STOCK")}
+        for r in report:
+            s = summary.setdefault(r["rule"], {"total": 0, "warn": 0, "crit": 0})
+            s["total"] += 1
+            s[r["level"]] = s.get(r["level"], 0) + 1
+        payload["health"] = {k: v.get("total", 0) for k, v in summary.items()}
+        crit_first = sorted(report, key=lambda x: 0 if x["level"] == "crit" else 1)
+        payload["health_findings"] = crit_first[:20]
+        payload["health_findings_total"] = len(report)
+    except Exception as e:  # noqa: BLE001 — 健康复核失败不阻断重算完成，但必须显式留痕
+        payload["health_error"] = f"{type(e).__name__}: {e}"[:500]
     notif = Notification(
-        job_id=job_id,
+        job_id=int(job.id),
         kind="recompute-done",
         title="全局重算完成",
         message=f"已在全局重算财富与派生数据（自 {start_year} 起）",
-        payload={"start_year": start_year, "files": files or [],
-                 "health": {k: v.get("total", 0) for k, v in health_summary.items()}},
+        payload=payload,
         created_at=datetime.now(),
     )
     session.add(notif)
+    job.status = "done"
+    job.finished_at = datetime.now()
     session.flush()
-    return {"job_id": job_id, "notification_id": int(notif.id)}
+    return {"job_id": int(job.id), "notification_id": int(notif.id)}

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -130,10 +130,11 @@ def _usd_rate(session: Session, currency: str, year: int) -> Decimal | None:
     return usd_rate(session, currency, year)
 
 
-def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
+def rebuild_snapshots(session: Session, years: range = None,
                       from_year: int | None = None) -> dict:
     """重建逐年账户/实体/家族三层快照。
 
+    years 缺省 = config.calendar_years()（issue #141：上限不再写死 2025/2026）；
     from_year=None → 全量重建（1947 起）；
     from_year=N    → 仅重建 [N, end] 年；旧 [1947, N-1] 快照保留（§9.2c 增量）。
 
@@ -142,6 +143,9 @@ def rebuild_snapshots(session: Session, years: range = range(1947, 2026),
 
     返回 {"snapshots": 行数, "accounts": 账户数, "entities": 实体数, "family_years": 家族快照年数}
     """
+    if years is None:
+        from app.config import calendar_years
+        years = calendar_years()
     stats = {"snapshots": 0, "accounts": 0, "entities": 0, "family_years": 0}
     years_list = list(years)
     if not years_list:

--- a/app/core/transfer.py
+++ b/app/core/transfer.py
@@ -17,13 +17,14 @@ from typing import Optional
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.config import CALENDAR_MAX_YEAR
 from app.core.invest import ValidationError
 from app.model import (
     Account, ExchangeRate, LedgerEntry, TimelineEvent,
 )
 
 _ZERO = Decimal(0)
-_MAX_YEAR = 2026  # DESIGN 日历年上限
+_MAX_YEAR = CALENDAR_MAX_YEAR  # issue #141：日历年上限收敛 config 单一来源
 
 
 def primary_account(session: Session, entity_id: int, currency: str) -> Optional[Account]:

--- a/app/core/versioning.py
+++ b/app/core/versioning.py
@@ -27,6 +27,14 @@ from app.model import Notification, SourceFileVersion
 _HASH_RE = re.compile(r"[^0-9a-zA-Z]")
 
 
+class RestoreConflict(Exception):
+    """issue #139：回退前置校验失败——磁盘内容已偏离当前版本，拒绝覆盖（API→409）。"""
+
+    def __init__(self, detail: str):
+        super().__init__(detail)
+        self.detail = detail
+
+
 def _fingerprint(content: str) -> str:
     """内容指纹（与 ingest main._content_fingerprint 同构：归一化空白后）。"""
     return _HASH_RE.sub("", (content or "").strip())
@@ -154,11 +162,28 @@ def _atomic_write(path: Path, content: str):
 
 
 def restore_version(db: Session, config, rel: str, version_id: int) -> dict:
-    """回退到指定版本：写盘复原 source_dir 文件 + 该版本置 is_current（旧失活）+ notification。"""
+    """回退到指定版本：写盘复原 source_dir 文件 + 该版本置 is_current（旧失活）+ notification。
+
+    issue #139 前置校验（§11.3「仍为『待回退』版本」）：写盘前核对磁盘现内容与
+    当前生效版（is_current）一致；已偏离（数据调整员在 diff 决策期间又手改过）→
+    RestoreConflict，绝不无提示覆盖第三方改动。
+    """
     v = db.get(SourceFileVersion, version_id)
     if v is None or v.file_path != rel:
         raise KeyError(f"版本不存在或不属于该文件: {rel}#{version_id}")
     target = _safe_target(config.source_dir, rel)
+    cur = db.execute(select(SourceFileVersion).where(
+        SourceFileVersion.file_path == rel,
+        SourceFileVersion.is_current.is_(True))).scalar_one_or_none()
+    if cur is not None and target.exists():
+        try:
+            disk = target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            disk = None
+        if disk is None or _fingerprint(disk) != _fingerprint(cur.content or ""):
+            raise RestoreConflict(
+                f"{rel}: 磁盘内容已偏离当前版本 v{cur.version}"
+                f"{'（读取失败）' if disk is None else ''}；请刷新 diff 确认后再决策")
     _atomic_write(target, v.content or "")
     for row in db.execute(select(SourceFileVersion).where(
             SourceFileVersion.file_path == rel)).scalars().all():

--- a/app/core/wealth.py
+++ b/app/core/wealth.py
@@ -68,12 +68,17 @@ def family_total_usd(session: Session, year: int) -> dict:
             "missing_rates": missing}
 
 
-def wealth_series(session: Session, year_from: int = 1947, year_to: int = 2025) -> dict:
+def wealth_series(session: Session, year_from: int = 1947,
+                  year_to: int | None = None) -> dict:
     """逐年 {year: {family_total_usd, accounts, currencies, missing_rates}}。
 
     issue #12：family_total_usd 直接读 family:total 快照（O(1)），
     accounts/currencies 仍按 account:* 快照聚合。missing_rates 从 account:* 快照反推。
+    year_to 缺省 = config 日历上限（issue #141，不再写死 2025）。
     """
+    if year_to is None:
+        from app.config import CALENDAR_MAX_YEAR
+        year_to = CALENDAR_MAX_YEAR
     out: dict[int, dict] = {}
     # 一次性把所有年份的快照取回来（避免逐 year 多次查询）
     all_snaps = session.execute(

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -7,9 +7,9 @@ from app.model.core import (
     Account, Entity, FinanceEntry, HoldingEvent, IncomeStream, InitialAsset, LedgerEntry,
 )
 from app.model.derived import (
-    DateRule, ExchangeRate, IngestReport, Investment, InvestmentAlloc, Notification,
-    RecomputeJob, Relationship, ReturnCurve, Snapshot, SourceFileVersion, TimelineEvent,
-    UserDataOverlay,
+    DateRule, ExchangeRate, ImportJob, IngestReport, Investment, InvestmentAlloc,
+    Notification, RecomputeJob, Relationship, ReturnCurve, Snapshot,
+    SourceFileVersion, TimelineEvent, UserDataOverlay,
 )
 from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmark
 from app.model.movie_event import MovieEvent
@@ -22,6 +22,7 @@ __all__ = [
     "FinanceEntry", "HoldingEvent",
     "ReturnCurve", "ExchangeRate", "DateRule", "TimelineEvent", "Relationship",
     "UserDataOverlay", "Snapshot", "SourceFileVersion", "RecomputeJob", "Notification",
+    "ImportJob",
     "Investment", "InvestmentAlloc",
     "LaborWageBenchmark", "LaborCpiGrowth", "LaborTaxBenchmark",
     "MovieEvent", "StockEvent", "SearchIndex",

--- a/app/model/derived.py
+++ b/app/model/derived.py
@@ -249,3 +249,26 @@ class InvestmentAlloc(Base):
 
 # forward import to satisfy .entity relationship type
 from app.model.core import Entity  # noqa: E402  isort:skip
+
+class ImportJob(Base):
+    """外部导入异步任务（issue #138 · DESIGN §14.2 import-jobs）。
+
+    provider ∈ {'company-info','labor-cost'}；payload 为该 provider 的请求参数
+    （company-info: {}；labor-cost: {year, company_ids?}）。status 走与
+    recompute_job 相同的 pending→running→done/failed 生命周期。
+    """
+    __tablename__ = "import_job"
+    __table_args__ = (
+        CheckConstraint("provider IN ('company-info','labor-cost')", name="ck_import_provider"),
+        CheckConstraint("status IN ('pending','running','done','failed')", name="ck_import_status"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[Optional[dict]] = mapped_column(JSONBCompat, default=dict)
+    status: Mapped[Optional[str]] = mapped_column(String, default="pending")
+    result: Mapped[Optional[dict]] = mapped_column(JSONBCompat)
+    error: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), server_default=func.now())
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))

--- a/app/search/search.py
+++ b/app/search/search.py
@@ -50,7 +50,8 @@ def _backfill_wealth(db: Session, question: str) -> list[str]:
     lines: list[str] = []
     from app.model import Snapshot
     for y in sorted({int(x) for x in re.findall(r"(?:19|20)\d{2}", question)}):
-        if not 1947 <= y <= 2026:
+        from app.config import CALENDAR_MIN_YEAR, CALENDAR_MAX_YEAR  # issue #141
+        if not CALENDAR_MIN_YEAR <= y <= CALENDAR_MAX_YEAR:
             continue
         row = db.execute(
             select(Snapshot.value, Snapshot.currency).where(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,8 +60,8 @@ export default function App() {
         <span className="mono">{asOf}</span>
       </div>
 
-      {/* issue #122：重算完成非阻断横幅（§9.3 / F-U3） */}
-      <NotificationsBanner />
+      {/* issue #122/#140：重算完成非阻断横幅（§9.3 / F-U3），含「查看影响」入口 */}
+      <NotificationsBanner onShowImpact={() => setActive('health')} />
 
       <nav className="nav">
         {TABS.map(t => (
@@ -96,11 +96,13 @@ export default function App() {
 }
 
 /**
- * 重算通知横幅（issue #122 · DESIGN §9.3 / PRD F-U3）：
+ * 重算通知横幅（issue #122/#140 · DESIGN §9.3 / PRD F-U3）：
  * 轮询 GET /notifications（默认仅未读）→ recompute-done 弹非阻断横幅，
- * 附 payload.health 摘要（issue #120）；「知道了」PATCH 标记已读。
+ * 附 payload.health 摘要（#120）+「查看影响」按钮（跳健康校验屏，§9.3）
+ * + crit 优先的 findings 预览（#140，payload.health_findings）；
+ * 「知道了」PATCH 标记已读。
  */
-function NotificationsBanner() {
+function NotificationsBanner({ onShowImpact }) {
   const [items, setItems] = useState([])
 
   useEffect(() => {
@@ -130,12 +132,26 @@ function NotificationsBanner() {
 
   return (
     <div className="panel banner" role="status">
-      {items.map(n => (
-        <div key={n.id} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-          <span>🔔 {n.message}{healthText(n.payload?.health) && ` · ${healthText(n.payload.health)}`}</span>
-          <button className="ghost" onClick={() => ack(n.id)}>知道了</button>
-        </div>
-      ))}
+      {items.map(n => {
+        const findings = n.payload?.health_findings || []
+        const total = n.payload?.health_findings_total ?? findings.length
+        return (
+          <div key={n.id} style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <span>🔔 {n.message}{healthText(n.payload?.health) && ` · ${healthText(n.payload.health)}`}</span>
+            <button className="ghost" onClick={() => onShowImpact?.()}>查看影响</button>
+            <button className="ghost" onClick={() => ack(n.id)}>知道了</button>
+            {!!findings.length && (
+              <details style={{ width: '100%' }}>
+                <summary className="note">受影响明细（前 {findings.length} / 共 {total}）</summary>
+                <pre className="mono" style={{ maxHeight: 200, overflow: 'auto', background: '#fff' }}>
+                  {findings.map((f, i) =>
+                    `[${f.rule}/${f.level}] ${f.location}: ${f.detail}`).join('\n')}
+                </pre>
+              </details>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/screens/ImportStatus.jsx
+++ b/frontend/src/screens/ImportStatus.jsx
@@ -1,16 +1,37 @@
-import { useState } from 'react'
-import { useFetch } from './useDataOp'
+import { useEffect, useState } from 'react'
+import { useDataOp, useFetch } from './useDataOp'
+import { ErrorBox } from './ui'
 
 const LEVELS = ['', 'block', 'warn', 'error']
 const LEVEL_LABEL = { block: '🔴 拦截', warn: '🟡 警告', error: '⛔ 解析失败' }
+const JOB_BADGE = { pending: '⏳ 待执行', running: '🏃 执行中', done: '✅ 完成', failed: '❌ 失败' }
 
-/** F-A5 导入状态屏（issue #123）：ingest_report（冲突拦截/软警告/解析失败）+ 最近批次。 */
+/** F-A5 导入状态屏（issue #123/#138）：ingest_report + 异步任务（重算/外部导入）触发与进度。 */
 export default function ImportStatus() {
   const [level, setLevel] = useState('')
   const q = new URLSearchParams({ page_size: '200' })
   if (level) q.set('level', level)
   const rep = useFetch(`/api/v1/ingest-reports?${q.toString()}`)
   const rows = rep.data?.items || []
+
+  // issue #138：异步 job 资源——触发重算 + 轮询任务状态
+  const [tick, setTick] = useState(0)
+  const jobs = useFetch(`/api/v1/recompute-jobs?limit=10&offset=0&t=${tick}`)
+  const imports = useFetch(`/api/v1/import-jobs?limit=10&offset=0&t=${tick}`)
+  const op = useDataOp(() => setTimeout(() => setTick(t => t + 1), 300))
+  const busyJobs = [...(jobs.data?.items || []), ...(imports.data?.items || [])]
+    .some(j => j.status === 'pending' || j.status === 'running')
+
+  useEffect(() => {
+    if (!busyJobs) return undefined
+    const t = setInterval(() => setTick(x => x + 1), 1500)
+    return () => clearInterval(t)
+  }, [busyJobs])
+
+  const triggerRecompute = () => op.submit('/api/v1/recompute-jobs',
+    { start_year: 1947, reason: 'ui-手动触发' })
+  const triggerCompanyImport = () => op.submit('/api/v1/import-jobs',
+    { provider: 'company-info' })
 
   return (
     <div className="panel">
@@ -19,6 +40,51 @@ export default function ImportStatus() {
         §11.4：硬拦截文件不入库，由数据调整员修源文件后重导；警告=已入库但需关注。
         CLI：<span className="mono">python -m app.ingest.main ingest --env …</span>
       </p>
+
+      {/* issue #138：异步任务资源（§14.2） */}
+      <h4>异步任务（#138 · §14.2）</h4>
+      <div className="row" style={{ marginBottom: 8 }}>
+        <button className="primary" disabled={op.busy || busyJobs} onClick={triggerRecompute}>
+          触发全量重算（1947 起）
+        </button>
+        <button className="ghost" disabled={op.busy || busyJobs} onClick={triggerCompanyImport}>
+          导入公司信息（外部 API①）
+        </button>
+        {busyJobs && <span className="note">⏳ 有任务执行中…（1.5s 自动刷新）</span>}
+      </div>
+      <ErrorBox error={op.error} />
+      <table style={{ marginBottom: 16 }}>
+        <thead><tr><th>ID</th><th>类型</th><th>状态</th><th>参数 / 结果</th><th>时间</th></tr></thead>
+        <tbody>
+          {(jobs.data?.items || []).map(j => (
+            <tr key={`r${j.id}`}>
+              <td className="mono">R{j.id}</td><td>重算</td>
+              <td>{JOB_BADGE[j.status] || j.status}</td>
+              <td style={{ fontSize: 12 }}>
+                自 {j.start_year} 起{j.reason ? ` · ${j.reason}` : ''}
+                {j.health_error && <span className="badge warn"> health 异常</span>}
+              </td>
+              <td className="muted" style={{ fontSize: 11 }}>{(j.finished_at || j.created_at || '').replace('T', ' ').slice(0, 19)}</td>
+            </tr>
+          ))}
+          {(imports.data?.items || []).map(j => (
+            <tr key={`i${j.id}`}>
+              <td className="mono">I{j.id}</td>
+              <td>{j.provider === 'company-info' ? '公司导入①' : '用工成本②'}</td>
+              <td>{JOB_BADGE[j.status] || j.status}</td>
+              <td style={{ fontSize: 12 }}>
+                {JSON.stringify(j.payload || {})}
+                {j.error && ` · ${j.error}`}
+                {j.result && ` · ${JSON.stringify(j.result).slice(0, 120)}`}
+              </td>
+              <td className="muted" style={{ fontSize: 11 }}>{(j.finished_at || j.created_at || '').replace('T', ' ').slice(0, 19)}</td>
+            </tr>
+          ))}
+          {!(jobs.data?.items?.length) && !(imports.data?.items?.length) &&
+            <tr><td colSpan={5} className="note">暂无任务记录</td></tr>}
+        </tbody>
+      </table>
+
       <div className="row" style={{ marginBottom: 8 }}>
         {LEVELS.map(l => (
           <button key={l || 'all'} className={`ghost ${level === l ? 'primary' : ''}`}

--- a/frontend/src/screens/SourceDiff.jsx
+++ b/frontend/src/screens/SourceDiff.jsx
@@ -12,7 +12,9 @@ export default function SourceDiff() {
   const files = useFetch(`/api/v1/source-files?refresh=${refresh}`)
   const [selVid, setSelVid] = useState(null)     // 当前选中文件（用 current_version id 标识）
   const [diffVersion, setDiffVersion] = useState('')
-  const diff = useFetch(selVid ? `/api/v1/source-files/${selVid}/diff${diffVersion ? `?version_id=${diffVersion}` : ''}?refresh=${refresh}` : null)
+  // issue #143：查询串拼接统一用 &（此前 diffVersion 与 refresh 各带一个 ?，产生双问号）
+  const diffQs = diffVersion ? `?version_id=${diffVersion}&refresh=${refresh}` : `?refresh=${refresh}`
+  const diff = useFetch(selVid ? `/api/v1/source-files/${selVid}/diff${diffQs}` : null)
   const versions = useFetch(selVid ? `/api/v1/source-files/${selVid}/versions?refresh=${refresh}` : null)
   const op = useDataOp(() => { setRefresh(r => r + 1); diff.refresh() })
 
@@ -26,7 +28,11 @@ export default function SourceDiff() {
     setDiffVersion('')
   }
   const adopt = (f) => op.submit(`/api/v1/source-files/${f.current_version}/versions`, {})
-  const restore = (f, vid) => op.submit(`/api/v1/source-files/${f.current_version}/versions/${vid}/restore`, {})
+  // issue #139：回退被 409 拒绝（磁盘已偏离当前版）时同样刷新 diff，引导重新决策
+  const restore = async (f, vid) => {
+    const res = await op.submit(`/api/v1/source-files/${f.current_version}/versions/${vid}/restore`, {})
+    if (!res.ok) { setRefresh(r => r + 1); diff.refresh() }
+  }
 
   const renderDiff = (s) => {
     if (!s) return <p className="note">选择文件查看 diff</p>

--- a/migrations/versions/f1a2b3c4d5e6_import_job.py
+++ b/migrations/versions/f1a2b3c4d5e6_import_job.py
@@ -1,0 +1,39 @@
+"""import_job 异步任务表（issue #138 · DESIGN §14.2 import-jobs）。
+
+revision: f1a2b3c4d5e6
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "f1a2b3c4d5e6"
+down_revision = "e3c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "import_job",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("provider", sa.String(), nullable=False),
+        # Postgres JSONB；测试 SQLite 由模型层 with_variant 兼容（迁移仅跑 PG）
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("status", sa.String(), nullable=True, server_default="pending"),
+        sa.Column("result", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(),
+                  nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint("provider IN ('company-info','labor-cost')",
+                           name="ck_import_provider"),
+        sa.CheckConstraint("status IN ('pending','running','done','failed')",
+                           name="ck_import_status"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("import_job")

--- a/tests/test_issue140_health_scope.py
+++ b/tests/test_issue140_health_scope.py
@@ -1,0 +1,103 @@
+"""issue #140 回归：健康复核范围化（§9.2d）+ findings 持久化进通知 + 异常不静默。
+
+- run_report/summarize 支持 from_year：H1/H2/H4/负余额只报告该年及以后；
+- record_recompute_done payload 携带 health_findings（crit 优先，截断 20 条）与
+  health_findings_total；health 自身异常 → payload["health_error"]（不再吞成 {}）。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core import health as health_mod
+from app.core.health import run_report, summarize
+from app.core.recompute import record_recompute_done
+from app.db import Base
+from app.model import (Account, Entity, IncomeStream, LedgerEntry, Notification,
+                       TimelineEvent)
+
+
+@pytest.fixture
+def session():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def _seed(session):
+    e = Entity(entity_type="person", name="Henri")
+    session.add(e)
+    session.flush()
+    acc = Account(entity_id=e.id, currency="BEF", bank=None)
+    session.add(acc)
+    session.flush()
+    # 一早一晚两笔负余额（H4/warn）
+    session.add(LedgerEntry(account_id=acc.id, date=date(1975, 12, 30),
+                            reason="早年透支", outflow=100, balance=-100, kind="expense"))
+    session.add(LedgerEntry(account_id=acc.id, date=date(2020, 12, 30),
+                            reason="近年透支", outflow=50, balance=-50, kind="expense"))
+    # 一早一晚两条「无收益流年份」时间线条目（H1/warn）
+    session.add(TimelineEvent(event_year=1950, title="早年事件", source_file="t.md"))
+    session.add(TimelineEvent(event_year=2020, title="近年事件", source_file="t.md"))
+    # H1 需要 income_years 非空才参与比对：给一个 1990 年收益流
+    session.add(IncomeStream(entity_id=e.id, stream_type="salary", group_key="g",
+                             currency="BEF", year=1990, amount=10, label="l",
+                             source_file="s.md"))
+    session.flush()
+
+
+def test_run_report_scopes_by_from_year(session):
+    _seed(session)
+    full = run_report(session)
+    assert {f["location"] for f in full if f["rule"] == "H1"} >= {
+        "时间线 1950「早年事件」", "时间线 2020「近年事件」"}
+    neg_years_full = sorted(f["location"] for f in full
+                            if f["level"] == "warn" and "负余额" in f["detail"])
+    assert len(neg_years_full) == 2
+
+    scoped = run_report(session, from_year=2000)
+    h1_locs = [f["location"] for f in scoped if f["rule"] == "H1"]
+    assert h1_locs == ["时间线 2020「近年事件」"]          # 早年条目被范围滤除
+    neg = [f for f in scoped if "负余额" in f["detail"]]
+    assert len(neg) == 1 and "2020" in neg[0]["location"]
+
+    s_full = summarize(session)
+    s_scope = summarize(session, from_year=2000)
+    assert s_full["H1"]["total"] > s_scope["H1"]["total"]
+
+
+def test_record_recompute_done_persists_findings(session):
+    _seed(session)
+    out = record_recompute_done(session, start_year=2000, reason="test")
+    n = session.get(Notification, out["notification_id"])
+    p = n.payload
+    assert p["start_year"] == 2000
+    assert isinstance(p["health"], dict) and "H4" in p["health"]
+    assert p["health_findings_total"] >= 1
+    assert any("负余额" in f["detail"] for f in p["health_findings"])
+    # crit 优先排序：若混有 crit，则其排前（此处仅 warn 也须合法）
+    levels = [f["level"] for f in p["health_findings"]]
+    assert levels == sorted(levels, key=lambda x: 0 if x == "crit" else 1)
+
+
+def test_record_recompute_done_does_not_swallow_errors(session, monkeypatch):
+    _seed(session)
+
+    def boom(s, from_year=None):
+        raise RuntimeError("health exploded")
+
+    monkeypatch.setattr(health_mod, "run_report", boom)
+    out = record_recompute_done(session, start_year=1990, reason="test")
+    n = session.get(Notification, out["notification_id"])
+    assert "health exploded" in n.payload["health_error"]
+    assert n.payload["health"] == {}

--- a/tests/test_issue141_calendar_cap.py
+++ b/tests/test_issue141_calendar_cap.py
@@ -1,0 +1,77 @@
+"""issue #141 回归：日历年上限收敛 app.config 单一来源，跨入上限年不再静默停滚。
+
+此前 range(from_year, 2026)（不含 2026）散落 leverage/snapshot/main 等十余处，
+余额滚动实际止于 2025。本文件验证：
+1. config 常量动态（>=2026 且随当前年推进）；
+2. leverage.recompute_one 能滚动到（monkeypatch 后的）上限年并回填年末余额；
+3. 各模块引用的上限与 config 一致。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+import app.core.leverage as leverage_mod
+from app.config import CALENDAR_MAX_YEAR, calendar_years
+from app.core.leverage import recompute_one
+from app.db import Base
+from app.model import Account, Entity, LedgerEntry, ReturnCurve
+
+
+@pytest.fixture
+def session():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    yield s
+    s.close()
+    engine.dispose()
+
+
+def test_config_bounds_dynamic():
+    import datetime
+    assert CALENDAR_MAX_YEAR >= 2026
+    assert CALENDAR_MAX_YEAR == max(2026, datetime.date.today().year + 1)
+    assert min(calendar_years()) == 1947
+    assert max(calendar_years()) == CALENDAR_MAX_YEAR
+
+
+@pytest.mark.parametrize("mod", ["app.api.ui_ops", "app.api.timeline",
+                                 "app.api.stock_events", "app.core.transfer"])
+def test_module_caps_follow_config(mod):
+    import importlib
+    m = importlib.import_module(mod)
+    val = getattr(m, "_YEAR_MAX", None) or getattr(m, "_MAX_YEAR", None)
+    assert val == CALENDAR_MAX_YEAR, f"{mod} 上限未跟随 config"
+
+
+def test_leverage_rolls_through_cap_year(session, monkeypatch):
+    """上限年有流水+收益值时，年末余额必须被复利回填（修复前循环止于 2025）。"""
+    monkeypatch.setattr(leverage_mod, "CALENDAR_MAX_YEAR", 2028)
+    e = Entity(entity_type="person", name="Investor",
+               fields={"compound": True, "return_region": "欧洲", "risk_lvl": "R3"})
+    session.add(e)
+    session.flush()
+    acc = Account(entity_id=e.id, currency="EUR", bank=None)
+    session.add(acc)
+    session.flush()
+    session.add(LedgerEntry(account_id=acc.id, date=date(2025, 12, 30),
+                            reason="期初", inflow=1000, balance=1000, kind="income"))
+    session.add(LedgerEntry(account_id=acc.id, date=date(2027, 6, 1),
+                            reason="年中流入", inflow=100, kind="income"))
+    session.add(ReturnCurve(country="欧洲", risk_lvl="R3", year=2027, rate=10.0))
+    session.flush()
+
+    res = recompute_one(session, acc.id, from_year=2026)
+    assert res["updated"] >= 1
+    row = session.execute(select(LedgerEntry).where(
+        LedgerEntry.date == date(2027, 6, 1))).scalar_one()
+    # 2027 年 rate=10% × 杠杆 2×（1989 起）=20% → 1000×1.2 + 流入 100 = 1300
+    assert abs(float(row.balance) - 1300.0) < 1e-6

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,0 +1,136 @@
+"""issue #138 回归：异步 job 资源（import-jobs / recompute-jobs · DESIGN §14.2 方案A）。
+
+- POST 建 pending → 后台执行（BackgroundTasks 在 TestClient 内同步跑完）→ done；
+- recompute job 复用任务行收尾 + 通知携带健康摘要；GET /{id} 暴露 health；
+- import job：provider 白名单 422 / 假 runner 全链 done(result)；
+- DELETE 仅 pending 可取消（204→409），404 语义。
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.core.jobs as jobs_mod
+from app.api.app import app
+from app.api.deps import get_db
+from app.db import Base
+from app.model import Account, Entity, LedgerEntry, Notification, RecomputeJob
+
+
+@pytest.fixture
+def env():
+    from sqlalchemy import BigInteger, Integer
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    def _override():
+        s = Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    # 后台执行器注入同一 SQLite 工厂（替代 make_sessionmaker(env) 的真实 PG）
+    jobs_mod.make_sessionmaker = lambda env: Session
+
+    app.dependency_overrides[get_db] = _override
+    with TestClient(app) as c:
+        yield c, Session
+    app.dependency_overrides.clear()
+    engine.dispose()
+
+
+def test_recompute_job_full_lifecycle(env):
+    c, Session = env
+    s = Session()
+    e = Entity(entity_type="person", name="Henri")
+    s.add(e)
+    s.flush()
+    acc = Account(entity_id=e.id, currency="BEF", bank=None)
+    s.add(acc)
+    s.flush()
+    s.add(LedgerEntry(account_id=acc.id, date=date(1990, 12, 30), reason="x",
+                      inflow=100, balance=100, kind="income"))
+    s.commit()
+    s.close()
+
+    r = c.post("/api/v1/recompute-jobs", json={"start_year": 1980, "reason": "test"})
+    assert r.status_code == 202
+    jid = r.json()["id"]
+    assert r.json()["status"] == "pending"
+
+    detail = c.get(f"/api/v1/recompute-jobs/{jid}").json()
+    assert detail["status"] == "done"
+    assert detail["health"] is not None and "H4" in detail["health"]
+
+    # 任务行复用：不产生第二个 job 行；通知挂本 job
+    s2 = Session()
+    assert s2.get(RecomputeJob, jid).status == "done"
+    n = s2.query(Notification).filter(Notification.job_id == jid).one_or_none()
+    assert n is not None and n.kind == "recompute-done"
+    s2.close()
+
+    lst = c.get("/api/v1/recompute-jobs", params={"status": "done"}).json()
+    assert any(x["id"] == jid for x in lst["items"])
+
+
+def test_import_job_provider_whitelist_and_fake_runner(env, monkeypatch):
+    c, _Session = env
+
+    r = c.post("/api/v1/import-jobs", json={"provider": "nope"})
+    assert r.status_code == 422
+
+    def fake_runner(s, payload):
+        return {"stats": {"companies": 2}}
+
+    monkeypatch.setattr(jobs_mod, "_default_runner", lambda provider: fake_runner)
+    r = c.post("/api/v1/import-jobs", json={"provider": "company-info", "payload": {}})
+    assert r.status_code == 202
+    jid = r.json()["id"]
+    detail = c.get(f"/api/v1/import-jobs/{jid}").json()
+    assert detail["status"] == "done"
+    assert detail["result"] == {"stats": {"companies": 2}}
+    assert detail["error"] is None
+
+
+def test_import_job_failure_marks_failed(env, monkeypatch):
+    c, Session = env
+
+    def boom(s, payload):
+        raise RuntimeError("外部系统不可达")
+
+    monkeypatch.setattr(jobs_mod, "_default_runner", lambda provider: boom)
+    r = c.post("/api/v1/import-jobs", json={"provider": "labor-cost",
+                                            "payload": {"year": 2020}})
+    jid = r.json()["id"]
+    detail = c.get(f"/api/v1/import-jobs/{jid}").json()
+    assert detail["status"] == "failed"
+    assert "RuntimeError" in (detail["error"] or "")
+
+
+def test_delete_cancel_semantics(env):
+    c, Session = env
+    # pending → 取消成功
+    s = Session()
+    j = RecomputeJob(start_year=1990, reason="t", status="pending")
+    s.add(j)
+    s.commit()
+    jid = j.id
+    s.close()
+    assert c.delete(f"/api/v1/recompute-jobs/{jid}").status_code == 204
+    # 已取消（failed）→ 再删 409
+    assert c.delete(f"/api/v1/recompute-jobs/{jid}").status_code == 409
+    # 不存在 → 404
+    assert c.delete("/api/v1/recompute-jobs/99999").status_code == 404

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -111,6 +111,37 @@ def test_restore_path_traversal_rejected(db, tmp_path):
     assert not (tmp_path.parent / "escape.md").exists()   # 未写越权
 
 
+def test_restore_blocked_when_disk_diverged_from_current(db, src):
+    """issue #139：磁盘内容已偏离当前生效版 → RestoreConflict，绝不无提示覆盖。"""
+    cfg, tmp = src
+    _seed_version(db, content="OLD v1\n", version=1, current=False)
+    _seed_version(db, content="NEW v2\n", version=2, current=True)
+    (tmp / "a.md").write_text("NEW v2\n", encoding="utf-8")
+    old = db.execute(select(SourceFileVersion).where(
+        SourceFileVersion.version == 1)).scalar_one()
+    # 数据调整员在决策期间又手改了磁盘
+    (tmp / "a.md").write_text("THIRD-PARTY EDIT\n", encoding="utf-8")
+    with pytest.raises(versioning.RestoreConflict):
+        restore_version(db, cfg, "a.md", old.id)
+    assert (tmp / "a.md").read_text(encoding="utf-8") == "THIRD-PARTY EDIT\n"   # 未被覆盖
+    v1 = db.execute(select(SourceFileVersion).where(
+        SourceFileVersion.version == 1)).scalar_one()
+    assert v1.is_current is False                        # 版本状态未变
+
+
+def test_restore_allowed_when_disk_matches_current(db, src):
+    """issue #139：磁盘与当前版一致（正常回退场景）→ 照常复原。"""
+    cfg, tmp = src
+    _seed_version(db, content="OLD v1\n", version=1, current=False)
+    _seed_version(db, content="NEW v2\n", version=2, current=True)
+    (tmp / "a.md").write_text("NEW v2\n", encoding="utf-8")
+    old = db.execute(select(SourceFileVersion).where(
+        SourceFileVersion.version == 1)).scalar_one()
+    r = restore_version(db, cfg, "a.md", old.id)
+    assert r["status"] == "restored"
+    assert (tmp / "a.md").read_text(encoding="utf-8") == "OLD v1\n"
+
+
 def test_adopt_wires_force_import_and_notifies(db, src, monkeypatch):
     cfg, _ = src
     _seed_version(db, content="OLD\n", version=1, current=True)


### PR DESCRIPTION
## 二轮审计 P1 批次（#146）

| Issue | 内容 |
|---|---|
| #138 | **定案方案A**：import_job 表 + core/jobs 执行器 + import/recompute-jobs 共 8 端点 + 前端触发/轮询/job 化 |
| #139 | §11.3 restore 前置校验：磁盘偏离当前版 → 409，绝不无提示覆盖 |
| #140 | health 范围化（§9.2d）+ findings 持久化 + 横幅「查看影响」入口 |
| #141 | CALENDAR_MAX_YEAR 动态上限收敛，11 处字面量清理 |

**测试**：+4 个测试文件；P1 树 checkpoint 97 passed。

Refs #138 #139 #140 #141 · 承 #146