### PR TITLE
fix(p0): 四轮审计 P0 修复合集（#160-#165，跟踪索引 #172）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,10 @@ __pycache__/
 frontend/node_modules/
 frontend/dist/
 
-# 数据输入/覆盖层目录（仅保留目录占位 .gitkeep）
-data/
-!data/
-!data/*/
+# 数据输入/覆盖层/导出目录（仅保留目录占位 .gitkeep；四轮审计 #165：
+# 旧写法 `data/` + `!data/` 正负抵消致内容未被忽略，导出产物会被误提交）
+data/**
+!data/**/
 !data/**/.gitkeep
 
 # macOS

--- a/app/api/movie_events.py
+++ b/app/api/movie_events.py
@@ -16,13 +16,25 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
-from app.model import LedgerEntry, MovieEvent
+from app.model import Account, LedgerEntry, MovieEvent
 
 router = APIRouter(prefix="/api/v1", tags=["movie-events"])
 
 
 class LinkIn(BaseModel):
     account_id: int
+
+
+def _require_same_currency(db: Session, event_currency: str | None, account_id: int):
+    """PRD §6.8 第3类铁律（四轮审计 #164）：同币种才连、不换算；不符则不可关联。"""
+    acc = db.get(Account, account_id)
+    if not acc:
+        raise HTTPException(404, "account not found")
+    ev_cur = event_currency or "USD"
+    if acc.currency != ev_cur:
+        raise HTTPException(
+            422, f"同币种才可关联（不换算）：事件 {ev_cur} ≠ 账户 {acc.currency}")
+    return acc
 
 
 def _me(movie: MovieEvent) -> dict:
@@ -88,6 +100,7 @@ def link_movie(movie_id: int, body: LinkIn, db: Session = Depends(get_db)):
         raise HTTPException(404, "movie event not found")
     if m.linked_account_id is not None:
         return {"linked": True, "skipped": True, "account_id": m.linked_account_id}
+    _require_same_currency(db, m.currency, body.account_id)   # issue #164
     written = _write_movie_ledger(m, body.account_id, db)
     m.linked_account_id = body.account_id
     m.linked_at = datetime.now()

--- a/app/api/stock_events.py
+++ b/app/api/stock_events.py
@@ -27,9 +27,21 @@ from app.core.snapshot import rebuild_snapshots
 from app.core.stock_cost import (
     apply_buy, apply_dividend, apply_passive_uplift, apply_sell,
 )
-from app.model import HoldingEvent, StockEvent
+from app.model import Account, HoldingEvent, StockEvent
 
 router = APIRouter(prefix="/api/v1", tags=["stock-events"])
+
+
+def _require_same_currency(db: Session, event_currency: str | None, account_id: int):
+    """PRD §6.8 第3类铁律（四轮审计 #164）：同币种才连、不换算；不符则不可关联。"""
+    acc = db.get(Account, account_id)
+    if not acc:
+        raise HTTPException(404, "account not found")
+    ev_cur = event_currency or "USD"
+    if acc.currency != ev_cur:
+        raise HTTPException(
+            422, f"同币种才可关联（不换算）：事件 {ev_cur} ≠ 账户 {acc.currency}")
+    return acc
 
 
 class AssociateIn(BaseModel):
@@ -121,6 +133,7 @@ def associate_stock_event(body: AssociateIn, db: Session = Depends(get_db)):
         return {"associated": True, "skipped": True, "account_id": se.linked_account_id}
     if se.event_type != "buy" or not se.shares or not se.unit_price:
         raise HTTPException(422, "仅 buy 事件可关联；sell/dividend 请用对应动作端点")
+    _require_same_currency(db, se.currency, body.account_id)   # issue #164
     try:
         r = apply_buy(db, entity_id=body.entity_id, company=se.company, ticker=se.ticker,
                       date=se.date, unit_price=float(se.unit_price), shares=float(se.shares),

--- a/app/core/transfer.py
+++ b/app/core/transfer.py
@@ -52,7 +52,10 @@ def _fx_rate(session: Session, fx_from: str, fx_to: str, year: int) -> Optional[
         ).limit(1)
     ).first()
     if row is not None and row[0] is not None:
-        return Decimal(str(row[0]))
+        rate = Decimal(str(row[0]))
+        if rate > 0:                     # issue #161：正向行同样拒绝 0/负值（防 amt×0 资金蒸发）
+            return rate
+        return None                      # 非法汇率行视同缺失 → 上层 422
     rrow = session.execute(
         select(ExchangeRate.rate).where(
             ExchangeRate.fx_from == fx_to,

--- a/app/export/pdf.py
+++ b/app/export/pdf.py
@@ -2,6 +2,9 @@
 
 reportlab 实现：家族总资产年度曲线（reportlab.graphics 内嵌折线图）
 + 实体/账户/财务计数摘要 + 编年史近段表。只读 DB，产物由调用方写 exports_dir。
+
+四轮审计 #160：reportlab 默认 Helvetica 不含 CJK 字形（中文全部渲染为 notdef
+方块）——统一注册 Adobe CID 字体 STSong-Light 并应用于全部样式/表格/图表标注。
 """
 from __future__ import annotations
 
@@ -15,6 +18,14 @@ from app.export.render import effective_timeline, family_total_series
 from app.model import Account, Entity, FinanceEntry
 
 _PAGE_W, _PAGE_H = 842, 595   # A4 landscape
+CJK_FONT = "STSong-Light"     # Adobe CID 内置字体，viewer 端渲染，无需字体文件
+
+
+def _register_cjk_font() -> None:
+    from reportlab.pdfbase import pdfmetrics
+    from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+    if CJK_FONT not in pdfmetrics.getRegisteredFontNames():
+        pdfmetrics.registerFont(UnicodeCIDFont(CJK_FONT))
 
 
 def render_pdf(db: Session) -> bytes:
@@ -26,9 +37,12 @@ def render_pdf(db: Session) -> bytes:
     from reportlab.lib.styles import getSampleStyleSheet
     from reportlab.lib.units import mm
 
+    _register_cjk_font()
     buf = io.BytesIO()
     doc = SimpleDocTemplate(buf, pagesize=(_PAGE_W, _PAGE_H), title="家族财富报告")
     styles = getSampleStyleSheet()
+    for name in ("Title", "Heading2", "Normal"):
+        styles[name].fontName = CJK_FONT   # issue #160：全样式换 CJK 字体
     story: list = []
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -48,7 +62,8 @@ def render_pdf(db: Session) -> bytes:
         [str(n_ent), str(n_acc), str(n_fin), f"{total_now:,.2f}"],
     ], colWidths=[40 * mm] * 4)
     summary.setStyle(TableStyle([("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-                                 ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke)]))
+                                 ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
+                                 ("FONTNAME", (0, 0), (-1, -1), CJK_FONT)]))
     story += [summary, Spacer(1, 8 * mm)]
 
     # ---- 家族总资产年度曲线（图表内嵌）----
@@ -59,7 +74,7 @@ def render_pdf(db: Session) -> bytes:
         chart.width, chart.height = 240 * mm, 70 * mm
         chart.data = [[v for _, v in series]]
         chart.categoryAxis.categoryNames = [str(y) for y, _ in series]
-        chart.categoryAxis.labels.fontName = "Helvetica"
+        chart.categoryAxis.labels.fontName = CJK_FONT
         chart.categoryAxis.labels.fontSize = 6
         chart.valueAxis.valueMin = min(v for _, v in series) or 0
         chart.lines[0].strokeColor = colors.HexColor("#2563eb")
@@ -67,7 +82,7 @@ def render_pdf(db: Session) -> bytes:
         drawing.add(chart)
         drawing.add(String(0, 80 * mm,
                            f"{series[0][0]}–{series[-1][0]} · 共 {len(series)} 年",
-                           fontSize=8))
+                           fontName=CJK_FONT, fontSize=8))
         story.append(drawing)
     else:
         story.append(Paragraph("（无 family:total 快照——先运行 snapshot 重建）",
@@ -85,6 +100,7 @@ def render_pdf(db: Session) -> bytes:
     tbl = Table(rows, colWidths=[18 * mm, 24 * mm, 90 * mm, 108 * mm], repeatRows=1)
     tbl.setStyle(TableStyle([("GRID", (0, 0), (-1, -1), 0.4, colors.grey),
                              ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
+                             ("FONTNAME", (0, 0), (-1, -1), CJK_FONT),
                              ("FONTSIZE", (0, 0), (-1, -1), 7)]))
     story.append(tbl)
 

--- a/app/ingest/normalize.py
+++ b/app/ingest/normalize.py
@@ -208,10 +208,27 @@ def apply_user_date_rules(raw: str) -> tuple[date, str] | None:
     return None
 
 
+# 中文币种词 ↔ 缩写配对（issue #162：节标题常同时出现多个缩写，
+# 如 `五、欧元 EUR（2002年BEF+NLG结转）`——配对命中的缩写才可信）。
+_ZH_CURRENCY_PAIRS = (
+    ("欧元", "EUR"), ("美元", "USD"), ("丹麦克朗", "DKK"), ("瑞典克朗", "SEK"),
+    ("比利时法郎", "BEF"), ("卢森堡法郎", "LUF"), ("荷兰盾", "NLG"),
+    ("港币", "HKD"), ("港元", "HKD"), ("人民币", "CNY"),
+)
+
+
 def currency_from(seg_title: str) -> str | None:
-    """从分节标题（如 `## 一、BEF（祖父）`）抽币种。"""
+    """从分节标题（如 `## 一、BEF（祖父）`）抽币种。
+
+    「中文币种词 + 缩写」配对命中优先（issue #162）；无中文词时回退首个缩写扫描
+    （兼容 `## 一、BEF（祖父）` 旧式标题）。
+    """
+    t = seg_title or ""
+    for zh, abbr in _ZH_CURRENCY_PAIRS:
+        if zh in t and abbr in t.upper():
+            return abbr
     for c in _CURRENCIES:
-        if c in (seg_title or "").upper():
+        if c in t.upper():
             return c
     return None
 

--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -211,11 +211,14 @@ def parse_return_table(path: Path) -> list[dict]:
     """支持两种格式（欧洲/美国/英国=逐行 `- R1：x%`；香港/中国=竖线分隔单行 `R1：x｜R2：y｜…`）。
 
     年份来自 `#### 1999（…）` / `## 1999年` 标题。
+    四轮审计 #163：每 (year) 集满 R1-R5 五档即封盘——文末「分阶段复合年化」附录
+    （阶段N/全周期行）与末年明细同 year 且重复，集满后一律忽略。
     """
     lines = _lines(path)
     recs: list[dict] = []
     year = None
     region = _region_from_file(path.name)
+    seen: dict[int, set[int]] = {}   # year -> 已入库 risk_lvl 集
     for line in lines:
         # 年份标题（多级 # 均可）
         ym = re.search(r"^#+\s*(?:\d{4}[-–]\d{4}\s+)?(19|20)\d{2}", line)
@@ -226,17 +229,22 @@ def parse_return_table(path: Path) -> list[dict]:
         # 格式A：竖线分隔 `R1：4.35｜R2：6.12｜R3：8.64｜R4：68.82｜R5：76.35`
         vm = re.finditer(r"R([1-5])\s*[:：]\s*([-+]?\d+(?:\.\d+)?)", line)
         pairs = [(int(m.group(1)), parse_number(m.group(2))) for m in vm]
-        if pairs and len(pairs) >= 3 and year:
-            for rl, rate in pairs:
-                recs.append({"country": region, "risk_lvl": f"R{rl}",
-                             "year": year, "rate": rate, "source_file": path.name})
+        done = seen.setdefault(year if year is not None else -1, set())
+        if pairs and len(pairs) >= 3 and year and len(done) < 5:
+            fresh = [(rl, rate) for rl, rate in pairs if rl not in done]
+            if fresh:
+                for rl, rate in fresh:
+                    recs.append({"country": region, "risk_lvl": f"R{rl}",
+                                 "year": year, "rate": rate, "source_file": path.name})
+                    done.add(rl)
             continue
         # 格式B：逐行 `- R1：x%`
         rm = re.match(r"^\s*[-–]\s*R([1-5])[:：]\s*([-+\d.]+)\s*%?", line)
-        if rm and year:
+        if rm and year and int(rm.group(1)) not in done:
             recs.append({"country": region, "risk_lvl": f"R{rm.group(1)}",
                          "year": year, "rate": parse_number(rm.group(2)),
                          "source_file": path.name})
+            done.add(int(rm.group(1)))
     return recs
 
 

--- a/frontend/src/screens/Movies.jsx
+++ b/frontend/src/screens/Movies.jsx
@@ -35,13 +35,15 @@ export default function Movies() {
 
         {linking && (
           <div style={{ margin: '8px 0' }}>
-            <span className="note">选择关联账户：</span>
+            <span className="note">选择关联账户（同币种 {linking.currency || 'USD'} · PRD §6.8）：</span>
             <select value={accSel} onChange={e => setAccSel(e.target.value)}>
               <option value="">— 选账户 —</option>
-              {(accounts.data?.items || []).map(a => (
+              {(accounts.data?.items || []).filter(a => a.currency === (linking.currency || 'USD')).map(a => (
                 <option key={a.id} value={a.id}>acct#{a.id} {a.currency}{a.status === 'closed' ? ' (已关)' : ''}</option>
               ))}
             </select>
+            {(accounts.data?.items || []).every(a => a.currency !== (linking.currency || 'USD')) &&
+              <span className="warn">无同币种 active/closed 账户可关联</span>}
             <button className="primary" disabled={!accSel || op.busy} onClick={doLink}>确认关联</button>
             <button className="ghost" onClick={() => { setLinking(null); setAccSel('') }}>取消</button>
           </div>

--- a/frontend/src/screens/Stock.jsx
+++ b/frontend/src/screens/Stock.jsx
@@ -77,21 +77,26 @@ export default function Stock() {
         </table>
 
         <h4>导入的待关联 buy 事件</h4>
-        {assocId && (
-          <div style={{ margin: '8px 0' }}>
-            <span className="note">选择主体 & 账户：</span>
-            <select value={entSel} onChange={e => setEntSel(e.target.value)}>
-              <option value="">— 主体 —</option>
-              {entities.map(e => <option key={e} value={e}>entity#{e}</option>)}
-            </select>
-            <select value={accSel} onChange={e => setAccSel(e.target.value)}>
-              <option value="">— 账户 —</option>
-              {accts.map(a => <option key={a.id} value={a.id}>acct#{a.id} {a.currency}</option>)}
-            </select>
-            <button className="primary" disabled={!entSel || !accSel || op.busy} onClick={doAssociate}>确认关联</button>
-            <button className="ghost" onClick={() => { setAssocId(null); setEntSel(''); setAccSel('') }}>取消</button>
-          </div>
-        )}
+        {assocId && (() => {
+          const evCur = (events.data?.items || []).find(e => e.id === assocId)?.currency || 'USD'
+          return (
+            <div style={{ margin: '8px 0' }}>
+              <span className="note">选择主体 & 账户（同币种 {evCur} · PRD §6.8）：</span>
+              <select value={entSel} onChange={e => setEntSel(e.target.value)}>
+                <option value="">— 主体 —</option>
+                {entities.map(e => <option key={e} value={e}>entity#{e}</option>)}
+              </select>
+              <select value={accSel} onChange={e => setAccSel(e.target.value)}>
+                <option value="">— 账户 —</option>
+                {accts.filter(a => a.currency === evCur).map(a => <option key={a.id} value={a.id}>acct#{a.id} {a.currency}</option>)}
+              </select>
+              {accts.length > 0 && accts.every(a => a.currency !== evCur) &&
+                <span className="warn">无同币种账户可关联</span>}
+              <button className="primary" disabled={!entSel || !accSel || op.busy} onClick={doAssociate}>确认关联</button>
+              <button className="ghost" onClick={() => { setAssocId(null); setEntSel(''); setAccSel('') }}>取消</button>
+            </div>
+          )
+        })()}
         <table style={{ borderCollapse: 'collapse', width: '100%' }}>
           <thead><tr><th>公司</th><th>日期</th><th>股数</th><th>单价</th><th>金额(万USD)</th><th>占比</th><th></th></tr></thead>
           <tbody>

--- a/tests/test_issue160_165_p0.py
+++ b/tests/test_issue160_165_p0.py
@@ -1,0 +1,242 @@
+"""四轮审计 P0 修复回归（issue #160-#164）。
+
+- #160 PDF 中文：产物字体资源必须含 CJK CID 字体（STSong-Light），杜绝 notdef 方块假绿
+- #161 换汇正向汇率行 rate=0/负 → 视缺失 422，两账户余额不变
+- #162 currency_from 中文币种词+缩写配对优先（多币种标题不再误判）
+- #163 return_table 复合年化附录不再污染末年（每年集满 R1-R5 封盘）
+- #164 movie link / stock associate 跨币关联 422、同币放行
+"""
+from __future__ import annotations
+
+import re
+import zlib
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import BigInteger, Integer, create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api.app import app
+from app.api.deps import get_db
+from app.db import Base
+from app.export import pdf as pdf_mod
+from app.ingest.normalize import currency_from
+from app.ingest.parsers import parse_return_table
+from app.model import (Account, Entity, ExchangeRate, LedgerEntry, MovieEvent,
+                       StockEvent)
+
+
+@pytest.fixture
+def db():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+# ---- #160 PDF 中文字体 ----
+class TestPdfCjk:
+    def test_pdf_registers_cjk_font(self):
+        class FakeQ:
+            def scalar(self): return 3
+            def __iter__(self): return iter([])
+
+        class FakeDB:
+            def execute(self, *a, **k): return FakeQ()
+
+        orig_series, orig_tl = pdf_mod.family_total_series, pdf_mod.effective_timeline
+        pdf_mod.family_total_series = lambda db: [(1990, 100.0), (1991, 250.0)]
+        pdf_mod.effective_timeline = lambda db: []
+        try:
+            data = pdf_mod.render_pdf(FakeDB())
+        finally:
+            pdf_mod.family_total_series = orig_series
+            pdf_mod.effective_timeline = orig_tl
+        fonts = set(re.findall(rb"/BaseFont\s*/([A-Za-z0-9\-]+)", data))
+        assert b"STSong-Light" in fonts, f"CJK 字体未注册，fonts={fonts}"
+        # 不再是纯 Helvetica 族产物（修复前实测仅 Helvetica/Helvetica-Bold/Times-Roman/ZapfDingbats）
+        assert any(b"Helvetica" not in f for f in fonts)
+
+    def test_register_idempotent(self):
+        pdf_mod._register_cjk_font()
+        pdf_mod._register_cjk_font()   # 二次注册不抛
+
+
+# ---- #161 换汇正向 rate=0/负防御 ----
+class TestTransferZeroRate:
+    def test_zero_positive_rate_row_rejected(self, db):
+        from app.core.invest import ValidationError
+        from app.core.transfer import transfer
+        e = Entity(entity_type="person", name="T161")
+        db.add(e)
+        db.flush()
+        src = Account(entity_id=e.id, currency="BEF")
+        dst = Account(entity_id=e.id, currency="EUR")
+        db.add_all([src, dst])
+        db.flush()
+        db.add(LedgerEntry(account_id=src.id, date=date(1999, 6, 1),
+                           reason="期初", inflow=1000, balance=1000, kind="income"))
+        db.flush()
+        # 非法正向行：BEF→EUR rate=0（修复前 target_amount=amt×0=0 资金蒸发）
+        db.add(ExchangeRate(fx_from="BEF", fx_to="EUR", year=1999, rate=0))
+        db.commit()
+        with pytest.raises(ValidationError) as ei:
+            transfer(db, source_account_id=src.id, target_entity_id=e.id,
+                     target_currency="EUR", amount=400, year=1999)
+        assert "汇率" in str(ei.value)
+        db.rollback()
+        # 两账户余额均不变
+        assert len(db.execute(select(LedgerEntry).where(
+            LedgerEntry.account_id == src.id)).scalars().all()) == 1
+        assert not db.execute(select(LedgerEntry).where(
+            LedgerEntry.account_id == dst.id)).scalars().all()
+
+    def test_negative_positive_rate_row_rejected(self, db):
+        from app.core.invest import ValidationError
+        from app.core.transfer import transfer
+        e = Entity(entity_type="person", name="T161b")
+        db.add(e)
+        db.flush()
+        src = Account(entity_id=e.id, currency="BEF")
+        db.add(src)
+        db.flush()
+        db.add(LedgerEntry(account_id=src.id, date=date(1999, 6, 1),
+                           reason="期初", inflow=1000, balance=1000, kind="income"))
+        db.add(ExchangeRate(fx_from="BEF", fx_to="EUR", year=1999, rate=-40))
+        db.commit()
+        with pytest.raises(ValidationError):
+            transfer(db, source_account_id=src.id, target_entity_id=e.id,
+                     target_currency="EUR", amount=400, year=1999)
+
+
+# ---- #162 currency_from 配对优先 ----
+class TestCurrencyFromPairs:
+    def test_multicurrency_titles(self):
+        # 真实《模版.md》两节标题（修复前分别误判 BEF/DKK）
+        assert currency_from("五、欧元 EUR（2002年BEF+NLG结转）") == "EUR"
+        assert currency_from("六、美元 USD（DKK+SEK 1991年底转入）") == "USD"
+
+    def test_legacy_single_abbr_title(self):
+        assert currency_from("## 一、BEF（祖父）") == "BEF"
+        assert currency_from("二、SEK（祖母）") == "SEK"
+
+    def test_no_currency_returns_none(self):
+        assert currency_from("三、附注说明") is None
+        assert currency_from("") is None
+
+
+# ---- #163 return_table 封盘 ----
+class TestReturnTableCap:
+    def test_composite_annex_not_polluting_last_year(self, tmp_path: Path):
+        p = tmp_path / "1999-2025 香港R1-R5投资风险分级收益测算表.md"
+        p.write_text(
+            "# 香港市场R1-R5投资风险分级收益测算（1999–2025）\n"
+            "#### 2024（上年）\n"
+            "R1：1.00｜R2：2.00｜R3：3.00｜R4：4.00｜R5：5.00\n"
+            "#### 2025（全球降息周期开启）\n"
+            "R1：2.05｜R2：5.17｜R3：7.64｜R4：14.29｜R5：16.71｜备注：真实行\n"
+            "\n## 五、分阶段复合年化收益测算\n"
+            "### 阶段1：1999–2007（9年）\n"
+            "R1：2.46%｜R2：3.67%｜R3：10.14%｜R4：12.07%｜R5：18.62%\n"
+            "### 全周期：1999–2025（27年完整周期）\n"
+            "R1：1.49%｜R2：3.61%｜R3：6.27%｜R4：3.55%｜R5：9.85%\n",
+            encoding="utf-8")
+        rows = parse_return_table(p)
+        y2025 = [r for r in rows if r["year"] == 2025]
+        y2024 = [r for r in rows if r["year"] == 2024]
+        assert len(y2025) == 5, f"复合年化污染末年：{y2025}"
+        assert {r["rate"] for r in y2025} == {2.05, 5.17, 7.64, 14.29, 16.71}
+        assert len(y2024) == 5 and all(r["risk_lvl"] in {"R1", "R2", "R3", "R4", "R5"} for r in rows)
+
+    def test_format_b_still_complete(self, tmp_path: Path):
+        """欧洲式逐行格式不受封盘影响。"""
+        p = tmp_path / "1983-2025 英国R1-R5投资风险分级收益测算表.md"
+        lines = ["# 英国测算", "#### 1983（起点）"]
+        lines += [f"- R{i}：{i}.1%" for i in range(1, 6)]
+        lines += ["### 附录：全周期", "- R1：9.9%"]   # 同年重复档应被忽略
+        p.write_text("\n".join(lines), encoding="utf-8")
+        rows = parse_return_table(p)
+        assert len(rows) == 5 and sum(1 for r in rows if r["risk_lvl"] == "R1") == 1
+
+
+# ---- #164 同币种关联铁律 ----
+class TestSameCurrencyLink:
+    @pytest.fixture(autouse=True)
+    def _seed(self, db):
+        self.db = db
+        e = Entity(entity_type="person", name="T164")
+        db.add(e)
+        db.flush()
+        self.bef_acc = Account(entity_id=e.id, currency="BEF")
+        self.usd_acc = Account(entity_id=e.id, currency="USD")
+        db.add_all([self.bef_acc, self.usd_acc])
+        db.flush()
+        self.movie = MovieEvent(title="泰坦尼克号", currency="USD",
+                                investment_date=date(1995, 6, 1),
+                                investment_total=100.0)
+        self.stock_evt = StockEvent(company="虎牙", date=date(2018, 5, 7),
+                                    event_type="buy", shares=10, unit_price=2.0,
+                                    currency="USD")
+        db.add_all([self.movie, self.stock_evt])
+        db.commit()
+        app.dependency_overrides[get_db] = lambda: db
+        yield
+        app.dependency_overrides.pop(get_db, None)
+
+    def _client(self):
+        return TestClient(app)
+
+    def test_movie_cross_currency_link_422(self):
+        with self._client() as c:
+            r = c.post(f"/api/v1/movie-events/{self.movie.id}/link",
+                       json={"account_id": self.bef_acc.id})
+            assert r.status_code == 422
+            assert "BEF" in r.json()["detail"] and "USD" in r.json()["detail"]
+            # 未写任何 ledger、未置 linked
+            assert not db_ledger(self.db, self.bef_acc.id)
+            assert self.db.get(MovieEvent, self.movie.id).linked_account_id is None
+
+    def test_movie_same_currency_link_ok(self):
+        with self._client() as c:
+            r = c.post(f"/api/v1/movie-events/{self.movie.id}/link",
+                       json={"account_id": self.usd_acc.id})
+            assert r.status_code == 200 and r.json()["linked"] is True
+
+    def test_movie_missing_account_404(self):
+        with self._client() as c:
+            assert c.post(f"/api/v1/movie-events/{self.movie.id}/link",
+                          json={"account_id": 999999}).status_code == 404
+
+    def test_stock_associate_cross_currency_422(self):
+        with self._client() as c:
+            r = c.post("/api/v1/stock-events/associate",
+                       json={"stock_event_id": self.stock_evt.id,
+                             "entity_id": self.usd_acc.entity_id,
+                             "account_id": self.bef_acc.id})
+            assert r.status_code == 422
+            assert self.db.get(StockEvent, self.stock_evt.id).linked_account_id is None
+
+    def test_stock_associate_same_currency_ok(self):
+        with self._client() as c:
+            r = c.post("/api/v1/stock-events/associate",
+                       json={"stock_event_id": self.stock_evt.id,
+                             "entity_id": self.usd_acc.entity_id,
+                             "account_id": self.usd_acc.id})
+            assert r.status_code == 200 and r.json().get("associated") is True
+
+
+def db_ledger(db, account_id):
+    return db.execute(select(LedgerEntry).where(
+        LedgerEntry.account_id == account_id)).scalars().all()


### PR DESCRIPTION
## 概要

四轮全量对照审计的 6 个确认缺陷修复（跟踪索引 #172）。pytest **516 passed**（+14 新回归），vite build 通过。

| Issue | 缺陷 | 修法 |
|---|---|---|
| #160 | PDF 中文全部渲染黑色方块（Helvetica 无 CJK 字形，实测 `(nnnnnn) Tj`） | 注册 `UnicodeCIDFont('STSong-Light')` 应用于全部样式/表格/图表；测试升级断言字体资源（旧 %PDF 魔数断言为假绿） |
| #161 | 换汇正向汇率行 rate=0/负未防御 → `amt×0=0` 资金蒸发 | `_fx_rate` 正向补 `rate>0`，非法视缺失 → 422；两账户余额不变用例 |
| #162 | bank 节标题多币种误判（实测 EUR节→BEF、USD节→DKK，《模版.md》89 行流水地雷） | `currency_from` 中文币种词↔缩写**配对优先**，无中文词回退旧逻辑 |
| #163 | return_table 复合年化附录污染末年（香港/中国 2025 各 30 行应 5 行） | 每 year 集满 R1-R5 即封盘；格式A/B 双路生效；真实结构 fixture 断言 |
| #164 | 事件关联「同币种才连、不换算」铁律三层缺失（PRD §6.8 第3类） | movie link / stock associate 服务端比对事件币种 vs 账户币种（422 附两侧币种）；前端下拉按事件币种过滤 + 空态提示。注：手动 buy/sell/dividend 无事件币种概念，不在该铁律范围 |
| #165 | .gitignore data 段正负抵消，导出产物 check-ignore 未命中（误提交风险） | 重写为 `data/**` + 反白目录/`.gitkeep`；check-ignore 全命中 |

## 验证

```
APP_ENV=test pytest -q   → 516 passed（基线 502 + 新增 14）
frontend vite build      → ✓
git check-ignore         → data/exports* 与 input-dev 内容全部命中
```

Closes #160, closes #161, closes #162, closes #163, closes #164, closes #165