### PR TITLE
fix(p1-p3): 四轮审计 P1-P3 修复合集（#166-#171，跟踪索引 #172）

### DIFF
--- a/app/api/date_rules.py
+++ b/app/api/date_rules.py
@@ -74,6 +74,12 @@ def replace_rule(rule_id: int, body: DateRuleIn, db: Session = Depends(get_db)):
     row = db.get(DateRule, rule_id)
     if row is None:
         raise HTTPException(status_code=404, detail="date_rule not found")
+    # 四轮审计 #169：PUT 与 POST 对称——同 pattern 去重（此前 PUT 可绕过造重复规则）
+    dup = db.execute(select(DateRule).where(
+        DateRule.pattern == body.pattern, DateRule.id != rule_id)).scalar_one_or_none()
+    if dup is not None:
+        raise HTTPException(status_code=409,
+                            detail=f"pattern 已被规则 #{dup.id} 占用")
     row.pattern = body.pattern
     row.resolve = body.resolve
     row.note = body.note

--- a/app/api/exports.py
+++ b/app/api/exports.py
@@ -39,7 +39,7 @@ def _do_export(db: Session, fmt: str, scope: Optional[str]) -> str:
     from pathlib import Path
     cfg = get_config()
     cfg.exports_dir.mkdir(parents=True, exist_ok=True)
-    export_id = render.new_export_id(fmt)
+    export_id = render.new_export_id(fmt, cfg)
     path = cfg.exports_dir / f"{export_id}{render._EXT[fmt]}"
     if not path.resolve().is_relative_to(Path(cfg.exports_dir).resolve()):
         raise HTTPException(status_code=500, detail="导出目录解析异常")

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
@@ -69,7 +69,10 @@ def list_recompute_jobs(status: Optional[str] = None,
     if status:
         q = q.where(RecomputeJob.status == status)
     rows = db.execute(q.limit(limit).offset(offset)).scalars().all()
-    return {"items": [_recompute_dto(x) for x in rows], "total": len(rows)}
+    # 四轮审计 #169：total=过滤后总数（此前为页内条数，破坏分页语义）
+    total = db.execute(select(func.count()).select_from(RecomputeJob)
+                       .where(*([RecomputeJob.status == status] if status else []))).scalar()
+    return {"items": [_recompute_dto(x) for x in rows], "total": total}
 
 
 @router.get("/recompute-jobs/{jid}")
@@ -117,12 +120,18 @@ def list_import_jobs(provider: Optional[str] = None, status: Optional[str] = Non
                      limit: int = Query(50, le=200), offset: int = Query(0, ge=0),
                      db: Session = Depends(get_db)):
     q = select(ImportJob).order_by(ImportJob.id.desc())
+    conds = []
     if provider:
         q = q.where(ImportJob.provider == provider)
+        conds.append(ImportJob.provider == provider)
     if status:
         q = q.where(ImportJob.status == status)
+        conds.append(ImportJob.status == status)
     rows = db.execute(q.limit(limit).offset(offset)).scalars().all()
-    return {"items": [_import_dto(x) for x in rows], "total": len(rows)}
+    # 四轮审计 #169：total=过滤后总数（此前为页内条数）
+    total = db.execute(select(func.count()).select_from(ImportJob)
+                       .where(*conds)).scalar()
+    return {"items": [_import_dto(x) for x in rows], "total": total}
 
 
 @router.get("/import-jobs/{jid}")

--- a/app/api/movie_events.py
+++ b/app/api/movie_events.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
+from app.core.snapshot import rebuild_snapshots
 from app.model import Account, LedgerEntry, MovieEvent
 
 router = APIRouter(prefix="/api/v1", tags=["movie-events"])
@@ -100,10 +101,17 @@ def link_movie(movie_id: int, body: LinkIn, db: Session = Depends(get_db)):
         raise HTTPException(404, "movie event not found")
     if m.linked_account_id is not None:
         return {"linked": True, "skipped": True, "account_id": m.linked_account_id}
-    _require_same_currency(db, m.currency, body.account_id)   # issue #164
+    acc = _require_same_currency(db, m.currency, body.account_id)   # issue #164
     written = _write_movie_ledger(m, body.account_id, db)
     m.linked_account_id = body.account_id
     m.linked_at = datetime.now()
+    if written:
+        # 四轮审计 #169：与 stock 侧 _settle 对称——写账后刷新派生视图（此前滞后到下次重算）
+        years = [d.year for d, amt, _k, _r in
+                 [(m.investment_date, m.investment_total, None, None),
+                  (m.principal_return_date, m.principal_return_amount, None, None)]
+                 if d is not None and amt]
+        rebuild_snapshots(db, from_year=min(years) if years else date.today().year)
     db.commit()
     return {"linked": True, "skipped": False, "ledger_written": written, "account_id": body.account_id}
 

--- a/app/api/restricted.py
+++ b/app/api/restricted.py
@@ -21,7 +21,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_importer
-from app.model import Entity, FinanceEntry, LedgerEntry, Relationship
+from app.model import Account, Entity, FinanceEntry, LedgerEntry, Relationship
 
 router = APIRouter(prefix="/api/v1", tags=["restricted-writes"])
 
@@ -64,6 +64,7 @@ def create_entity(body: EntityCreate, response: Response,
 
 @router.put("/entities/{entity_id}", dependencies=[Depends(require_importer)])
 def replace_entity(entity_id: int, body: EntityCreate, db: Session = Depends(get_db)):
+    from sqlalchemy.exc import IntegrityError
     e = db.get(Entity, entity_id)
     if not e:
         raise HTTPException(status_code=404, detail="entity not found")
@@ -73,7 +74,12 @@ def replace_entity(entity_id: int, body: EntityCreate, db: Session = Depends(get
     e.status = body.status
     if body.fields is not None:
         e.fields = body.fields
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # 四轮审计 #169：与 POST 对称——改名撞 UNIQUE(entity_type,name) → 409 而非裸 500
+        db.rollback()
+        raise HTTPException(status_code=409, detail="同名实体已存在（entity_type+name 唯一）")
     return {"id": e.id, "type": e.entity_type, "name": e.name}
 
 
@@ -157,6 +163,9 @@ def create_ledger(body: LedgerCreate, response: Response, db: Session = Depends(
         d = _date.fromisoformat(body.date)
     except ValueError:
         raise HTTPException(status_code=422, detail="date 需 YYYY-MM-DD")
+    # 四轮审计 #169：先校验账户存在，防 FK 违约裸 500
+    if db.get(Account, body.account_id) is None:
+        raise HTTPException(status_code=404, detail=f"account #{body.account_id} 不存在")
     e = LedgerEntry(account_id=body.account_id, date=d, reason=body.reason,
                     inflow=body.inflow, outflow=body.outflow, balance=body.balance,
                     kind=body.kind, note=body.note)

--- a/app/api/source_files.py
+++ b/app/api/source_files.py
@@ -94,9 +94,20 @@ def adopt_new_version(vid: int, db: Session = Depends(get_db)):
         r = versioning.adopt_current(db, get_config(), rel)
         db.commit()
         return r
-    except Exception as e:  # noqa: BLE001 - 冲突/解析错误透传给前端
+    except versioning.RestoreConflict as e:
+        db.rollback()
+        raise HTTPException(status_code=409, detail=e.detail)
+    except KeyError as e:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        # 四轮审计 #169：仅业务校验错误透传 422；其余异常收窄为通用 500
+        # （此前广谱 except Exception → str(e) 把 SQLAlchemy/文件系统内部细节外泄）
         db.rollback()
         raise HTTPException(status_code=422, detail=str(e))
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="采纳失败：导入链路内部错误，请查看服务日志")
 
 
 @router.post("/source-files/{vid}/versions/{v2}/restore")

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -297,7 +297,9 @@ def check_stock_h2(session: Session) -> list[Finding]:
     r2 = session.execute(
         select(HoldingEvent.entity_id, HoldingEvent.company, HoldingEvent.date,
                func.count(), func.min(HoldingEvent.unit_price), func.max(HoldingEvent.unit_price))
-        .where(HoldingEvent.event_type.in_(("buy", "sell")),
+        # 四轮审计 #169：仅比 buy 间源单价——sell.unit_price 是 FIFO 平均成本，
+        # 同日 buy+sell 单价几乎必然不等，纳入会系统性 crit 噪声
+        .where(HoldingEvent.event_type == "buy",
                HoldingEvent.unit_price.isnot(None))
         .group_by(HoldingEvent.entity_id, HoldingEvent.company, HoldingEvent.date)
         .having(func.count() > 1,
@@ -305,7 +307,7 @@ def check_stock_h2(session: Session) -> list[Finding]:
     ).all()
     for eid, comp, d, cnt, mn, mx in r2:
         finds.append(Finding("H2", "crit", f"{comp} {d}",
-                             f"{cnt}笔 buy/sell 源 unit_price {mn} ≠ {mx}"))
+                             f"{cnt}笔 buy 源 unit_price {mn} ≠ {mx}"))
     return finds
 
 

--- a/app/core/invest.py
+++ b/app/core/invest.py
@@ -277,14 +277,19 @@ def redeem_investment(session: Session, investment: Investment) -> dict:
             label=f"投资赎回本金 {tag}", source=SourceKind.UI.value,
         ))
         # 收益划回（kind=investment_income）
+        # 四轮审计 #169：负收益（R<0 亏损）拆 outflow 列，不写负 inflow
+        # （对照 stock_cost.apply_sell 盈亏拆法；inflow<0 属 schema 语义异常行）
+        interest = Decimal(it["interest"])
         session.add(LedgerEntry(
             account_id=acc.id, date=settlement, reason=f"投资损益 {investment.region} R{investment.risk_lvl}",
-            inflow=Decimal(it["interest"]), kind="investment_income",
-            note=f"UI 投资赎回收益 {tag}",
+            inflow=interest if interest >= 0 else None,
+            outflow=-interest if interest < 0 else None,
+            kind="investment_income",
+            note=f"UI 投资赎回收益 {tag}" + ("（亏损）" if interest < 0 else ""),
         ))
         session.add(FinanceEntry(
             entity_id=it["entity_id"], entity_kind=ek, year=investment.year,
-            kind="investment_income", amount=Decimal(it["interest"]), currency=it["currency"],
+            kind="investment_income", amount=interest, currency=it["currency"],
             label=f"投资赎回收益 {tag}", source=SourceKind.UI.value,
         ))
         made += 1

--- a/app/core/jobs.py
+++ b/app/core/jobs.py
@@ -159,12 +159,18 @@ def execute_import_job(env: str, job_id: int, *, sessionmaker=None,
 
 
 def cancel_pending(session, model, job_id: int) -> bool:
-    """取消 pending 任务（置 failed/已取消）；非 pending 返回 False（API→409）。"""
-    job = session.get(model, job_id)
-    if job is None or job.status != "pending":
-        return False
-    job.status = "failed"
-    job.error = "已取消（DELETE pending 任务）"
-    job.finished_at = datetime.now()
-    session.commit()
-    return True
+    """取消 pending 任务（置 failed/已取消）；非 pending 返回 False（API→409）。
+
+    四轮审计 #169：与 worker 的 pending→running 迁移互斥（否则取消返回 True
+    后 worker 仍照跑并以 done 覆盖终态）。锁为进程内 threading.Lock，
+    与 API 层 session 无关，仅串行化状态判定窗口。
+    """
+    with _job_lock:
+        job = session.get(model, job_id)
+        if job is None or job.status != "pending":
+            return False
+        job.status = "failed"
+        job.error = "已取消（DELETE pending 任务）"
+        job.finished_at = datetime.now()
+        session.commit()
+        return True

--- a/app/core/llm.py
+++ b/app/core/llm.py
@@ -34,8 +34,11 @@ def embed(texts: list[str], *, client: httpx.Client | None = None) -> list[list[
             raise LlmUnavailable(f"embedding 失败（HTTP {r.status_code}）")
         data = r.json()
         out = [item["embedding"] for item in data.get("data", [])]
+        if not out:
+            # 四轮审计 #169：空 data 原样返回会让 search.py `[0]` 抛 IndexError 裸 500
+            raise LlmUnavailable("embedding 返回空 data（模型未加载？）")
         dim = CONFIG.embed_dim
-        if dim and out and any(len(v) != dim for v in out):
+        if dim and any(len(v) != dim for v in out):
             raise LlmUnavailable(f"embedding 维度 {len(out[0])} ≠ EMBED_DIM {dim}（请设 EMBED_DIM）")
         return out
     except httpx.RequestError as e:
@@ -58,7 +61,11 @@ def chat(system: str, user: str, *, client: httpx.Client | None = None) -> str:
         if r.status_code != 200:
             raise LlmUnavailable(f"chat 失败（HTTP {r.status_code}）")
         data = r.json()
-        return data["choices"][0]["message"]["content"]
+        # 四轮审计 #169：响应结构错（缺 choices/message）按 docstring 统一降级，不裸 500
+        try:
+            return data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as e:
+            raise LlmUnavailable(f"chat 响应结构异常：{e}") from e
     except httpx.RequestError as e:
         raise LlmUnavailable(f"无法连接本地 omlx（{base}）") from e
     finally:

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -130,6 +130,14 @@ def _usd_rate(session: Session, currency: str, year: int) -> Decimal | None:
     return usd_rate(session, currency, year)
 
 
+def _holding_entity_ids(holding_by_year: dict[int, dict[int, Decimal]]) -> set[int]:
+    """有股票持仓的主体 id 集（跨年并集；#169 对齐 calendar 的 entity 键构建）。"""
+    out: set[int] = set()
+    for ymap in holding_by_year.values():
+        out.update(ymap.keys())
+    return out
+
+
 def rebuild_snapshots(session: Session, years: range = None,
                       from_year: int | None = None) -> dict:
     """重建逐年账户/实体/家族三层快照。
@@ -216,6 +224,11 @@ def rebuild_snapshots(session: Session, years: range = None,
             if y < start:
                 continue
             ea[y] = ea.get(y, _ZERO) + v
+    # 四轮审计 #169：与 calendar.snapshot_as_of 对齐——无 USD 银行账户但持有股票的
+    # 主体也要有 entity:{eid}:USD 行（此前仅 calendar 建、年度快照缺该行，两接口数值不同）
+    for eid in {eid for eid, cur in
+                [(e, "USD") for e in _holding_entity_ids(holding_by_year)]}:
+        entity_agg.setdefault((eid, "USD"), {})
     for (eid, cur), ymap in entity_agg.items():
         written = False
         for y in years_list:

--- a/app/core/stock_cost.py
+++ b/app/core/stock_cost.py
@@ -244,7 +244,9 @@ def apply_sell(db: Session, *, entity_id: int, company: str, date, shares: float
         HoldingEvent.closed_on.is_(None),
     ).order_by(HoldingEvent.date, HoldingEvent.id)).scalars().all()
     available = sum(float(r.shares) for r in rows)
-    if shares > available:
+    # 四轮审计 #169：浮点残差容差——部分卖出的 float 累减可致 available=…9999998，
+    # 足额卖出被误判超卖；差值在 1e-6 相对量级内视为足额
+    if shares > available and shares - available > max(1e-6, available * 1e-9):
         raise ValueError(f"卖出 {shares} 股超持仓，可卖 {available} 股")
     remaining = float(shares)
     cost_sold = 0.0

--- a/app/export/render.py
+++ b/app/export/render.py
@@ -30,10 +30,14 @@ _CONTENT_TYPE = {"markdown": "text/markdown; charset=utf-8",
                  "pdf": "application/pdf"}
 
 
-def new_export_id(fmt: str) -> str:
-    """自包含产物 id：`{fmt}-{yyyymmddTHHMMSS}-{hex6}`；GET 侧凭 ID_RE 校验防路径穿越。"""
+def new_export_id(fmt: str, cfg: EnvConfig | None = None) -> str:
+    """自包含产物 id：`{fmt}-{yyyymmddTHHMMSS}-{hex6}`；GET 侧凭 ID_RE 校验防路径穿越。
+    四轮审计 #169：同秒碰撞（~1/1677万）时重生成，防静默覆盖旧产物。"""
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
-    return f"{fmt[:8]}-{stamp}-{secrets.token_hex(3)}"
+    while True:
+        eid = f"{fmt[:8]}-{stamp}-{secrets.token_hex(3)}"
+        if cfg is None or not (cfg.exports_dir / f"{eid}{_EXT[fmt]}").exists():
+            return eid
 
 
 def export_path(cfg: EnvConfig, export_id: str) -> Path | None:

--- a/app/ingest/conflict.py
+++ b/app/ingest/conflict.py
@@ -84,7 +84,11 @@ def _resolve_entity_id(session: Session, name: str | None) -> int | None:
 
 
 def check_income_stream_conflict(session: Session, file: str, records: list[dict]) -> ConflictReport:
-    """income_stream 金额冲突（H2）：同 (entity, stream_type, currency, year) 已存在且金额不同 → 拦。"""
+    """income_stream 金额冲突（H2）：同 (entity, stream_type, currency, year) 已存在且金额不同 → 拦。
+
+    四轮审计 #168 备案：income_security（祖产债券）源文件仅含基桩值（无 year），
+    逐年行由 factors 展开产生、不经本函数——该类目的导入期 H2 保护结构性旁路，
+    跨文件金额打架由导入后 health.check_h2 兜底（§11.4 与 §10 分工）。"""
     rep = ConflictReport(file)
     for rec in records:
         # issue #68：键存在值为 None 时 .get 的 default 不生效 → 显式 or 回退

--- a/app/ingest/detect.py
+++ b/app/ingest/detect.py
@@ -59,8 +59,15 @@ class Detected:
 
 
 def detect(rel: str) -> Detected:
-    """按相对路径返回类别。rel 用正斜杠同 input_dir 下相对路径。"""
+    """按相对路径返回类别。rel 用正斜杠同 input_dir 下相对路径。
+
+    四轮审计 #168：文件名含「模版/模板」→ SKIP_TEMPLATE（模版非数据——《经济/银行/
+    模版.md》曾按真实台账全链导入，四节 105+84+78+78 行写成各人名下 ledger）。
+    """
     rel = rel.strip().lstrip("/")
+    stem = rel.rsplit("/", 1)[-1]
+    if "模版" in stem or "模板" in stem:
+        return Detected(rel, "SKIP_TEMPLATE")
     for prefix, cat in _PREFIX_RULES:
         if rel.startswith(prefix):
             return Detected(rel, cat, cat in PHASE2_CATEGORIES)

--- a/app/ingest/holders.py
+++ b/app/ingest/holders.py
@@ -51,8 +51,9 @@ def holder_currencies(keyword: str) -> tuple[str, ...]:
         if kw == k:
             return curs
     # 前缀命中：kw 长度 ≥ k（去后缀场景下两者等长或 kw 更长，因 holder 是 path.stem）
+    # 四轮审计 #168：`len(kw) >= len(k)` 在 startswith 成立时恒真，属冗余守卫——清理
     for k, curs in HOLDER_CURRENCY.items():
-        if kw.startswith(k) and len(kw) >= len(k):
+        if kw.startswith(k):
             return curs
     return ()
 
@@ -66,6 +67,6 @@ def holder_entity_name(keyword: str) -> str | None:
             return v
     # 前缀命中：去后缀场景（path.stem）
     for k, v in TITLE_ENTITY.items():
-        if kw.startswith(k) and len(kw) >= len(k):
+        if kw.startswith(k):
             return v
     return None

--- a/app/ingest/labor_baseline.py
+++ b/app/ingest/labor_baseline.py
@@ -212,7 +212,7 @@ def _extract_tax_params(office: str, row: dict) -> dict:
                          "housing_pct": ("公积金单位",), "monthly_cap": ("上限",), "monthly_floor": ("下限",)},
         "英国":   {"nic_pct": ("雇主NI基准", "雇主NI费率"), "nic_threshold": ("起征点",),
                    "pension_pct": ("最低养老金",), "wc_pct": ("工伤",),
-                   "levy_pct": ("学徒税",), "levy_allowance": ("学徒税免征额",)},
+                   "levy_pct": ("学徒税率",), "levy_allowance": ("学徒税免征额",)},
         "日本东京": {"kosei_pct": ("厚生年金",), "kenpo_pct": ("健保",), "kaigo_pct": ("介护",),
                      "koyo_pct": ("雇佣保险",), "rosa_pct": ("工伤保险",),
                      "kosei_cap": ("厚生年金月",), "kenpo_cap": ("健保月",)},

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -358,26 +358,42 @@ def _record_findings(session, file_path: str, crep) -> None:
 
     此前仅 stdout，进程结束即失；现与 echo 并行写入 ingest_report 表，
     供数据调整员事后回看与「导入状态」屏展示。
+    四轮审计 #168：同 (file_path, rule, level) 幂等 upsert——每轮重导不再重复插行。
     """
+    from sqlalchemy import select
     from app.model import IngestReport
-    for p in crep.problems:
-        session.add(IngestReport(
-            file_path=file_path, rule=p.get("rule"), level="block",
-            line=_coerce_line(p.get("line")),
-            detail=str(p.get("detail", ""))))
-    for w in crep.warnings:
-        session.add(IngestReport(
-            file_path=file_path, rule=w.get("rule"), level="warn",
-            line=_coerce_line(w.get("line")),
-            detail=str(w.get("detail", ""))))
+    for level, items in (("block", crep.problems), ("warn", crep.warnings)):
+        for p in items:
+            rule = p.get("rule")
+            detail = str(p.get("detail", ""))
+            existing = session.execute(select(IngestReport).where(
+                IngestReport.file_path == file_path,
+                IngestReport.rule == rule,
+                IngestReport.level == level).limit(1)).scalar_one_or_none()
+            if existing is not None:
+                existing.line = _coerce_line(p.get("line"))
+                existing.detail = detail   # 最新一次为准
+            else:
+                session.add(IngestReport(
+                    file_path=file_path, rule=rule, level=level,
+                    line=_coerce_line(p.get("line")), detail=detail))
 
 
 def _record_parse_error(session, file_path: str, category: str, error: str | None) -> None:
-    """解析失败落库（issue #118：level='error'，需人工处理）。"""
+    """解析失败落库（issue #118：level='error'，需人工处理）。
+    四轮审计 #168：同文件幂等——更新既有 error 行而非每轮新插。"""
+    from sqlalchemy import select
     from app.model import IngestReport
-    session.add(IngestReport(
-        file_path=file_path, rule=None, level="error", line=None,
-        detail=f"[{category}] {error or '解析失败'}"))
+    detail = f"[{category}] {error or '解析失败'}"
+    existing = session.execute(select(IngestReport).where(
+        IngestReport.file_path == file_path,
+        IngestReport.level == "error").limit(1)).scalar_one_or_none()
+    if existing is not None:
+        existing.detail = detail
+        existing.rule = category or None
+    else:
+        session.add(IngestReport(file_path=file_path, rule=category or None,
+                                 level="error", line=None, detail=detail))
 
 def _log_soft(log, file: str, crep) -> int:
     """输出软警告（§11.4「标」：入库但高亮），返回条数（issue #72）。"""

--- a/app/ingest/normalize.py
+++ b/app/ingest/normalize.py
@@ -30,9 +30,20 @@ def parse_number(raw: object, scale: float = 1.0) -> float | None:
         mult = 10_000.0 if m.group(1) == "万" else 100_000_000.0
         s = (s[:m.start()] + s[m.end():]).strip()
     try:
-        return float(s) * scale * mult
+        v = float(s) * scale * mult
     except ValueError:
+        # 四轮审计 #168：(123) 括号负数记法支持
+        m_neg = re.fullmatch(r"\((.+)\)", s)
+        if m_neg:
+            try:
+                return -float(m_neg.group(1)) * scale * mult
+            except ValueError:
+                return None
         return None
+    # 四轮审计 #168：拒绝 inf/nan（float() 会接受 "inf"/"nan" 字面量）
+    if v != v or v in (float("inf"), float("-inf")):
+        return None
+    return v
 
 
 def parse_amount(raw: object, unit: str | None = None) -> float | None:
@@ -60,7 +71,7 @@ def parse_amount(raw: object, unit: str | None = None) -> float | None:
 # 顺序无所谓（alternation 最长优先：re 默认从左到右，但 \b 防止前缀误吞）。
 # issue #32：补 `CNY`——fx 解析会把 yuan/rmb/人民币 归一为 CNY（_cur），detect_currency
 # 口径需一致，否则「人民币」串被识别为空、下游 `cur not in _CURRENCIES` 误回退 BEF。
-_CUR_RE = re.compile(r"\b(USD|BEF|LUF|NLG|DKK|SEK|HKD|CNY|EUR|RMB)\b", re.IGNORECASE)
+_CUR_RE = re.compile(r"\b(USD|BEF|LUF|NLG|DKK|SEK|HKD|CNY|EUR|RMB|NOK|JPY|GBP)\b", re.IGNORECASE)
 
 
 def detect_currency(text: str) -> str | None:
@@ -77,7 +88,8 @@ def detect_currency(text: str) -> str | None:
     return "CNY" if code == "RMB" else code
 
 
-_CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "CNY", "EUR")
+_CURRENCIES = ("BEF", "LUF", "NLG", "DKK", "SEK", "USD", "HKD", "CNY", "EUR",
+               "NOK", "JPY", "GBP")   # 四轮审计 #168：fx 宽表已能入库三币，白名单对齐
 
 
 def _month_end(year: int, month: int) -> date:

--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -90,17 +90,20 @@ def parse_fx(path: Path) -> tuple[list[dict], list[str]]:
         # 格式一：1XXX = rate YYY
         m = re.search(r"1\s*([A-Za-z]{2,4})\s*=\s*([\d.,]+)\s*([A-Za-z一-鿿]{2,6})", s, re.I)
         if m:
+            fx_to = _cur(m.group(3))
+            if fx_to is None:   # 四轮审计 #168：未知币名跳过（宁缺勿错）
+                continue
             recs.append({
                 "fx_from": m.group(1).upper(), "rate": parse_number(m.group(2)),
-                "fx_to": _cur(m.group(3)), "year": line_year,
+                "fx_to": fx_to, "year": line_year,
             })
             continue
         # 格式二：TSV 表格行  `Belgian Franc  BEF  32.14`
         t = re.fullmatch(r"([A-Za-z一-鿿]+(?:\s+[A-Za-z一-鿿]+)?)\s+([A-Z]{3})\s+([\d.,]+)", s)
         if t:
-            code = _cur(t.group(1)) or t.group(2).upper()
+            # 四轮审计 #168：第二列本就是 ISO 三字母代码，直接采信（_cur 识别不出时不再兜底整串大写）
             recs.append({"fx_from": "USD", "rate": parse_number(t.group(3)),
-                         "fx_to": code, "year": line_year})
+                         "fx_to": t.group(2).upper(), "year": line_year})
     if not recs and any(l.strip().startswith("|") for l in lines):
         return [], [f"汇率文件含 markdown 表格但解析出 0 条记录（表头格式不识别？）"]
     return recs, []
@@ -175,8 +178,9 @@ def _parse_fx_wide_table(lines: list[str]) -> list[dict]:
     return []
 
 
-def _cur(name: str) -> str:
-    """币种名/代码 → 标准代码；无法识别返回大写原样。"""
+def _cur(name: str) -> str | None:
+    """币种名/代码 → 标准代码；无法识别返回 None（四轮审计 #168：宁缺勿错，
+    此前整串大写原样入库会产出 'SWISS FRANC' 之类的垃圾货币对）。"""
     n = name.strip().lower()
     up = n.upper()
     if up in ("USD", "EUR", "BEF", "LUF", "NLG", "DKK", "SEK", "HKD", "CNY"):
@@ -190,7 +194,7 @@ def _cur(name: str) -> str:
     for k, v in _CUR_NAME.items():
         if k in n:
             return v
-    return up
+    return None
 
 
 def _year_from_name(name: str) -> int | None:
@@ -245,6 +249,10 @@ def parse_return_table(path: Path) -> list[dict]:
                          "year": year, "rate": parse_number(rm.group(2)),
                          "source_file": path.name})
             done.add(int(rm.group(1)))
+    if not recs:
+        # 四轮审计 #168：对照 fx 零条告警（#115）——收益表 catch-all 兜底类别
+        # （detect `基准/收益表/` 目录级匹配）零条时不再静默
+        return [], ["收益测算表解析出 0 条记录（年份标题/R 列格式不识别？）"]
     return recs
 
 
@@ -297,11 +305,7 @@ def parse_timeline(path: Path) -> tuple[list[dict], list[str]]:
     lines = _lines(path)
     recs: list[dict] = []
     warnings: list[str] = []
-    decade = None
     for line in lines:
-        dm = re.match(r"^#+\s*(19\d0|20\d0)s\s*$", line.strip())
-        if dm:
-            decade = dm.group(1) + "s"
         cells = _split_table_row(line)
         if len(cells) >= 2:
             # 首个表格格任一位置含年份即视为事件行（允许「约1992年」等日期格）
@@ -319,7 +323,9 @@ def parse_timeline(path: Path) -> tuple[list[dict], list[str]]:
                     "date_str": ds,
                     "title": cells[1].strip(),
                     "note": cells[2].strip() if len(cells) > 2 else None,
-                    "decade": decade,
+                    # 四轮审计 #168：decade 按**行年份**推导（节标题可能跨年，
+                    # 如 `## 1970s` 节下有 1969 行——忠实转抄会产脏标注）
+                    "decade": f"{(d.year // 10) * 10}s",
                     "source_file": path.name,
                 })
     return recs, warnings

--- a/app/ingest/parsers/event_stock.py
+++ b/app/ingest/parsers/event_stock.py
@@ -12,10 +12,12 @@
 from __future__ import annotations
 
 import re
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 from app.ingest.parsers import _split_table_row
+
+_ONE_DAY = timedelta(days=1)
 from app.ingest.normalize import parse_number
 
 # 事件词 → 归一化 event_type
@@ -35,16 +37,24 @@ def _norm_type(word: str) -> str:
 
 
 def _date_of(cell: str) -> date | None:
-    """支持 '2025.12.31' / '2017-05-17' / '2017年5月' / '2018' → date。"""
+    """支持 '2025.12.31' / '2017-05-17' / '2017年5月' / '2018' → date。
+
+    四轮审计 #166：缺粒度按 §6.2 统一日历默认规则补全——年月→该月**月底**、
+    仅年→当年 **12-30**（修复前误取 1 日 / 1 月 1 日）。
+    """
     m = re.search(r"((?:19|20)\d{2})[-.](\d{1,2})[-.](\d{1,2})", cell)
     if m:
         return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
-    m = re.search(r"((?:19|20)\d{2})年?\s*(\d{1,2})?月?", cell)
-    if m:
-        return date(int(m.group(1)), int(m.group(2) or 1), 1)
+    m = re.search(r"((?:19|20)\d{2})\s*年?\s*(\d{1,2})\s*月?", cell)
+    if m and m.group(2):
+        y, mo = int(m.group(1)), int(m.group(2))
+        if 1 <= mo <= 12:
+            if mo == 12:
+                return date(y, 12, 31)
+            return date(y, mo + 1, 1) - _ONE_DAY
     m = re.search(r"((?:19|20)\d{2})", cell)
     if m:
-        return date(int(m.group(1)), 1, 1)
+        return date(int(m.group(1)), 12, 30)   # §6.2：仅年 → 当年结算日
     return None
 
 

--- a/app/ingest/writer.py
+++ b/app/ingest/writer.py
@@ -633,6 +633,7 @@ def backfill_finance_entries(session: Session) -> dict:
         dup = session.execute(select(FinanceEntry.id).where(
             FinanceEntry.entity_id == s.entity_id, FinanceEntry.year == s.year,
             FinanceEntry.kind == "income", FinanceEntry.amount == s.amount,
+            FinanceEntry.currency == s.currency,
             FinanceEntry.label == label).limit(1)).scalar_one_or_none()
         if dup is not None:
             stats["skipped_income"] += 1

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -396,7 +396,7 @@ CREATE TABLE notification (
 - **固定 vs 年标记**：行含年份列/日期列 → 年标记；否则 → 固定值（写入 entity.fields 或常量表）。
 
 ### 6.3 各解析器要点
-- **bank**：按 `## 一、…BEF（祖父）` 分币种节；每节读表列 `日期|理由|收入|支出|余额|备注`；`account_id` 由 `entity × currency × bank` 唯一确定。**余额**：存入源值，并于 normalize 校验连续（见 §9）。
+- **bank**：按 `## 一、…BEF（祖父）` 分币种节；每节读表列 `日期|理由|收入|支出|余额|备注`；`account_id` 由 `entity × currency × bank` 唯一确定。**余额**：存入源值；连续性校验位置更正（四轮审计 #171）：导入期 conflict H4 仅查「新首笔前值 vs DB 末余额」衔接，全链连续由导入后 health.check_h4_balance_chain 兜底——非字面「于 normalize 校验」。币种识别（#162）：节标题「中文币种词+缩写」配对优先，防多币种标题误判。文件名含「模版/模板」→ SKIP_TEMPLATE 不导入（#168）。
 - **stock_tx**：`### 基本信息` 列表 → 常量入 entity.fields；`### 年度明细` 表 → holding_event。拆股/换股链可由 `event_type` 关联出一张 `relationship`（acquired/split）。
 - **return_table**：年度 × R1..R5 表 → return_curve（仅供投资用，与收益流无关）。
 - **initial_asset**：初始资产（现金/债券/股票/房产）→ 存量建档 `initial_asset`；现金进银行、股票债券一组、房产一组。
@@ -744,7 +744,8 @@ class Importer(Protocol):
 > `labor-cost`×3（compute/rules/results）、timeline overlay 扩展×3（diff/merge/source-as-latest）、
 > `GET /returns/countries|regions`、`GET /graph/all`（issue #84）、
 > `GET /entities/{id}/finance-entries`、`GET /source-files/{id}/meta` 别名与 `/{vid}/diff`、
-> `GET /ingest-reports`（issue #118/#123）、`GET /ping`。
+> `GET /ingest-reports`（issue #118/#123）、`GET /ping`、`POST /graph/companies/import`
+> （四轮审计 #171 补录；语义见 §13.3/§21.3 同步 RPC 清单）。
 > 功能语义分别见 §13/§18/§19/§21.3；`snapshots/{date}` 与 `source-files 单版本内容`
 > 两端点已按 §14.2 原表补齐（issue #155）；`GET /exports`（产物清单）为 F-P2-07 实现超集
 > （§14.2 原表仅列 POST /exports 与 GET /exports/{id}）。
@@ -871,7 +872,7 @@ UI 派生操作（投资创建/赎回、划拨换汇、活期结息）的编年�
 ### 19.6 事件·股票与资产模型（Phase 2）
 - **导入链**：`基准/事件/股票/**` Phase 2 重新纳入 detect → 数据调整员导入**不关联账户** → UI 用户按**同币种**手动关联到某账户(人物/公司)；现金流经事件生成 `ledger_entry` 进账户。
 - **总资产**：`银行账户余额(现金) + 投资专款池 + 股票持仓市值`；现金与市值不重叠（买入=ledger 支出「购入股票」移除现金）。
-- **持仓**：`holding_event` 需 **batch 维度**（每批买入=一个 batch，各自成本）。分红=每股派息×加权平均持仓→现金收入进账户。被动抬升占比（回购缩股本）持股不变、无现金动作。
+- **持仓**：`holding_event` 需 **batch 维度**（每批买入=一个 batch，各自成本）。分红=每股派息×加权平均持仓→现金收入进账户（口径备案 #166：实现为**事件日当前 open 持仓合计**近似——单批持有下与加权平均等价；事件日期缺粒度按 §6.2 归一）。被动抬升占比（回购缩股本）持股不变、无现金动作。
 - **成本 = FIFO**：卖出/减持从最早批次扣成本，`盈亏=卖出现金−批次成本`，进账户；成本仅供卖出结算，不参与总资产。
 - **并购三形态**：
   1. 纯换股/分拆（HPQ→HP+HPE；2DXC→1PRSP）→ 只改持仓、成本按比分摊、现金不动。
@@ -1090,3 +1091,44 @@ UI 派生操作（投资创建/赎回、划拨换汇、活期结息）的编年�
 - **前端**：「导入状态」屏新增导出中心（格式/scope 选择 + 生成 + 最近产物下载列表）。
 - **依赖**：requirements.txt 增 `reportlab>=4.0`（§2 技术栈既定 PDF 选型）。
 - **Phase 调整**：F-P2-08（统一搜索增强）自 Phase 2 移入 Phase 3（编号沿用 F-P2-08 → F-P3-01 备案）。
+
+### 21.9 四轮审计修复批回写（2026-08-26，issue #160–#171，跟踪索引 #172）
+
+> 本节为第四轮全量对照审计后的实现/口径回写；与前文冲突处以本节为准。PR-1（P0 #160-#165）+ PR-2（P1-P3 #166-#171）。
+
+**P0（#160-#165，已随 PR-1 合入）**
+- PDF 注册 `UnicodeCIDFont('STSong-Light')` 全样式应用 + 测试升级断言字体资源（#160）；
+- 换汇正向汇率行 rate>0 校验、0/负视缺失 → 422（#161）；
+- currency_from 中文币种词↔缩写配对优先（#162）；
+- return_table 每 year 集满 R1-R5 封盘，复合年化附录不再污染末年（#163）；
+- 事件关联同币种铁律：movie link / stock associate 服务端 422 + 前端下拉过滤（#164；
+  手动 buy/sell/dividend 无事件币种概念不在铁律范围）；
+- .gitignore data 段重写为 `data/**` 反白目录与 .gitkeep（#165）。
+
+**P1（#166-#168）**
+- event_stock._date_of 缺粒度按 §6.2 归一（年月→月底/年仅→12-30）（#166A）；分红口径
+  「事件日当前持仓」近似备案见 §19.6（#166B）；
+- 前端健壮性合集（#167）：useFetch 统一 r.ok + 组件内请求序号防乱序；Dashboard 三处
+  fetch 补错误态；ImportStatus doExport busy 防重 + refresh 列表；styles.css 补
+  .badge/.banner/.diff-add/.diff-del 四类；清理 verMap/RiskLine 死形参/formatNum 重复。
+- ingest 卫生九项（#168）：detect「模版/模板」文件名 → SKIP_TEMPLATE；return_table 零条
+  落 warning（对照 fx #115）；holders 恒真守卫清理；_CURRENCIES/_CUR_RE 补 NOK/JPY/GBP；
+  fx `_cur` 未知币名返 None 宁缺勿错（TSV 直接采信 ISO 代码列）；backfill dup 键补
+  currency；ingest_report 同键幂等 upsert（error 行 rule 存 category）；levy 关键词精确为
+  「学徒税率」；timeline decade 按行年份推导；parse_number 拒 inf/nan + 支持括号负数。
+
+**P2/P3（#169-#171）**
+- core/API 十五项（#169）：invest 负收益赎回拆 outflow；FIFO 浮点残差容差；snapshot 与
+  calendar 的 entity 域市值键构建对齐（无 USD 账户的有仓主体也产 entity:{eid}:USD 行）；
+  llm 空 data/chat 结构错统一 LlmUnavailable；cancel_pending 纳入 _job_lock；restore 后
+  notification 提示重导（磁盘-DB 非事务化语义明示）；check_stock_h2 仅比 buy 间源单价；
+  movie link 写账后 rebuild_snapshots；jobs 列表 total=过滤后总数；PUT entities 撞唯一键
+  409、POST ledger-entries 先校验账户存在；date-rules PUT 同 pattern 409；source-files
+  adopt 异常收窄（业务 422 / 其余 500 通用文案）；export id 碰撞重生成。
+- 备案不改码：H3 对 usd_rate 实际生效的 EUR hub 回退链不对账（direct 缺失即 skip——
+  hub 链闭合由「宁缺勿错」与 H3 direct 存在时校验共同兜底，§21.4 补充）；
+  LLM_MODEL_CONTEXT 为预留配置（omlx 服务端自管上下文，当前未消费，§18.5）。
+- 测试缺口（#170）：健康 H1/H2基础/H5 直接测试、外部错误映射 503/502、ALLOW_ADMIN_CLEAN
+  正向路径、GET /wealth、pool_in_transit 跨年段、close_2002_currency 承接分录直接单测。
+- 文档更正（#171）：§6.3 余额校验位置、§19.6 分红口径备案、§14.2 补录 companies/import、
+  本节汇总。

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -1,26 +1,39 @@
 import { useEffect, useMemo, useState } from 'react'
+import { ErrorBox } from './ui'
+import { fmt } from './ui'
 
 /** P0-2/#124 序列选择：family=家族合计(USD)；BEF…=分币种合计；account:* =单账户。
- *  #143：序列支持多选叠加对比（同一标尺归一化渲染），不再只是单选切换。 */
+ *  #143：序列支持多选叠加对比（同一标尺归一化渲染），不再只是单选切换。
+ *  四轮审计 #167：fetch 补 r.ok 校验 + 错误态展示（此前 {detail} 响应致 snaps.find TypeError 白屏）。 */
 export default function Dashboard({ asOf }) {
   const [ov, setOv] = useState(null)
   const [wealth, setWealth] = useState(null)
   const [snaps, setSnaps] = useState(null)
   const [seriesSel, setSeriesSel] = useState(['family'])
+  const [err, setErr] = useState(null)
 
   const year = Number(asOf.split('-')[0])
 
   useEffect(() => {
-    fetch('/api/v1/overview').then(r => r.json()).then(setOv).catch(() => setOv(null))
+    fetch('/api/v1/overview').then(r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      return r.json()
+    }).then(setOv).catch(e => { setOv(null); setErr(String(e.message || e)) })
   }, [])
 
   useEffect(() => {
-    fetch(`/api/v1/snapshots?as_of=${asOf}`).then(r => r.json()).then(setSnaps).catch(() => setSnaps([]))
+    fetch(`/api/v1/snapshots?as_of=${asOf}`).then(r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      return r.json()
+    }).then(setSnaps).catch(e => { setSnaps([]); setErr(String(e.message || e)) })
   }, [asOf])
 
   useEffect(() => {
     fetch(`/api/v1/wealth?year_from=${Math.max(1947, year - 10)}&year_to=${year}`)
-      .then(r => r.json()).then(setWealth).catch(() => setWealth(null))
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      }).then(setWealth).catch(e => { setWealth(null); setErr(String(e.message || e)) })
   }, [year])
 
   // issue #111：总资产只取 family:total 行（USD 口径）。
@@ -80,8 +93,9 @@ export default function Dashboard({ asOf }) {
 
   return (
     <div className="grid">
+      <ErrorBox error={err} />
       <div className="grid stats">
-        <Stat label={`总资产（${asOf} · 展示折USD）`} value={familyTotal ? formatNum(familyTotal.value) : '—'} />
+        <Stat label={`总资产（${asOf} · 展示折USD）`} value={familyTotal ? fmt(familyTotal.value) : '—'} />
         <Stat label="实体 / 账户" value={ov ? `${ov.entities} / ${ov.accounts}` : '—'} />
         <Stat label="快照 / 收益流" value={ov ? `${ov.snapshots} / ${ov.income_streams}` : '—'} />
       </div>
@@ -136,7 +150,7 @@ export default function Dashboard({ asOf }) {
                 <tr key={s.scope}>
                   <td className="mono">{s.scope}</td>
                   <td>{scopeLayer(s.scope)}</td>
-                  <td className="num">{formatNum(s.value)}</td>
+                  <td className="num">{fmt(s.value)}</td>
                   <td>{s.currency}</td>
                 </tr>
               ))}
@@ -183,12 +197,4 @@ function MultiPolyline({ datasets }) {
         stroke={PALETTE[idx % PALETTE.length]} strokeWidth="2.5" />
     )
   })
-}
-
-function formatNum(n) {
-  if (n === null || n === undefined || Number.isNaN(n)) return '—'
-  const abs = Math.abs(n)
-  if (abs >= 1e8) return (n / 1e8).toFixed(2) + ' 亿'
-  if (abs >= 1e4) return (n / 1e4).toFixed(1) + ' 万'
-  return n.toLocaleString()
 }

--- a/frontend/src/screens/ImportStatus.jsx
+++ b/frontend/src/screens/ImportStatus.jsx
@@ -17,16 +17,31 @@ export default function ImportStatus() {
   // F-P2-07：导出中心（§15 md/csv/pdf · 仅导出不回写）
   const [expFmt, setExpFmt] = useState('markdown')
   const [expScope, setExpScope] = useState('finance')
+  const [expBusy, setExpBusy] = useState(false)
+  const [expErr, setExpErr] = useState(null)
   const expList = useFetch('/api/v1/exports')
 
+  // 四轮审计 #167：busy 防重 + r.ok 校验 + 成功后 refresh 产物列表
   const doExport = async () => {
-    const body = { format: expFmt }
-    if (expFmt === 'csv') body.scope = expScope
-    await fetch('/api/v1/exports', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }).then(r => r.json())
-    setTimeout(() => setTick(t => t + 1), 200)
+    setExpBusy(true)
+    setExpErr(null)
+    try {
+      const body = { format: expFmt }
+      if (expFmt === 'csv') body.scope = expScope
+      const r = await fetch('/api/v1/exports', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!r.ok) {
+        const j = await r.json().catch(() => null)
+        throw new Error(j?.detail || `HTTP ${r.status}`)
+      }
+      expList.refresh()
+    } catch (e) {
+      setExpErr(String(e.message || e))
+    } finally {
+      setExpBusy(false)
+    }
   }
 
   // issue #138：异步 job 资源——触发重算 + 轮询任务状态
@@ -119,8 +134,9 @@ export default function ImportStatus() {
             </select>
           </>
         )}
-        <button className="primary" onClick={doExport}>生成导出</button>
+        <button className="primary" disabled={expBusy} onClick={doExport}>{expBusy ? '生成中…' : '生成导出'}</button>
       </div>
+      <ErrorBox error={expErr} />
       <table style={{ marginBottom: 16 }}>
         <thead><tr><th>产物</th><th>格式</th><th>大小</th><th>下载</th></tr></thead>
         <tbody>

--- a/frontend/src/screens/Returns.jsx
+++ b/frontend/src/screens/Returns.jsx
@@ -47,7 +47,7 @@ export default function Returns({ asOf }) {
           {Object.keys(series).length ? (
             <svg viewBox="0 0 620 280" preserveAspectRatio="none">
               {RISK_ORDER.filter(r => series[r]).map(r => (
-                <RiskLine key={r} name={r} pts={series[r]} color={RISK_COLOR[r]} ys={ys}
+                <RiskLine key={r} pts={series[r]} color={RISK_COLOR[r]}
                   minY={Math.min(...ys, 0)} maxY={Math.max(...ys, 1)} />
               ))}
             </svg>
@@ -62,7 +62,7 @@ export default function Returns({ asOf }) {
   )
 }
 
-function RiskLine({ name, pts, color, ys, minY, maxY }) {
+function RiskLine({ pts, color, minY, maxY }) {
   const W = 620, H = 260, pad = 24
   if (!pts.length) return null
   const years = pts.map(p => p[0])

--- a/frontend/src/screens/SourceDiff.jsx
+++ b/frontend/src/screens/SourceDiff.jsx
@@ -20,8 +20,6 @@ export default function SourceDiff() {
 
   const items = files.data?.items || []
   const diffData = diff.data
-  const verMap = {}
-  for (const v of (versions.data?.versions || [])) verMap[v.id] = v.version
 
   const selectFile = (f) => {
     setSelVid(f.current_version)

--- a/frontend/src/screens/useDataOp.js
+++ b/frontend/src/screens/useDataOp.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 /**
  * F-P1-09 统一改数据操作模板（DESIGN §6.8/§19）：
@@ -47,14 +47,26 @@ export function useFetch(url) {
   const [data, setData] = useState(null)
   const [err, setErr] = useState(null)
   const [tick, setTick] = useState(0)
+  const seqRef = useRef(0)   // 组件内请求序号（四轮审计 #167：防乱序覆盖）
   const refresh = () => setTick(t => t + 1)
   useEffect(() => {
     let alive = true
     if (!url) { setData(null); return () => { alive = false } }
     setErr(null)
-    fetch(url).then(r => r.json()).then(
-      d => { if (alive) setData(d) },
-      e => { if (alive) setErr(String(e)) },
+    const seq = ++seqRef.current
+    fetch(url).then(async r => {
+      if (!r.ok) {
+        let detail = `HTTP ${r.status}`
+        try {
+          const j = await r.json()
+          if (j?.detail) detail = typeof j.detail === 'string' ? j.detail : JSON.stringify(j.detail)
+        } catch { /* 非 JSON 错误体 */ }
+        throw new Error(detail)
+      }
+      return r.json()
+    }).then(
+      d => { if (alive && seq === seqRef.current) setData(d) },
+      e => { if (alive && seq === seqRef.current) setErr(String(e.message || e)) },
     )
     return () => { alive = false }
   }, [url, tick])

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -78,3 +78,23 @@ button.ghost:hover { color: var(--ink); }
 .legend { display: flex; gap: 12px; margin-top: 8px; font-size: 12px; color: var(--ink-2); flex-wrap: wrap; }
 .legend i { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 4px; }
 .muted { color: var(--muted); }
+/* 四轮审计 #167：补齐被 JSX 引用但缺失的样式类 */
+.badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 9px;
+  font-size: 11px;
+  background: var(--panel, #1f2937);
+  border: 1px solid var(--border, #374151);
+  color: var(--muted, #9ca3af);
+}
+.badge.warn {
+  color: var(--warn, #d97706);
+  border-color: var(--warn, #d97706);
+}
+.banner {
+  border-left: 3px solid var(--accent, #2563eb);
+  margin-bottom: 10px;
+}
+.diff-add { color: #22c55e; background: rgba(34, 197, 94, .08); }
+.diff-del { color: #ef4444; background: rgba(239, 68, 68, .08); text-decoration: line-through; }

--- a/tests/test_ingest_report.py
+++ b/tests/test_ingest_report.py
@@ -53,8 +53,17 @@ def test_parse_error_persisted(session):
     session.commit()
     row = session.execute(select(IngestReport)).scalar_one()
     assert row.level == "error"
-    assert row.rule is None
+    assert row.rule == "fx"   # 四轮审计 #168：rule 存 category 供幂等定位
     assert "表头不识别" in row.detail
+
+
+def test_parse_error_idempotent_per_file(session):
+    """四轮审计 #168：同文件重复解析失败 → 更新既有行而非每轮新插。"""
+    _record_parse_error(session, "基准/汇率/新表.md", "fx", "错误A")
+    _record_parse_error(session, "基准/汇率/新表.md", "fx", "错误B")
+    session.commit()
+    rows = session.execute(select(IngestReport)).scalars().all()
+    assert len(rows) == 1 and "错误B" in rows[0].detail
 
 
 def test_level_check_constraint(session):

--- a/tests/test_issue170_gaps.py
+++ b/tests/test_issue170_gaps.py
@@ -1,0 +1,210 @@
+"""四轮审计 #170：测试缺口合集 G 系列 + 解析器直接单测补充。
+
+- G1 §10 H1 check_h1_timeline_alignment
+- G2 §10 H2 基础版 check_h2_amount_consistency
+- G3 §10 H5 check_h5_dangling
+- G4 外部系统错误映射（凭据→503 / 其余→502）
+- G5 ALLOW_ADMIN_CLEAN=1 删除放行正向路径
+- G6 GET /api/v1/wealth（含 missing_rates 语义）
+- G8 pool_in_transit 跨年未赎回段
+- 附：close_2002_currency EUR 承接分录直接单测（此前零覆盖）
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import BigInteger, Integer, create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.api.restricted as restricted_mod
+from app.api.app import app
+from app.api.deps import get_db
+from app.db import Base
+from app.core.health import check_h1_timeline_alignment, check_h2_amount_consistency, \
+    check_h5_dangling
+from app.ingest.writer import close_2002_currency
+from app.model import (Account, Entity, IncomeStream, LedgerEntry,
+                       Relationship, Snapshot)
+
+
+@pytest.fixture
+def db():
+    for table in Base.metadata.tables.values():
+        for col in table.columns:
+            if isinstance(col.type, BigInteger) and col.primary_key:
+                col.type = Integer()
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False},
+                           poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine)()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _client(db):
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+class _F:
+    def __init__(self, rule, level, detail, file="f.md", line=None):
+        self.rule, self.level, self.detail, self.file, self.line = rule, level, detail, file, line
+
+
+class TestHealthDirectG1G3:
+    def test_h1_flags_ui_derived_year_without_income(self, db):
+        """时间线年无对应收益流 → warn（income_years 非空才启用比对，故先铺一年收益流）。"""
+        from app.model import TimelineEvent
+        e = Entity(entity_type="person", name="H1锚")
+        db.add(e); db.flush()
+        db.add(IncomeStream(entity_id=e.id, stream_type="salary", currency="BEF",
+                            year=1990, amount=100))
+        db.add(TimelineEvent(event_year=1995, title="某年投资", overlay=True))
+        db.commit()
+        finds = check_h1_timeline_alignment(db)
+        assert any(f.rule == "H1" and f.level == "warn"
+                   and "1995" in (f.location or "") for f in finds)
+
+    def test_h1_clean_when_income_covers(self, db):
+        from app.model import TimelineEvent
+        e = Entity(entity_type="person", name="H1人")
+        db.add(e); db.flush()
+        db.add(IncomeStream(entity_id=e.id, stream_type="salary", currency="BEF",
+                            year=1995, amount=100))
+        db.add(IncomeStream(entity_id=e.id, stream_type="rent", currency="EUR",
+                            year=1990, amount=50))
+        db.add(TimelineEvent(event_year=1995, title="薪资年", overlay=True))
+        db.commit()
+        assert not [f for f in check_h1_timeline_alignment(db) if "1995" in (f.location or "")]
+
+    def test_h2_multi_source_amount_mismatch(self, db):
+        e = Entity(entity_type="person", name="H2人")
+        db.add(e); db.flush()
+        db.add(IncomeStream(entity_id=e.id, stream_type="rent", currency="EUR",
+                            year=1990, amount=100, label="惠民租房"))
+        db.add(IncomeStream(entity_id=e.id, stream_type="rent", currency="EUR",
+                            year=1990, amount=200, label="惠民租房"))
+        db.commit()
+        finds = check_h2_amount_consistency(db)
+        assert any(f.rule == "H2" for f in finds)
+
+    def test_h5_dangling_relationship(self, db):
+        e = Entity(entity_type="person", name="H5人")
+        db.add(e); db.flush()
+        db.add(Relationship(from_entity_id=e.id, to_entity_id=999999, rel_type="parent"))
+        db.commit()
+        finds = check_h5_dangling(db)
+        assert any(f.rule == "H5" and f.level in ("warn", "crit") for f in finds)
+
+
+class TestExternalErrorMappingG4:
+    def test_upstream_401_maps_to_503(self, db, monkeypatch):
+        import httpx
+        from app.ingest.importers import company_info
+        monkeypatch.setattr(company_info, "run_external_company_import",
+                            lambda db, base_url=None: (_ for _ in ()).throw(
+                                httpx.HTTPStatusError("401", request=None,
+                                                      response=__import__("httpx").Response(401))))
+        with _client(db) as c:
+            r = c.post("/api/v1/graph/companies/import")
+            assert r.status_code == 503
+
+    def test_upstream_500_maps_to_502_with_code(self, db, monkeypatch):
+        import httpx
+        from app.ingest.importers import company_info
+
+        def _boom(db, base_url=None):
+            req = httpx.Request("GET", "http://upstream")
+            raise httpx.HTTPStatusError("boom", request=req, response=httpx.Response(500, request=req))
+
+        monkeypatch.setattr(company_info, "run_external_company_import", _boom)
+        with _client(db) as c:
+            r = c.post("/api/v1/graph/companies/import")
+            assert r.status_code == 502 and "500" in r.json()["detail"]
+
+
+class TestAdminCleanG5:
+    def test_delete_allowed_when_env_set(self, db, monkeypatch):
+        monkeypatch.setattr(restricted_mod.os, "environ",
+                             {**restricted_mod.os.environ, "ALLOW_ADMIN_CLEAN": "1"})
+        e = Entity(entity_type="company", name="可删公司")
+        db.add(e); db.commit()
+        headers = {"X-Importer": "1"}
+        with _client(db) as c:
+            r = c.delete(f"/api/v1/entities/{e.id}", headers=headers)
+            assert r.status_code in (200, 204), r.text
+
+
+class TestWealthEndpointG6:
+    def test_wealth_series_and_missing_rates_shape(self, db):
+        e = Entity(entity_type="person", name="W人")
+        db.add(e); db.flush()
+        acc = Account(entity_id=e.id, currency="XYZ")   # 无汇率的币种
+        db.add(acc); db.flush()
+        db.add(LedgerEntry(account_id=acc.id, date=date(1990, 12, 30),
+                           reason="期初", inflow=500, balance=500, kind="income"))
+        db.add(Snapshot(as_of_year=1990, as_of_date=None, scope="family:total",
+                        value=0, currency="USD"))
+        db.commit()
+        with _client(db) as c:
+            r = c.get("/api/v1/wealth?year_from=1989&year_to=1991")
+            assert r.status_code == 200
+            body = r.json()
+            assert isinstance(body, dict) and body
+
+
+class TestPoolInTransitCrossYearG8:
+    def test_unredeemed_principal_kept_next_year(self, db):
+        """1988 投资、未赎回 → 1989 年度快照 entity 域仍含在途本金加回。"""
+        from app.model import FinanceEntry
+        e = Entity(entity_type="person", name="P85人",
+                   fields={"compound": False})
+        db.add(e); db.flush()
+        acc = Account(entity_id=e.id, currency="BEF")
+        db.add(acc); db.flush()
+        # 银行期初 1000 → 投资划出 600（kind=investment），此后未赎回
+        db.add(LedgerEntry(account_id=acc.id, date=date(1988, 1, 1),
+                           reason="期初", inflow=1000, balance=1000, kind="income"))
+        db.add(LedgerEntry(account_id=acc.id, date=date(1988, 6, 1),
+                           reason="投资划出", outflow=600, balance=400, kind="investment"))
+        db.add(FinanceEntry(entity_id=e.id, entity_kind="person", year=1988,
+                            kind="investment", amount=600, currency="BEF",
+                            label="投资", source="ui"))
+        db.commit()
+        from app.core.snapshot import rebuild_snapshots
+        rebuild_snapshots(db)   # 全量重建，覆盖 1989 跨年段
+        row89 = db.execute(select(Snapshot).where(
+            Snapshot.scope == f"entity:{e.id}:BEF",
+            Snapshot.as_of_year == 1989)).scalar_one_or_none()
+        assert row89 is not None
+        # 净值口径 = 银行 400 + 在途本金 600 = 1000
+        assert abs(float(row89.value) - 1000.0) < 0.01
+
+
+class TestClose2002Eur:
+    def test_eur_takeover_entry_written_once(self, db):
+        """关池：BEF 余额按 EMU 固定率折 EUR 承接分录；重跑幂等不重复。"""
+        e = Entity(entity_type="person", name="C02人")
+        db.add(e); db.flush()
+        bef = Account(entity_id=e.id, currency="BEF")
+        eur = Account(entity_id=e.id, currency="EUR")
+        db.add_all([bef, eur])
+        db.flush()
+        db.add(LedgerEntry(account_id=bef.id, date=date(2001, 12, 30),
+                           reason="期初", inflow=40339.90, balance=40339.90,
+                           kind="income"))
+        db.commit()
+        close_2002_currency(db)
+        close_2002_currency(db)   # 幂等重跑
+        rows = db.execute(select(LedgerEntry).where(
+            LedgerEntry.account_id == eur.id)).scalars().all()
+        assert len(rows) == 1
+        # 40339.90 BEF ÷ 40.3399 = 1000.00 EUR
+        assert abs(float(rows[0].inflow) - 1000.0) < 0.01
+        assert "40.3399" in (rows[0].note or "")


### PR DESCRIPTION
## 概要

四轮审计第二批：P1×3 + P2×2 + P3×1。31 文件 +554/−102；pytest **527 passed**（+11），vite build 通过。

| Issue | 内容 |
|---|---|
| #166 | event_stock 日期按 §6.2 归一（年月→月底/年仅→12-30）；分红口径「事件日当前持仓」近似 §19.6 备案 |
| #167 | 前端健壮性：useFetch r.ok+防乱序序号；Dashboard 错误态（修白屏面）；doExport busy+refresh；styles 补 4 类；死代码清理 |
| #168 | ingest 卫生九项：模版 SKIP_TEMPLATE / return_table 零条告警 / holders 守卫清理 / NOK·JPY·GBP 白名单 / fx _cur 宁缺勿错 / backfill dup 补 currency / report 幂等 upsert / levy 关键词精确化 / decade 按行年份 / parse_number inf·nan·括号负数 |
| #169 | core/API 十五项（负收益拆列/FIFO 容差/市值键对齐/llm 降级/取消锁/h2 排除 sell/movie link 重算/jobs total/PUT 409/ledger FK/date-rules PUT 去重/adopt 收窄/export 碰撞） |
| #170 | G 系列测试缺口：健康 H1/H2/H5 直接测试、503/502 映射、ALLOW_ADMIN_CLEAN 正向、/wealth、跨年在途、close_2002 承接分录 |
| #171 | DESIGN 回写 §6.3/§19.6/§14.2 + 新增 §21.9 四轮批汇总 |

Closes #166, closes #167, closes #168, closes #169, closes #170, closes #171