### PR TITLE
fix(p1-p3): 五轮审计修复合集（#175-#178，跟踪索引 #179）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@
 
 ---
 
+## [Audit Round 3+4+5 · #151-#179] — 2026-08-26
+
+**三轮/四轮/五轮对照审计修复批**（跟踪索引 #157/#172/#179；DESIGN §21.7–§21.9）
+
+- **三轮（PR #158，#151-#156）**：Dashboard 渲染崩溃死代码、CLI 快照动态上限收尾
+  （calendar_years 全链路）、overlay 三端点补重算、§14.2 两端点补齐
+  （snapshots/{date}、source-files 单版本内容）、英国学徒税 levy 公式、docs 回写。
+- **F-P2-07 导出落地（PR #159）**：`app/export/` md 六节档案 + csv 五 scope（RFC4180）
+  + reportlab PDF 报告（CJK 字体内嵌）；`/api/v1/exports`×3；「导入状态」屏导出中心；
+  F-P2-08 移入 Phase 3（F-P3-01）。
+- **四轮（PR #173 P0 + PR #174 P1-P3，#160-#171）**：PDF 中文 CJK 字体注册、换汇正向
+  零汇率防御、bank 节标题币种配对识别、return_table 复合年化封盘、事件关联同币种铁律、
+  .gitignore data/** 重写、event_stock 日期归一、前端 useFetch r.ok+防乱序、ingest 卫生九项、
+  core/API 健壮性十五项、测试缺口 G 系列、§21.9 回写。
+- **五轮（本批，#175-#178）**：换汇反向负汇率穿透修复 + available_fx_pairs 过滤非法行；
+  closed 关池账户全通道拒新流水（movie link/stock 动作/_require_open_account 防线 +
+  前端过滤）；ui_ops 五端点异常收窄（业务族 422/409、其余 500 通用文案）；
+  NotificationsBanner ack 校验；Timeline save 失败保留编辑 + 行级按钮 busy；
+  年份输入上限动态化（calMax prop）；Health 屏错误上屏；G6 missing_rates 实质断言；
+  return_table 零条告警达主链路（ingest_report 落库）；死变量/未用导入清理。
+
+最终验证：pytest **531 passed**；vite build 通过。
+
+---
+
 ## [Phase 2 · F-P2-06] — 2026-08-25
 
 **文件 diff 回退：版本 diff → UI 决策「采纳新版本」/「回退」（DB+磁盘复原）**（DESIGN §11）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - 账务本金记账、展示层才折算 USD；BEF/LUF/NLG 2002 关池转 EUR；收益文件模块化挂账。
 - 开发进度以 `docs/DESIGN-webnovel-dashboard.md` §20 功能清单（编号 `F-P0-xx`/`F-P1-xx`/`F-P2-xx`，状态图例 ⬜/🟨/✅）为准，完成一项勾一项，在需求/任务/commit 中以此编号引用。
 
-**启动 / 运行 Dashboard（F-P0-01..14，Phase 1 P0 已实现）**：
+**启动 / 运行 Dashboard（Phase 1 P0×14 + P1×10 + Phase 2 P2×01-07 全部 ✅；F-P3-01 暂缓——进度以 DESIGN §20 为准）**：
 
 前置（一次性）：
 1. **Postgres**：本机 `Postgres.app`（PostgreSQL 18），端口 `5432`；需已有三库 `novel_dev` / `novel_test` / `novel_prod`（同名库已建，缺失可用 `createdb` 补）。免密 trust 即可；若设了密码，导出 `export POSTGRES_PASSKEY=...`。

--- a/app/api/movie_events.py
+++ b/app/api/movie_events.py
@@ -27,7 +27,8 @@ class LinkIn(BaseModel):
 
 
 def _require_same_currency(db: Session, event_currency: str | None, account_id: int):
-    """PRD §6.8 第3类铁律（四轮审计 #164）：同币种才连、不换算；不符则不可关联。"""
+    """PRD §6.8 第3类铁律（四轮审计 #164）：同币种才连、不换算；不符则不可关联。
+    五轮审计 #176：关池（closed）账户只读终态（§6.6），拒攰流水。"""
     acc = db.get(Account, account_id)
     if not acc:
         raise HTTPException(404, "account not found")
@@ -35,6 +36,10 @@ def _require_same_currency(db: Session, event_currency: str | None, account_id: 
     if acc.currency != ev_cur:
         raise HTTPException(
             422, f"同币种才可关联（不换算）：事件 {ev_cur} ≠ 账户 {acc.currency}")
+    if acc.status == "closed":
+        raise HTTPException(
+            422, f"账户 #{acc.id}（{acc.currency}）已于 {acc.closed_on} 关池，"
+                 f"只读终态不可收新流水（§6.6）")
     return acc
 
 

--- a/app/api/stock_events.py
+++ b/app/api/stock_events.py
@@ -33,7 +33,8 @@ router = APIRouter(prefix="/api/v1", tags=["stock-events"])
 
 
 def _require_same_currency(db: Session, event_currency: str | None, account_id: int):
-    """PRD §6.8 第3类铁律（四轮审计 #164）：同币种才连、不换算；不符则不可关联。"""
+    """PRD §6.8 第3类铁律（四轮审计 #164）：同币种才连、不换算；不符则不可关联。
+    五轮审计 #176：关池（closed）账户只读终态（§6.6），拒新流水。"""
     acc = db.get(Account, account_id)
     if not acc:
         raise HTTPException(404, "account not found")
@@ -41,6 +42,10 @@ def _require_same_currency(db: Session, event_currency: str | None, account_id: 
     if acc.currency != ev_cur:
         raise HTTPException(
             422, f"同币种才可关联（不换算）：事件 {ev_cur} ≠ 账户 {acc.currency}")
+    if acc.status == "closed":
+        raise HTTPException(
+            422, f"账户 #{acc.id}（{acc.currency}）已于 {acc.closed_on} 关池，"
+                 f"只读终态不可新流水（§6.6）")
     return acc
 
 

--- a/app/api/ui_ops.py
+++ b/app/api/ui_ops.py
@@ -17,7 +17,8 @@ from app.api.deps import apply_error, get_db
 from app.config import CALENDAR_MAX_YEAR as _YEAR_MAX  # issue #141
 from app.core.demand import accrue_demand_interest
 from app.core.invest import (
-    create_investment, redeem_investment, region_start_years, unlock_investment,
+    InvestmentError, create_investment, redeem_investment, region_start_years,
+    unlock_investment,
 )
 from app.core.recompute import recompute_all, record_recompute_done
 from app.core.snapshot import rebuild_snapshots
@@ -111,9 +112,12 @@ def post_investment(body: InvestmentIn, response: Response, db: Session = Depend
         inv = create_investment(db, year=body.year, region=body.region,
                                 risk_lvl=body.risk_lvl, start_date=body.start_date,
                                 allocs=allocs)
-    except Exception as e:  # noqa: BLE001 —— 业务校验统一映射
+    except InvestmentError as e:   # 业务校验族 → 422/409（五轮审计 #177：收窄捕获面）
         db.rollback()
         _apply_error(e)
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="操作失败：服务内部错误，请查看服务日志")
     _after_ui_write(db, body.year, f"投资 {body.region} R{body.risk_lvl} {body.year}")
     response.headers["Location"] = f"/api/v1/investments/{inv.id}"   # §14.1（issue #127）
     return {"id": inv.id, "status": "created", "year": body.year, "region": body.region}
@@ -127,9 +131,12 @@ def post_redeem(investment_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="investment not found")
     try:
         out = redeem_investment(db, inv)
-    except Exception as e:  # noqa: BLE001
+    except InvestmentError as e:   # 五轮审计 #177：业务族 → 422/409
         db.rollback()
         _apply_error(e)
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="操作失败：服务内部错误，请查看服务日志")
     _after_ui_write(db, inv.year, f"赎回投资 {inv.region} R{inv.risk_lvl} {inv.year}")
     return {"id": inv.id, **out}
 
@@ -158,9 +165,12 @@ def patch_investment(investment_id: int, body: InvestmentPatch,
     # 解锁（locked=false）：抹除旧写入，恢复 as-of
     try:
         inv = unlock_investment(db, inv)
-    except Exception as e:  # noqa: BLE001
+    except InvestmentError as e:   # 五轮审计 #177：业务族 → 422/409
         db.rollback()
         _apply_error(e)
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="操作失败：服务内部错误，请查看服务日志")
     _after_ui_write(db, inv.year, f"解锁投资 {inv.region} {inv.year}")
     return _inv_dict(inv, db.execute(
         select(InvestmentAlloc).where(InvestmentAlloc.investment_id == inv.id)
@@ -175,9 +185,12 @@ def post_transfer(body: TransferIn, db: Session = Depends(get_db)):
                        target_entity_id=body.target_entity_id,
                        target_currency=body.target_currency,
                        amount=body.amount, year=body.year)
-    except Exception as e:  # noqa: BLE001
+    except InvestmentError as e:   # 五轮审计 #177：业务族 → 422/409
         db.rollback()
         _apply_error(e)
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="操作失败：服务内部错误，请查看服务日志")
     _after_ui_write(db, body.year, f"{out['operation']} {body.year}")
     return {"status": "ok", **out}
 
@@ -201,8 +214,11 @@ def post_demand_interest(body: DemandInterestIn, db: Session = Depends(get_db)):
     """
     try:
         out = accrue_demand_interest(db, body.year)
-    except Exception as e:  # noqa: BLE001
+    except InvestmentError as e:   # 五轮审计 #177：业务族 → 422/409
         db.rollback()
         _apply_error(e)
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="操作失败：服务内部错误，请查看服务日志")
     _after_ui_write(db, body.year, f"活期结息 {body.year}")
     return {"status": "ok", **out}

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -64,7 +64,7 @@ def check_h2_amount_consistency(session: Session, from_year: int | None = None) 
     rows = session.execute(
         q.having(func.count() > 1, func.min(IncomeStream.amount) != func.max(IncomeStream.amount))
     ).all()
-    for eid, st, label, gk, cur, year, cnt, mn, mx in rows:
+    for eid, st, label, _gk, cur, year, cnt, mn, mx in rows:
         ent = session.get(Entity, eid)
         finds.append(Finding("H2", "crit", f"{ent.name if ent else '?'} {st} {cur} {year} [{label}]",
                              f"{cnt}条 金额 {mn} ≠ {mx}"))
@@ -258,7 +258,7 @@ def check_holding_value(session: Session) -> list[Finding]:
                HoldingEvent.entity_id, HoldingEvent.shares, HoldingEvent.unit_price)
         .where(HoldingEvent.shares > 0, HoldingEvent.closed_on.is_(None))
     ).all()
-    for hid, company, hdate, eid, shares, up in rows:
+    for hid, company, hdate, eid, _shares, up in rows:
         if up is None or float(up) == 0:
             finds.append(Finding("H-STOCK", "warn", f"holding_event#{hid} {company} {hdate}",
                                  f"shares>0 但 unit_price 缺失（无法估值）"))

--- a/app/core/hp_csc_chain.py
+++ b/app/core/hp_csc_chain.py
@@ -92,7 +92,6 @@ HP_CSC_DXC_EXPECTED = [
 ]
 
 #: 主链 unasserted 处理：HPQ 为父保留腿，由子链另验证（informational）
-HP_CSC_DXC_UNASSERTED = ["HPQ"]
 
 #: 只读 verify 子链（steps=[]，不重复 buy/分割；只复验主链已建头寸）
 HP_CSC_HPINC = {

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -178,8 +178,7 @@ def rebuild_snapshots(session: Session, years: range = None,
         holding_by_year[y] = {eid: Decimal(str(v))
                               for eid, v in portfolio_breakdown(session, date(y, 12, 30)).items()}
 
-    # 1) 清旧：仅清 from_year 起（含）的 account/entity/family 三种 scope 行
-    scope_prefixes = ("account:", "entity:", "family:")
+    # 1) 清旧：仅清 from_year 起（含）的三种 scope 行
     session.execute(
         delete(Snapshot).where(
             Snapshot.as_of_year >= start,

--- a/app/core/stock_cost.py
+++ b/app/core/stock_cost.py
@@ -196,6 +196,16 @@ def _event_nonce_applied(db: Session, entity_id: int, event_id: str) -> bool:
         HoldingEvent.source_file == event_id).limit(1)).scalar_one_or_none() is not None
 
 
+def _require_open_account(db: Session, account_id: int) -> None:
+    """五轮审计 #176：关池（closed）账户只读终态（§6.6），拒新流水——
+    手动 buy/sell/dividend 与事件关联共用同一防线（ValueError → API 层 422）。"""
+    from app.model import Account
+    acc = db.get(Account, account_id) if account_id else None
+    if acc is not None and acc.status == "closed":
+        raise ValueError(f"账户 #{account_id}（{acc.currency}）已于 {acc.closed_on} "
+                         f"关池，只读终态不可记新流水（§6.6）")
+
+
 def apply_buy(db: Session, *, entity_id: int, company: str, ticker: str | None = None,
               date, unit_price: float, shares: float, event_id: str, account_id: int) -> dict:
     """买入建仓：写 holding_event(batch) + ledger(现金移出，kind=investment)。
@@ -205,6 +215,7 @@ def apply_buy(db: Session, *, entity_id: int, company: str, ticker: str | None =
     if _event_nonce_applied(db, entity_id, event_id):
         return {"event_id": event_id, "entity_id": entity_id, "company": company,
                 "batch_id": None, "shares": shares, "cost_basis": 0.0, "skipped": True}
+    _require_open_account(db, account_id)   # 五轮审计 #176：关池拒新流水
     if not (account_id and unit_price and shares > 0):
         raise ValueError("apply_buy 需 account_id / unit_price>0 / shares>0")
     batch_id = next(_next_batch_ids(db, 1))
@@ -233,6 +244,7 @@ def apply_sell(db: Session, *, entity_id: int, company: str, date, shares: float
         return {"event_id": event_id, "company": company, "sold_shares": shares,
                 "cost_basis": 0.0, "proceeds": 0.0, "realized_pnl": 0.0,
                 "accepted": [], "skipped": True}
+    _require_open_account(db, account_id)   # 五轮审计 #176
     if not account_id or shares <= 0:
         raise ValueError("apply_sell 需 account_id / shares>0")
     rows = db.execute(select(HoldingEvent).where(
@@ -289,6 +301,7 @@ def apply_dividend(db: Session, *, entity_id: int, company: str, date, per_share
     if existing is not None:
         return {"event_id": event_id, "company": company, "holding_shares": 0.0,
                 "dividend": 0.0, "skipped": True}
+    _require_open_account(db, account_id)   # 五轮审计 #176
     holding = sum(b["shares"] for b in _open_batches(db, entity_id, company))
     amount = round(holding * per_share, 6)
     db.add(LedgerEntry(account_id=account_id, date=date, reason=f"股票分红·{company}",

--- a/app/core/transfer.py
+++ b/app/core/transfer.py
@@ -63,16 +63,23 @@ def _fx_rate(session: Session, fx_from: str, fx_to: str, year: int) -> Optional[
             ExchangeRate.year == year,
         ).limit(1)
     ).first()
-    if rrow is not None and rrow[0] is not None and Decimal(str(rrow[0])) != 0:
-        return Decimal(1) / Decimal(str(rrow[0]))
+    if rrow is not None and rrow[0] is not None:
+        rate = Decimal(str(rrow[0]))
+        if rate > 0:                     # 五轮审计 #175：与正向对称，负值取倒数仍非法
+            return Decimal(1) / rate
     return None
 
 
 def available_fx_pairs(session: Session, year: int) -> list[tuple[str, str]]:
-    """该年在库的直接货币对方向（issue #87-1：供错误提示/前端可用方向下拉）。"""
+    """该年在库的**有效**直接货币对方向（issue #87-1：供错误提示/前端可用方向下拉）。
+
+    五轮审计 #175：0/负汇率行不可用于换汇（_fx_rate 拒绝），提示列表同步过滤，
+    避免展示可选但提交必 422 的方向。
+    """
     return session.execute(
         select(ExchangeRate.fx_from, ExchangeRate.fx_to)
-        .where(ExchangeRate.year == year, ExchangeRate.rate.isnot(None))
+        .where(ExchangeRate.year == year,
+               ExchangeRate.rate.isnot(None), ExchangeRate.rate > 0)
         .order_by(ExchangeRate.fx_from, ExchangeRate.fx_to)
         .distinct()
     ).all()

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -179,6 +179,11 @@ def import_all(session, source_dir, log=None, force: bool = False, force_files=N
         if r.category == "return_table" and r.records:
             imported_rs.append(r)
             rcur += writer.import_return_curves(session, r.records)["n"]
+        if r.category == "return_table" and not r.records and r.warnings:
+            # 五轮审计 #177：零条告警达主链路（此前只进 run stdout，ingest 静默）——
+            # 落 ingest_report(warn) + 日志，供数据调整员察觉 catch-all 误归档
+            _record_parse_warning(session, r.file, "; ".join(r.warnings))
+            log(f"   ⚠ {r.file}: {r.warnings[0]}")
         if r.category == "fx" and r.records:
             fx_files.append(r)        # 收集，权威优先 + 冲突检测在下方统一处理
         if r.category == "timeline" and r.records:
@@ -394,6 +399,21 @@ def _record_parse_error(session, file_path: str, category: str, error: str | Non
     else:
         session.add(IngestReport(file_path=file_path, rule=category or None,
                                  level="error", line=None, detail=detail))
+
+def _record_parse_warning(session, file_path: str, detail: str) -> None:
+    """五轮审计 #177：解析层 warning 落库主链路（level='warn'，同键幂等）。"""
+    from sqlalchemy import select as _s
+    from app.model import IngestReport
+    existing = session.execute(_s(IngestReport).where(
+        IngestReport.file_path == file_path,
+        IngestReport.rule.is_(None),
+        IngestReport.level == "warn").limit(1)).scalar_one_or_none()
+    if existing is not None:
+        existing.detail = detail
+    else:
+        session.add(IngestReport(file_path=file_path, rule=None,
+                                 level="warn", line=None, detail=detail))
+
 
 def _log_soft(log, file: str, crep) -> int:
     """输出软警告（§11.4「标」：入库但高亮），返回条数（issue #72）。"""

--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -154,7 +154,6 @@ def _parse_fx_wide_table(lines: list[str]) -> list[dict]:
         if any(h in _FX_WIDE_HEADERS or _cn_cur(h) for h in hl):
             header = hl
             # 从 i+1 起扫数据行
-            cur_year = None
             recs: list[dict] = []
             for data_line in lines[i + 1:]:
                 ds = data_line.strip()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -82,8 +82,10 @@ export default function App() {
         {active === 'dashboard' && <Dashboard asOf={asOf} />}
         {/* issue #121：数据屏以 asOf 作 key——游标变动即重挂载重新拉取，全 App 联动。
             投资/划拨为写操作表单，有意不随游标联动（#143 备案，见各屏 docstring） */}
-        {active === 'invest' && <Invest asOf={asOf} />}
-        {active === 'transfer' && <Transfer asOf={asOf} />}
+        {/* 五轮审计 #177：死传参 asOf 改为 calMax（写操作年份上限动态收敛，#152 收尾） */}
+        {active === 'invest' && <Invest calMax={Number(calRange.max.slice(0, 4))} />}
+        {active === 'transfer' && <Transfer calMax={Number(calRange.max.slice(0, 4))} />}
+
         {active === 'returns' && <Returns key={`r-${asOf}`} asOf={asOf} />}
         {active === 'finance' && <Finance key={`f-${asOf}`} asOf={asOf} />}
         {active === 'labor' && <LaborCost />}
@@ -92,7 +94,7 @@ export default function App() {
         {active === 'persons' && <Graph url="/api/v1/graph/persons" />}
         {active === 'companies' && <CompanyGraph />}
         {active === 'graphall' && <Graph url="/api/v1/graph/all" />}
-        {active === 'timeline' && <Timeline key={`t-${asOf}`} asOf={asOf} />}
+        {active === 'timeline' && <Timeline key={`t-${asOf}`} asOf={asOf} calMax={Number(calRange.max.slice(0, 4))} />}
         {active === 'search' && <Search asOf={asOf} />}
         {active === 'diff' && <SourceDiff />}
         {active === 'health' && <Health />}
@@ -129,7 +131,10 @@ function NotificationsBanner({ onShowImpact }) {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ read_at: 'now' }),
-  }).finally(() => setItems(xs => xs.filter(x => x.id !== id)))
+  }).then(r => {
+    // 五轮审计 #177：仅成功才移除（失败保留，等下轮轮询重试），避免复活闪烁
+    if (r.ok) setItems(xs => xs.filter(x => x.id !== id))
+  }).catch(() => {})
 
   const healthText = (h) => {
     if (!h) return ''

--- a/frontend/src/screens/Health.jsx
+++ b/frontend/src/screens/Health.jsx
@@ -1,15 +1,17 @@
 import { useFetch } from './useDataOp'
+import { ErrorBox } from './ui'
 
 const RULES = ['H1', 'H2', 'H3', 'H4', 'H5', 'H-STOCK']
 
 /** F-U4 健康校验屏（issue #123）：H1–H5/H-STOCK 汇总 + 问题清单（文件/行/规则/明细）。 */
 export default function Health() {
-  const { data } = useFetch('/api/v1/health')
+  const { data, err } = useFetch('/api/v1/health')
   const summary = data?.summary || {}
   const findings = data?.findings || []
 
   return (
     <div className="cols2">
+      <ErrorBox error={err} />
       <div className="panel">
         <h3>健康校验汇总（H1–H5 · H-STOCK）</h3>
         <p className="note">GET /api/v1/health · 导入/UI 改动后重算完成时会自动复核（摘要随通知推送）</p>

--- a/frontend/src/screens/Invest.jsx
+++ b/frontend/src/screens/Invest.jsx
@@ -7,7 +7,7 @@ const RISK = ['R1', 'R2', 'R3', 'R4', 'R5']
 /** F-P1-01/02/09 投资屏：一年一投、R 级计息、年末赎回、失败整体拒绝（useDataOp）。
  *  #143 备案：本屏为写操作表单，**有意**不随全局日历游标（asOf）联动重挂载——
  *  投资年份/发生日由表单显式输入；余额校验以服务端 start_date 的 as-of 口径为准。 */
-export default function Invest() {
+export default function Invest({ calMax = 2026 }) {
   const regions = useFetch('/api/v1/returns/regions')
   const ents = useFetch('/api/v1/entities?page_size=200')
   const accts = useFetch('/api/v1/accounts?page_size=500')      // issue #87-2：币种下拉
@@ -86,7 +86,7 @@ export default function Invest() {
         <p className="note">DESIGN §19.1–19.4 · UI 派生通道 · 失败整体拒绝（表单保留不变）</p>
         <div className="form">
           <div className="row">
-            <Field label="年份"><input type="number" min={1947} max={2026} value={form.year}
+            <Field label="年份"><input type="number" min={1947} max={calMax} value={form.year}
               onChange={e => setYear(Number(e.target.value))} /></Field>
             <Field label="风险级">
               <select value={form.risk_lvl} onChange={e => set('risk_lvl', e.target.value)}>
@@ -138,7 +138,7 @@ export default function Invest() {
           <h3 style={{ marginTop: 22 }}>活期结息（§19.2 · 2% 年化按日折）</h3>
           <p className="note">对全部 active 账户按台账逐日余额加权计息，当年 12-30 入账；同年重跑幂等覆盖</p>
           <div className="row">
-            <Field label="结息年份"><input type="number" min={1947} max={2026} value={demandYear}
+            <Field label="结息年份"><input type="number" min={1947} max={calMax} value={demandYear}
               onChange={e => setDemandYear(Number(e.target.value))} /></Field>
             <button className="primary" disabled={demand.busy} style={{ alignSelf: 'flex-end' }}
               onClick={() => demand.submit('/api/v1/demand-interest', { year: Number(demandYear) })}>

--- a/frontend/src/screens/Movies.jsx
+++ b/frontend/src/screens/Movies.jsx
@@ -38,11 +38,11 @@ export default function Movies() {
             <span className="note">选择关联账户（同币种 {linking.currency || 'USD'} · PRD §6.8）：</span>
             <select value={accSel} onChange={e => setAccSel(e.target.value)}>
               <option value="">— 选账户 —</option>
-              {(accounts.data?.items || []).filter(a => a.currency === (linking.currency || 'USD')).map(a => (
+              {(accounts.data?.items || []).filter(a => a.currency === (linking.currency || 'USD') && a.status !== 'closed').map(a => (
                 <option key={a.id} value={a.id}>acct#{a.id} {a.currency}{a.status === 'closed' ? ' (已关)' : ''}</option>
               ))}
             </select>
-            {(accounts.data?.items || []).every(a => a.currency !== (linking.currency || 'USD')) &&
+            {!(accounts.data?.items || []).some(a => a.currency === (linking.currency || 'USD') && a.status !== 'closed') &&
               <span className="warn">无同币种 active/closed 账户可关联</span>}
             <button className="primary" disabled={!accSel || op.busy} onClick={doLink}>确认关联</button>
             <button className="ghost" onClick={() => { setLinking(null); setAccSel('') }}>取消</button>
@@ -73,7 +73,7 @@ export default function Movies() {
             {linkedItems.map(m => (
               <tr key={m.id}>
                 <td>{m.title}</td><td>acct#{m.linked_account_id}</td><td>{FMT(m.dividends_total)}</td>
-                <td><button className="ghost" onClick={() => op.submit(`/api/v1/movie-events/${m.id}/unlink`, {})}>解关联</button></td>
+                <td><button className="ghost" disabled={op.busy} onClick={() => op.submit(`/api/v1/movie-events/${m.id}/unlink`, {})}>解关联</button></td>
               </tr>
             ))}
             {!linkedItems.length && <tr><td colSpan="4" className="note">无已关联事件</td></tr>}

--- a/frontend/src/screens/SourceDiff.jsx
+++ b/frontend/src/screens/SourceDiff.jsx
@@ -70,7 +70,7 @@ export default function SourceDiff() {
                     <button className="primary" disabled={op.busy} onClick={() => adopt(f)}>采纳新版本</button>
                   )}
                   {(f.current_version && f.current_version > 1) && (
-                    <button className="ghost" onClick={() => restore(f, f.current_version - 1)}>回退上一版</button>
+                    <button className="ghost" disabled={op.busy} onClick={() => restore(f, f.current_version - 1)}>回退上一版</button>
                   )}
                 </td>
               </tr>

--- a/frontend/src/screens/Stock.jsx
+++ b/frontend/src/screens/Stock.jsx
@@ -88,9 +88,9 @@ export default function Stock() {
               </select>
               <select value={accSel} onChange={e => setAccSel(e.target.value)}>
                 <option value="">— 账户 —</option>
-                {accts.filter(a => a.currency === evCur).map(a => <option key={a.id} value={a.id}>acct#{a.id} {a.currency}</option>)}
+                {accts.filter(a => a.currency === evCur && a.status !== 'closed').map(a => <option key={a.id} value={a.id}>acct#{a.id} {a.currency}</option>)}
               </select>
-              {accts.length > 0 && accts.every(a => a.currency !== evCur) &&
+              {accts.length > 0 && !accts.some(a => a.currency === evCur && a.status !== 'closed') &&
                 <span className="warn">无同币种账户可关联</span>}
               <button className="primary" disabled={!entSel || !accSel || op.busy} onClick={doAssociate}>确认关联</button>
               <button className="ghost" onClick={() => { setAssocId(null); setEntSel(''); setAccSel('') }}>取消</button>

--- a/frontend/src/screens/Timeline.jsx
+++ b/frontend/src/screens/Timeline.jsx
@@ -6,7 +6,7 @@ import { ErrorBox, Field } from './ui'
  * 编年史屏（F-P2-05 · §12/§6.4）：overlay 增改删 + 差异/重置回源/以源为最新。
  * 用户覆盖行可编辑；系统行（投资/划拨 overlay）只读；源行可发起覆盖编辑。
  */
-export default function Timeline({ asOf }) {
+export default function Timeline({ asOf, calMax = 2026 }) {
   const [refresh, setRefresh] = useState(0)
   // issue #121：全局日历游标接入（§14.2 ?as_of= 已发生事件）
   const asOfQ = asOf ? `&as_of=${asOf}` : ''
@@ -38,19 +38,20 @@ export default function Timeline({ asOf }) {
 
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
 
-  const save = () => {
+  const save = async () => {
     const body = {
       event_year: Number(form.event_year), event_date: form.event_date || null,
       title: form.title, note: form.note || null, decade: form.decade || null,
     }
+    // 五轮审计 #177：await 结果，仅成功才关闭表单（失败保留编辑内容供修正重提）
+    let res
     if (editingKey === 'new') {
-      op.submit('/api/v1/timeline-events', body)
+      res = await op.submit('/api/v1/timeline-events', body)
     } else {
-      // 用标题/year 反查覆盖行 id → PATCH
       const row = items.find(r => r.editable && `${r.event_year}:${r.title}` === editingKey)
-      if (row) op.submit(`/api/v1/timeline-events/${row.id}`, body, { method: 'PATCH' })
+      if (row) res = await op.submit(`/api/v1/timeline-events/${row.id}`, body, { method: 'PATCH' })
     }
-    cancel()
+    if (res?.ok) cancel()
   }
 
   return (
@@ -64,7 +65,7 @@ export default function Timeline({ asOf }) {
           <div className="form">
             <h4>{editingKey === 'new' ? '新增覆盖条目' : `编辑覆盖条目 ${editingKey}`}</h4>
             <div className="row">
-              <Field label="年份"><input type="number" min={1947} max={2026} value={form.event_year}
+              <Field label="年份"><input type="number" min={1947} max={calMax} value={form.event_year}
                 onChange={e => set('event_year', Number(e.target.value))} /></Field>
               <Field label="日期"><input type="date" value={form.event_date}
                 onChange={e => set('event_date', e.target.value)} /></Field>
@@ -104,9 +105,9 @@ export default function Timeline({ asOf }) {
                     {isUser ? (
                       <>
                         <button className="ghost" onClick={() => startEdit(r)}>编辑</button>
-                        <button className="ghost" onClick={() => op.submit(`/api/v1/timeline-events/${r.id}/overlay/restore`, {})}>重置回源</button>
-                        <button className="ghost" onClick={() => op.submit(`/api/v1/timeline-events/${r.id}/overlay/source-as-latest`, {})}>以源为最新</button>
-                        <button className="ghost" onClick={() => op.submit(`/api/v1/timeline-events/${r.id}`, {}, { method: 'DELETE' })}>删除</button>
+                        <button className="ghost" disabled={op.busy} onClick={() => op.submit(`/api/v1/timeline-events/${r.id}/overlay/restore`, {})}>重置回源</button>
+                        <button className="ghost" disabled={op.busy} onClick={() => op.submit(`/api/v1/timeline-events/${r.id}/overlay/source-as-latest`, {})}>以源为最新</button>
+                        <button className="ghost" disabled={op.busy} onClick={() => op.submit(`/api/v1/timeline-events/${r.id}`, {}, { method: 'DELETE' })}>删除</button>
                       </>
                     ) : !r.system ? (
                       <button className="ghost" onClick={() => startCreate(r)}>覆盖编辑</button>

--- a/frontend/src/screens/Transfer.jsx
+++ b/frontend/src/screens/Transfer.jsx
@@ -5,7 +5,7 @@ import { ErrorBox, Field } from './ui'
 /** F-P1-03/09 划拨/换汇屏：同币=划拨、跨币=换汇（需该年汇率），转出向后全链不破负。
  *  #143 备案：本屏为写操作表单，**有意**不随全局日历游标（asOf）联动——
  *  划拨年份由表单显式输入；余额校验以服务端该年 as-of 口径为准。 */
-export default function Transfer() {
+export default function Transfer({ calMax = 2026 }) {
   const accounts = useFetch('/api/v1/accounts?page_size=200')
   const entities = useFetch('/api/v1/entities?page_size=200')
   const op = useDataOp()
@@ -53,7 +53,7 @@ export default function Transfer() {
         <div className="form">
           <div className="row">
             <Field label="年份">
-              <input type="number" min={1947} max={2026} value={form.year}
+              <input type="number" min={1947} max={calMax} value={form.year}
                 onChange={e => set('year', Number(e.target.value))} />
             </Field>
           </div>

--- a/tests/test_issue160_165_p0.py
+++ b/tests/test_issue160_165_p0.py
@@ -46,6 +46,11 @@ def db():
         engine.dispose()
 
 
+def _client(db):
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
 # ---- #160 PDF 中文字体 ----
 class TestPdfCjk:
     def test_pdf_registers_cjk_font(self):
@@ -240,3 +245,61 @@ class TestSameCurrencyLink:
 def db_ledger(db, account_id):
     return db.execute(select(LedgerEntry).where(
         LedgerEntry.account_id == account_id)).scalars().all()
+
+
+# ---- 五轮审计 #175/#176 回归 ----
+class TestReverseNegativeRate:
+    def test_reverse_negative_rate_row_rejected(self, db):
+        """反向行 rate=-40 → 取倒数仍非法 → 422（修复前 -1/40 负流水入账）。"""
+        from app.core.invest import ValidationError
+        from app.core.transfer import transfer
+        e = Entity(entity_type="person", name="T175")
+        db.add(e); db.flush()
+        src = Account(entity_id=e.id, currency="EUR")
+        db.add(src); db.flush()
+        db.add(LedgerEntry(account_id=src.id, date=date(1999, 6, 1),
+                           reason="期初", inflow=100, balance=100, kind="income"))
+        # 仅反向行：BEF→EUR rate=-40；请求方向 EUR→BEF
+        db.add(ExchangeRate(fx_from="BEF", fx_to="EUR", year=1999, rate=-40))
+        db.commit()
+        with pytest.raises(ValidationError):
+            transfer(db, source_account_id=src.id, target_entity_id=e.id,
+                     target_currency="BEF", amount=10, year=1999)
+
+    def test_available_pairs_excludes_nonpositive(self, db):
+        from app.core.transfer import available_fx_pairs
+        db.add(ExchangeRate(fx_from="AAA", fx_to="BBB", year=1999, rate=0))
+        db.add(ExchangeRate(fx_from="CCC", fx_to="DDD", year=1999, rate=-5))
+        db.add(ExchangeRate(fx_from="EEE", fx_to="FFF", year=1999, rate=2))
+        db.commit()
+        pairs = available_fx_pairs(db, 1999)
+        assert ("EEE", "FFF") in pairs
+        assert ("AAA", "BBB") not in pairs and ("CCC", "DDD") not in pairs
+
+
+class TestClosedAccountGate:
+    def test_movie_link_to_closed_account_422(self, db):
+        e = Entity(entity_type="person", name="C176a")
+        db.add(e); db.flush()
+        acc = Account(entity_id=e.id, currency="USD", status="closed",
+                      closed_on=date(2003, 1, 1))
+        db.add(acc)
+        m = MovieEvent(title="closed测试", currency="USD",
+                       investment_date=date(1995, 6, 1), investment_total=50.0)
+        db.add(m); db.commit()
+        with _client(db) as c:
+            r = c.post(f"/api/v1/movie-events/{m.id}/link", json={"account_id": acc.id})
+            assert r.status_code == 422 and "关池" in r.json()["detail"]
+
+    def test_stock_buy_on_closed_account_422(self, db):
+        e = Entity(entity_type="person", name="C176b")
+        db.add(e); db.flush()
+        acc = Account(entity_id=e.id, currency="USD", status="closed",
+                      closed_on=date(2003, 1, 1))
+        db.add(acc); db.commit()
+        with _client(db) as c:
+            r = c.post("/api/v1/stock-events/buy", json={
+                "entity_id": e.id, "company": "X", "date": "2018-05-07",
+                "unit_price": 2.0, "shares": 10, "event_id": "ui-closed-1",
+                "account_id": acc.id})
+            assert r.status_code == 422 and "关池" in r.json()["detail"]

--- a/tests/test_issue170_gaps.py
+++ b/tests/test_issue170_gaps.py
@@ -143,20 +143,28 @@ class TestAdminCleanG5:
 
 class TestWealthEndpointG6:
     def test_wealth_series_and_missing_rates_shape(self, db):
+        """五轮审计 #177 补强：missing_rates 语义实质断言（此前仅断 dict 类型=假绿）。"""
         e = Entity(entity_type="person", name="W人")
         db.add(e); db.flush()
         acc = Account(entity_id=e.id, currency="XYZ")   # 无汇率的币种
         db.add(acc); db.flush()
         db.add(LedgerEntry(account_id=acc.id, date=date(1990, 12, 30),
                            reason="期初", inflow=500, balance=500, kind="income"))
-        db.add(Snapshot(as_of_year=1990, as_of_date=None, scope="family:total",
-                        value=0, currency="USD"))
         db.commit()
+        # wealth_series 读预计算快照 → 先重建（含 missing_rates 反推所需的 account:* 行）
+        from app.core.snapshot import rebuild_snapshots
+        rebuild_snapshots(db)
         with _client(db) as c:
             r = c.get("/api/v1/wealth?year_from=1989&year_to=1991")
             assert r.status_code == 200
             body = r.json()
-            assert isinstance(body, dict) and body
+            # 1990 年有 XYZ 账户余额但无汇率 → 该年 missing_rates 必含 XYZ
+            y1990 = body.get("1990") or {}
+            assert "XYZ" in (y1990.get("missing_rates") or []), \
+                f"missing_rates 未反映 XYZ 汇率缺失: {y1990}"
+            # 1989（无流水年）不误报 XYZ
+            y1989 = body.get("1989") or {}
+            assert "XYZ" not in (y1989.get("missing_rates") or [])
 
 
 class TestPoolInTransitCrossYearG8:


### PR DESCRIPTION
## 概要

五轮审计修复（四轮修复批回归深审发现的新问题 + 前端残余/全库一致性）。22 文件 +215/−48；pytest **531 passed**（+4），vite build 通过。

| Issue | 内容 |
|---|---|
| #175 | 换汇**反向**负汇率穿透修复（`!=0`→`>0` 对称，此前 `-1/40` 负流水入账）；available_fx_pairs 过滤 0/负行 |
| #176 | closed 关池账户全通道拒新流水：movie link / stock associate 422；stock_cost `_require_open_account` 防线覆盖手动 buy/sell/dividend；前端下拉过滤 closed |
| #177 | 卫生九项：ui_ops 五端点异常收窄、ack 校验+catch、Timeline save 失败保留编辑、行级按钮 busy×5、年份 max 动态化（calMax）、Health err 上屏、G6 missing_rates 实质断言（修假绿）、return_table 零条告警达主链路、死变量/未用导入清理 |
| #178 | CLAUDE.md §20 表述更新 + CHANGELOG 补三轮/四轮/五轮批条目 |

## 验证

```
APP_ENV=test pytest -q   → 531 passed（基线 527 + 新增回归）
frontend vite build      → ✓
```

Closes #175, closes #176, closes #177, closes #178