### PR TITLE
chore(p3): 五轮收敛尾巴清理（#179 附注两条备案项）

### DIFF
--- a/app/core/stock_cost.py
+++ b/app/core/stock_cost.py
@@ -198,10 +198,14 @@ def _event_nonce_applied(db: Session, entity_id: int, event_id: str) -> bool:
 
 def _require_open_account(db: Session, account_id: int) -> None:
     """五轮审计 #176：关池（closed）账户只读终态（§6.6），拒新流水——
-    手动 buy/sell/dividend 与事件关联共用同一防线（ValueError → API 层 422）。"""
+    手动 buy/sell/dividend 与事件关联共用同一防线（ValueError → API 层 422）。
+    六轮收敛 #179 附注：account_id 缺失/不存在同样在此拒绝（此前 dividend
+    缺校验会落到 ledger FK 约束裸 500）。"""
     from app.model import Account
     acc = db.get(Account, account_id) if account_id else None
-    if acc is not None and acc.status == "closed":
+    if acc is None:
+        raise ValueError(f"apply 需有效 account_id（收到 {account_id!r}）")
+    if acc.status == "closed":
         raise ValueError(f"账户 #{account_id}（{acc.currency}）已于 {acc.closed_on} "
                          f"关池，只读终态不可记新流水（§6.6）")
 

--- a/frontend/src/screens/Movies.jsx
+++ b/frontend/src/screens/Movies.jsx
@@ -39,11 +39,11 @@ export default function Movies() {
             <select value={accSel} onChange={e => setAccSel(e.target.value)}>
               <option value="">— 选账户 —</option>
               {(accounts.data?.items || []).filter(a => a.currency === (linking.currency || 'USD') && a.status !== 'closed').map(a => (
-                <option key={a.id} value={a.id}>acct#{a.id} {a.currency}{a.status === 'closed' ? ' (已关)' : ''}</option>
+                <option key={a.id} value={a.id}>acct#{a.id} {a.currency}</option>
               ))}
             </select>
             {!(accounts.data?.items || []).some(a => a.currency === (linking.currency || 'USD') && a.status !== 'closed') &&
-              <span className="warn">无同币种 active/closed 账户可关联</span>}
+              <span className="warn">无同币种可用账户可关联</span>}
             <button className="primary" disabled={!accSel || op.busy} onClick={doLink}>确认关联</button>
             <button className="ghost" onClick={() => { setLinking(null); setAccSel('') }}>取消</button>
           </div>


### PR DESCRIPTION
第六轮收敛验证【收敛】结论下的两条备案级尾巴：Movies.jsx 过滤后死分支与陈旧文案；apply_dividend 补账户存在性校验（None/不存在 → ValueError 422，替代 FK 裸 500）。pytest 531 passed / build ✓。