### PR TITLE
fix(p1-p3): 八轮审计修复 —— transfer nonce 可达性 + skipped short-circuit + ci.yml 入库（#189-#190，索引 #191）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # 单元测试全部跑在内存 SQLite 上，不依赖本地 Postgres / Design_Folder（issue #128）。
+      # 真实 Postgres 集成验证仍按 §17 在本机对 novel_test 库执行（见 CLAUDE.md）。
+      - name: Run tests
+        env:
+          APP_ENV: test
+        run: python -m pytest -q
+
+  frontend-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: npm run build

--- a/app/api/ui_ops.py
+++ b/app/api/ui_ops.py
@@ -51,6 +51,9 @@ class TransferIn(BaseModel):
     target_currency: str
     amount: float
     year: int = Field(ge=1947, le=_YEAR_MAX)
+    # 八轮审计 #189：客户端幂等键——同一表单重试复用同一 nonce → 服务端查重 skipped；
+    # 缺省时服务端生成（兼容直调方，但该路径无重放保护）
+    nonce: str | None = Field(default=None, max_length=32)
 
 
 _apply_error = apply_error   # issue #132：收敛到 deps 共享
@@ -187,13 +190,16 @@ def post_transfer(body: TransferIn, db: Session = Depends(get_db)):
                        target_entity_id=body.target_entity_id,
                        target_currency=body.target_currency,
                        amount=body.amount, year=body.year,
-                       nonce=uuid4().hex[:12])   # 七轮审计 #182：幂等标签
+                       nonce=body.nonce or uuid4().hex[:12])   # 七轮 #182 + 八轮 #189：客户端幂等键透传
     except InvestmentError as e:   # 五轮审计 #177：业务族 → 422/409
         db.rollback()
         _apply_error(e)
     except Exception:
         db.rollback()
         raise HTTPException(status_code=500, detail="操作失败：服务内部错误，请查看服务日志")
+    if out.get("skipped"):
+        # 八轮审计 #189：幂等重放无写入——short-circuit，不跑全量重算/通知/commit
+        return {"status": "skipped", **out}
     _after_ui_write(db, body.year, f"{out['operation']} {body.year}")
     return {"status": "ok", **out}
 

--- a/app/core/transfer.py
+++ b/app/core/transfer.py
@@ -206,7 +206,8 @@ def transfer(session: Session, *, source_account_id: int, target_entity_id: int,
              + "（UI 转移）",   # issue #132：统一 §19 定位标签为「UI 转移」前缀
         decade=f"{year // 10 * 10}s", overlay=True,     ))
     return {
-        "operation": op, "source_account_id": source.id, "target_account_id": target.id,
+        "operation": op, "skipped": False,
+        "source_account_id": source.id, "target_account_id": target.id,
         "source_currency": source.currency, "target_currency": target.currency,
         "amount": float(amt), "target_amount": float(target_amount), "year": year,
     }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -155,7 +155,7 @@ function NotificationsBanner({ onShowImpact }) {
             {!!findings.length && (
               <details style={{ width: '100%' }}>
                 <summary className="note">受影响明细（前 {findings.length} / 共 {total}）</summary>
-                <pre className="mono" style={{ maxHeight: 200, overflow: 'auto', background: '#fff' }}>
+                <pre className="mono" style={{ maxHeight: 200, overflow: 'auto', background: 'var(--surface-1)' }}>
                   {findings.map((f, i) =>
                     `[${f.rule}/${f.level}] ${f.location}: ${f.detail}`).join('\n')}
                 </pre>

--- a/frontend/src/screens/Transfer.jsx
+++ b/frontend/src/screens/Transfer.jsx
@@ -33,6 +33,13 @@ export default function Transfer({ calMax = 2026 }) {
   // 源账户/年份变化后目标币种随之回落到合法首项（避免显示与提交不一致）
   const effTarget = validTargets.includes(form.target_currency) ? form.target_currency : (validTargets[0] || '')
 
+  // 八轮审计 #189：表单级幂等键——挂载生成、仅成功提交后重置；
+  // 双击/重试复用同一 nonce → 服务端查重第二次 skipped，不再双记账
+  const [nonce, setNonce] = useState(() =>
+    (crypto.randomUUID?.() || `${Date.now()}${Math.random()}`).replace(/-/g, '').slice(0, 12))
+  const newNonce = () => setNonce(
+    (crypto.randomUUID?.() || `${Date.now()}${Math.random()}`).replace(/-/g, '').slice(0, 12))
+
   const doSubmit = async () => {
     if (!form.source_account_id || !form.target_entity_id) return
     const res = await op.submit('/api/v1/transfers', {
@@ -41,8 +48,14 @@ export default function Transfer({ calMax = 2026 }) {
       target_currency: effTarget || form.target_currency,
       amount: Number(form.amount),
       year: Number(form.year),
+      nonce,
     })
-    if (res.ok) { setForm(f => ({ ...f, amount: '' })) }
+    if (res.ok) {
+      setForm(f => ({ ...f, amount: '' }))
+      newNonce()
+    }
+    // skipped（幂等重放）也重置 nonce——用户需感知为一次新操作起点
+    else if (res.data?.status === 'skipped') { newNonce() }
   }
 
   return (
@@ -95,7 +108,9 @@ export default function Transfer({ calMax = 2026 }) {
           <ErrorBox error={op.error} />
           {op.last && (
             <div className="result">
-              {op.last.operation === '换汇' ? '换汇' : '划拨'}：{op.last.amount} {op.last.source_currency} → {op.last.target_amount} {op.last.target_currency}
+              {op.last.status === 'skipped' || op.last.operation === '重放跳过'
+                ? '重复提交已跳过（幂等保护）——该笔此前已入账'
+                : `${op.last.operation === '换汇' ? '换汇' : '划拨'}：${op.last.amount} ${op.last.source_currency} → ${op.last.target_amount} ${op.last.target_currency}`}
             </div>
           )}
         </div>

--- a/frontend/src/screens/ui.jsx
+++ b/frontend/src/screens/ui.jsx
@@ -15,7 +15,8 @@ export function ErrorBox({ error }) {
 }
 
 export function fmt(n) {
-  if (n === null || n === undefined || Number.isNaN(n)) return '—'
+  // 八轮审计 #190：非数值输入守卫（此前字符串会输出 "NaN" 字样）
+  if (typeof n !== 'number' || Number.isNaN(n)) return n === null || n === undefined ? '—' : String(n)
   const abs = Math.abs(n)
   if (abs >= 1e8) return (n / 1e8).toFixed(2) + ' 亿'
   if (abs >= 1e4) return (n / 1e4).toFixed(1) + ' 万'

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -10,10 +10,13 @@ body { background: var(--page); color: var(--ink); font-family: system-ui, -appl
   --good:#0ca30c; --warn:#fab219; --crit:#d03b3b;
   --card:hsl(0 0% 100% / .65); --border:rgba(11,11,11,.10);
   --shadow:0 1px 2px rgba(11,11,11,.05), 0 4px 14px rgba(11,11,11,.05);
+  /* 八轮审计 #190：补齐 badge/banner 引用的语义变量（原引用未定义恒走兜底色） */
+  --panel:#fcfcfb; --accent:#2a78d6; --diff-add-bg:rgba(12,163,12,.10); --diff-del-bg:rgba(208,59,59,.10);
   min-height: 100vh; padding: 20px clamp(12px, 3vw, 40px) 60px; }
 :root[data-theme="dark"] .viz { --surface-1:#1a1a19; --page:#0d0d0d; --ink:#fff; --ink-2:#c3c2b7;
   --muted:#898781; --grid:#2c2c2a; --axis:#383835; --s1:#3987e5; --s2:#d95926; --s3:#199e70;
-  --good:#0ca30c; --warn:#fab219; --crit:#d03b3b; --card:hsl(0 0% 9%/.6); --border:rgba(255,255,255,.10); }
+  --good:#0ca30c; --warn:#fab219; --crit:#d03b3b; --card:hsl(0 0% 9%/.6); --border:rgba(255,255,255,.10);
+  --panel:#242423; --accent:#3987e5; --diff-add-bg:rgba(12,163,12,.16); --diff-del-bg:rgba(208,59,59,.16); }
 
 .topbar { display: flex; align-items: center; gap: 16px; padding: 6px 2px 14px; }
 .brand h1 { font-size: 17px; font-weight: 650; }
@@ -84,17 +87,17 @@ button.ghost:hover { color: var(--ink); }
   padding: 1px 7px;
   border-radius: 9px;
   font-size: 11px;
-  background: var(--panel, #1f2937);
+  background: var(--panel);
   border: 1px solid var(--border, #374151);
-  color: var(--muted, #9ca3af);
+  color: var(--ink-2);
 }
 .badge.warn {
   color: var(--warn, #d97706);
   border-color: var(--warn, #d97706);
 }
 .banner {
-  border-left: 3px solid var(--accent, #2563eb);
+  border-left: 3px solid var(--accent);
   margin-bottom: 10px;
 }
-.diff-add { color: #22c55e; background: rgba(34, 197, 94, .08); }
-.diff-del { color: #ef4444; background: rgba(239, 68, 68, .08); text-decoration: line-through; }
+.diff-add { color: var(--good); background: var(--diff-add-bg); }
+.diff-del { color: var(--crit); background: var(--diff-del-bg); text-decoration: line-through; }

--- a/tests/test_issue160_165_p0.py
+++ b/tests/test_issue160_165_p0.py
@@ -303,3 +303,78 @@ class TestClosedAccountGate:
                 "unit_price": 2.0, "shares": 10, "event_id": "ui-closed-1",
                 "account_id": acc.id})
             assert r.status_code == 422 and "关池" in r.json()["detail"]
+
+
+# ---- 八轮审计 #189：transfer nonce 幂等 API 链路可达 ----
+class TestTransferNonceIdempotent:
+    def _seed(self, db):
+        # 目标用另一实体（同实体同币种会被 primary_account 解析回源账户自身）
+        e_src = Entity(entity_type="person", name="T189s")
+        e_dst = Entity(entity_type="person", name="T189d")
+        db.add_all([e_src, e_dst]); db.flush()
+        src = Account(entity_id=e_src.id, currency="EUR")
+        dst = Account(entity_id=e_dst.id, currency="EUR")   # 同币种=划拨路径，无需汇率
+        db.add_all([src, dst]); db.flush()
+        db.add(LedgerEntry(account_id=src.id, date=date(1999, 6, 1),
+                           reason="期初", inflow=1000, balance=1000, kind="income"))
+        db.commit()
+        return e_dst, src, dst
+
+    def test_same_nonce_replay_skipped_no_double_entry(self, db):
+        """同 nonce 双提交：第二次 skipped 且 ledger 仅一对分录。"""
+        from app.core.transfer import transfer
+        e_target, src, dst = self._seed(db)   # e_target=目标实体
+        r1 = transfer(db, source_account_id=src.id, target_entity_id=e_target.id,
+                      target_currency="EUR", amount=100, year=1999,
+                      nonce="abc123def456")
+        assert r1["skipped"] is not True
+        r2 = transfer(db, source_account_id=src.id, target_entity_id=e_target.id,
+                      target_currency="EUR", amount=100, year=1999,
+                      nonce="abc123def456")
+        assert r2["skipped"] is True
+        # 仅一对分录（源 outflow + 目标 inflow 各一笔）
+        n_src = len(db.execute(select(LedgerEntry).where(
+            LedgerEntry.account_id == src.id)).scalars().all())
+        n_dst = len(db.execute(select(LedgerEntry).where(
+            LedgerEntry.account_id == dst.id)).scalars().all())
+        assert n_src == 2 and n_dst == 1   # 源=期初+转出；目标=转入
+
+    def test_different_nonce_both_post(self, db):
+        """不同 nonce（新操作）正常各自入账——幂等不误伤。"""
+        from app.core.transfer import transfer
+        e_target, src, dst = self._seed(db)   # e_target=目标实体
+        for i, nc in enumerate(["aaa111", "bbb222"]):
+            r = transfer(db, source_account_id=src.id, target_entity_id=e_target.id,
+                         target_currency="EUR", amount=10, year=1999, nonce=nc)
+            assert r["skipped"] is not True
+        n_dst = len(db.execute(select(LedgerEntry).where(
+            LedgerEntry.account_id == dst.id)).scalars().all())
+        assert n_dst == 2
+
+    def test_api_nonce_passthrough_and_skipped_shortcircuit(self, db):
+        """API 层透传客户端 nonce；skipped 不产生 recompute-done（short-circuit）。"""
+        from fastapi.testclient import TestClient
+        from app.model import Notification
+        e_src = Entity(entity_type="person", name="T189api")
+        e_dst = Entity(entity_type="person", name="T189apiD")
+        db.add_all([e_src, e_dst]); db.flush()
+        src = Account(entity_id=e_src.id, currency="EUR")
+        db.add(Account(entity_id=e_dst.id, currency="EUR"))   # 目标主体需有该币种账户
+        db.add(src); db.flush()
+        db.add(LedgerEntry(account_id=src.id, date=date(1999, 6, 1),
+                           reason="期初", inflow=500, balance=500, kind="income"))
+        db.commit()
+        body = {"source_account_id": src.id, "target_entity_id": e_dst.id,
+                "target_currency": "EUR", "amount": 50, "year": 1999,
+                "nonce": "replay999999"}
+        app.dependency_overrides[get_db] = lambda: db
+        try:
+            with TestClient(app) as c:
+                r1 = c.post("/api/v1/transfers", json=body)
+                assert r1.status_code == 200 and r1.json()["status"] == "ok"
+                n_after_first = len(db.query(Notification).all())
+                r2 = c.post("/api/v1/transfers", json=body)   # 同 nonce 重放
+                assert r2.status_code == 200 and r2.json()["status"] == "skipped"
+            assert len(db.query(Notification).all()) == n_after_first   # 无新通知
+        finally:
+            app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## 概要

八轮独立复核发现七轮 #182 修复的**实现级缺陷**：nonce 幂等机制已写但接线错误——服务端每 POST 现生成 uuid4、schema/前端均不传 → 查重永不命中、双击仍双记账。本 PR 修复并顺带清掉 ci.yml 游离与前端外观四件。8 文件 +155/−12；pytest **537 passed**（+3），vite build 通过。

| Issue | 内容 |
|---|---|
| #189 | TransferIn 加可选 `nonce` 字段透传；Transfer.jsx 表单级幂等键（挂载生成、成功后重置——双击复用同 nonce 第二次 skipped）；skipped short-circuit（跳过全量重算/通知/commit）；「重复提交已跳过」提示替代误导渲染；正常路径响应补 `skipped:false`；3 个重放回归用例 |
| #190 | `.github/workflows/ci.yml` 入库（远端 CI 首次生效）；styles.css 补 `--panel/--accent/diff-bg` 语义变量（亮暗两套）；findings pre 白底改 surface-1；ui.fmt 非数值守卫 |

## 等价性结论附注（A 组 ✅）

currency 重构逐分支等价确认：直连排序语义新旧一致、hub/quantize 一致、NULL-rate 行为变化实测三库 0 行零影响且方向更稳；备案 14 项终态盘点全部维持合理。

Closes #189, closes #190, closes #191