### PR TITLE
feat(p1): 外部 API v2.6 适配（#193）—— companies 税区落库 / positions unknown_level 防低估

### DIFF
--- a/app/ingest/importers/company_info.py
+++ b/app/ingest/importers/company_info.py
@@ -96,6 +96,9 @@ def import_external_companies(session: Session, companies: list[dict]) -> dict:
             "opening_date": rec.get("opening_date"),
             "closing_date": rec.get("closing_date"),
             "is_active": rec.get("is_active"),
+            # 外部 API v1.6/v2.6 R1：公司↔税区一对一（内部成本口径键，对外仅引用）
+            "tax_zone_id": rec.get("tax_zone_id"),
+            "tax_zone_label": rec.get("tax_zone_label"),
         }
         comp = writer.upsert_entity(
             session, "company", name, source="external-api", fields=fields)

--- a/app/ingest/importers/positions.py
+++ b/app/ingest/importers/positions.py
@@ -130,13 +130,20 @@ def run_labor_cost(db: Session, year: int, company_ids: list[int] | None = None,
     token = login_and_token(url, username, password, client=client)
     positions = fetch_positions(url, token, year, company_ids, client=client)
     costs = []
+    unknown_levels: list[str] = []
     for p in positions:
         if not _in_post(p, year):
             continue
+        lvl = p.get("level")
+        if lvl and lvl not in LC.LEVEL_PCT:
+            # 外部 API v2.6 /public/levels 字典对齐提示：未知 level 会按 0% 费率计成本
+            # （静默低估）——计入返回统计供调用方察觉，必要时以 public.levels 对齐编码
+            unknown_levels.append(str(lvl))
         c = LC.compute_position_cost(db, p, year)
         costs.append(c)
     agg = aggregate_to_finance(db, costs, year)
-    return {"year": year, "companies_computed": agg, "positions_fetched": len(positions)}
+    return {"year": year, "companies_computed": agg, "positions_fetched": len(positions),
+            "unknown_levels": sorted(set(unknown_levels))}
 
 
 __all__ = ["run_labor_cost", "fetch_positions", "login_and_token",

--- a/docs/DESIGN-webnovel-dashboard.md
+++ b/docs/DESIGN-webnovel-dashboard.md
@@ -620,6 +620,12 @@ class Importer(Protocol):
 - 配置 provider + 凭据（本地）；结果出现在「导入状态」屏；失败进入需人工处理。
 - **凭据存放**：外部 API 凭据放本地 `secrets.local.yaml`（**不入 git、不入 DB**）；adapter 只通过配置键读取，不在日志或 notification 中泄露。
 - **实现（API① · F-P1-05）**：`app/ingest/importers/company_info.py`（login→fetch `/public/companies`→按 `(entity_type='company', name)` 只增不减 upsert，source=`external-api`；股权结构→公司/自然人股东建实体 + `rel_type='holds'` 边；开停业日期/外部ID/持股比落 `entity.fields` JSONB）。凭据 `secrets.local.yaml` + 环境变量覆盖，URL per-env 默认 dev/test 7273、prod 7274。触发 `POST /api/v1/graph/companies/import`。
+- **外部 API v2.6 适配（2026-08-26）**：① `/public/companies` 新增 `tax_zone_id/tax_zone_label`
+  （公司↔税区一对一，内部成本口径键）随 fields 落库备查；② `/public/positions` v2.6 R2
+  「计算权移交第三方」与现架构一致（外部只给明细、本地基准自算成本），新增
+  `unknown_levels` 统计防未知 level 静默 0% 低估；③ `/public/levels` 字典端点暂不接入
+  （LEVEL_PCT 为本方费率映射表，外部字典仅编码展示）；④ 403 权限语义/429 限流由既有
+  upstream 错误映射覆盖。
 - **实现（API② 用工成本 · F-P1-10）**：`app/core/labor_cost.py`（本地基准 + 税率公式执行器 + 逐岗位成本；Level/外包/晋级规则表，也是「加薪规则」屏数据源）+ `app/ingest/importers/positions.py`（`GET /public/positions?year=` 拉流入岗岗位 → 逐岗位算成本 → 每公司×年 `finance_entry(entity_kind='company', kind='expense')` 落账）。基准三表 `labor_wage_benchmark / labor_cpi_growth / labor_tax_benchmark`（`python -m app.ingest.main labor-baseline`）。税率公式细节只在后台（含说明文字隐藏项：比利时 CP200 十三薪/双倍假期、英国学徒税 >£3m、日本固定奖金 3 月等）；UI 只展示加薪规则。端点 `POST /labor-cost/compute`、`GET /labor-cost/rules|results`。
 
 ---

--- a/tests/test_company_import.py
+++ b/tests/test_company_import.py
@@ -184,3 +184,25 @@ class TestWriterExtras:
         session.commit()
         assert rel.since_year == 1990
         assert rel.until_year == 2000  # 同键复用并更新年窗
+
+# ---- 外部 API v1.6/v2.6 更新适配（tax_zone 字段落 fields）----
+def test_tax_zone_fields_persisted(session):
+    """v1.6/v2.6 R1：tax_zone_id/tax_zone_label 随公司信息落 entity.fields 备查。"""
+    recs = [{"id": 77, "name": "税区对照公司", "is_active": True,
+             "tax_zone_id": 3, "tax_zone_label": "比利时（国家级）",
+             "shareholders": []}]
+    company_info.import_external_companies(session, recs)
+    session.flush()
+    ent = session.query(Entity).filter(Entity.name == "税区对照公司").one()
+    assert ent.fields["tax_zone_id"] == 3
+    assert ent.fields["tax_zone_label"] == "比利时（国家级）"
+
+
+def test_tax_zone_absent_is_none_not_missing_key(session):
+    """旧版响应无 tax_zone 字段 → fields 显式 None（不缺键，消费方安全 .get）。"""
+    recs = [{"id": 78, "name": "旧版无税区公司", "is_active": True}]
+    company_info.import_external_companies(session, recs)
+    session.flush()
+    ent = session.query(Entity).filter(Entity.name == "旧版无税区公司").one()
+    assert ent.fields.get("tax_zone_id") is None
+    assert ent.fields.get("tax_zone_label") is None

--- a/tests/test_labor_cost.py
+++ b/tests/test_labor_cost.py
@@ -221,3 +221,35 @@ def test_rules_payload_hides_levy_details():
     payload = L.rules_payload()
     blob = str(payload)
     assert "学徒" not in blob and "levy" not in blob.lower()
+
+
+# ---- 外部 API v2.6 /public/levels 对齐：unknown level 统计（防静默 0% 低估）----
+def test_run_reports_unknown_levels(db, monkeypatch):
+    """岗位 level 不在 LEVEL_PCT → 计入返回 unknown_levels（仍按 0% 计成本但可见）。"""
+    from app.ingest.importers import positions as P
+
+    class FakeResp:
+        def raise_for_status(self): pass
+        def json(self):
+            return {"year": 1982, "company_filter": None, "total": 1, "items": [
+                dict(_pos(), level="Z99"),      # 未知级别
+                dict(_pos(), position_name="B8b岗"),
+            ]}
+    class FakeClient:
+        def __init__(self): self.calls = []
+        def close(self): pass
+        def get(self, url, params=None, headers=None):
+            self.calls.append(url)
+            return FakeResp()
+        def post(self, url, json=None):
+            class R:
+                def raise_for_status(self): pass
+                def json(self): return {"access_token": "t"}
+            return R()
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    monkeypatch.setattr(P.httpx, "Client", lambda timeout=30: FakeClient())
+    _seed_be(db)
+    out = P.run_labor_cost(db, year=1982)
+    assert out["unknown_levels"] == ["Z99"]


### PR DESCRIPTION
## 影响评估

外部系统 v2.6 三端点更新对照现有 importer：**架构无需调整**——「计算权移交第三方」（外部只给在岗明细、成本自算）与现架构一致；「基准包推送」链路从未实现；响应包裹/在岗判定/company_ids 模式 B/403·429 错误映射均兼容。

## 适配两点

1. **company_info.py**：`tax_zone_id/tax_zone_label`（v1.6/v2.6 R1 公司↔税区一对一，内部成本口径键）随 `entity.fields` 落库备查；旧版响应无该字段 → 显式 None 不缺键。
2. **positions.run_labor_cost**：返回体增 `unknown_levels`——岗位 level 不在本地 LEVEL_PCT 时此前**静默按 0% 计成本**（低估不可见），现计入统计供调用方察觉（必要时以 `/public/levels` 对齐编码）。

## 备案不接入

`/public/levels` 字典端点：LEVEL_PCT 是本方费率映射表，外部字典仅编码/展示名/管理岗标记——暂无消费场景，DESIGN §13.3 已备案。

## 验证

```
pytest 540 passed（+3 新用例）；vite build ✓
```

Closes #193