### PR TITLE
Feat(graph): #201 人物图谱多层级星型 + 拖拽 + 位置持久化

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -603,6 +603,50 @@ def graph_unsuppress_inferred(body: _RelBody, db: Session = Depends(get_db)):
     return {"ok": True}
 
 
+# ---------------- 图谱节点坐标持久化（#201 · 拖拽后刷新锁定） ----------------
+class _PosBody(BaseModel):
+    scope: str = "person"
+    positions: list[dict] = []                       # [{entity_id, x, y}]
+
+
+@app.get(API_PREFIX + "/graph/positions")
+def graph_positions(scope: str = Query("person"), db: Session = Depends(get_db)):
+    """读取该 scope 已保存的节点坐标。"""
+    from app.model import GraphNodePosition
+    rows = db.execute(select(GraphNodePosition).where(
+        GraphNodePosition.scope == scope)).scalars().all()
+    return {"scope": scope, "positions": [
+        {"entity_id": r.entity_id, "x": float(r.x), "y": float(r.y)} for r in rows]}
+
+
+@app.post(API_PREFIX + "/graph/positions")
+def graph_save_positions(body: _PosBody, db: Session = Depends(get_db)):
+    """保存/覆盖拖拽后的节点坐标（幂等 upsert by entity+scope）。"""
+    from app.model import GraphNodePosition
+    for p in body.positions or []:
+        eid = int(p["entity_id"]); x = float(p["x"]); y = float(p["y"])
+        row = db.execute(select(GraphNodePosition).where(
+            GraphNodePosition.entity_id == eid,
+            GraphNodePosition.scope == body.scope).limit(1)).scalar_one_or_none()
+        if row is not None:
+            row.x, row.y = x, y
+        else:
+            db.add(GraphNodePosition(entity_id=eid, scope=body.scope, x=x, y=y))
+    db.commit()
+    return {"ok": True}
+
+
+@app.delete(API_PREFIX + "/graph/positions")
+def graph_clear_positions(scope: str = Query("person"), db: Session = Depends(get_db)):
+    """清空该 scope 已保存坐标 → 回到自动多层级布局。"""
+    from app.model import GraphNodePosition
+    for r in db.execute(select(GraphNodePosition).where(
+            GraphNodePosition.scope == scope)).scalars().all():
+        db.delete(r)
+    db.commit()
+    return {"ok": True}
+
+
 # ---------------- 通知（非阻断提示；DESIGN §9.3；issue #13） ----------------
 
 @app.get(API_PREFIX + "/ingest-reports")

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -10,10 +10,27 @@ from __future__ import annotations
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
-from app.model import Entity, Relationship
-from app.core.kinship import infer_person_edges
+from app.model import Entity, GraphNodePosition, Relationship
+from app.core.kinship import infer_person_edges, person_generation
 
 SUPPRESS_SRC = "infer-suppressed"
+
+
+def _node_gen(e: Entity) -> int | None:
+    """person 节点代际（多层级星型）；非 person 无 gen。"""
+    if e.entity_type == "person":
+        return person_generation((e.fields or {}).get("与主角的关系"))
+    return None
+
+
+def _positions(session: Session, ents: dict[int, Entity], scope: str) -> dict[str, dict]:
+    """已保存的节点坐标（#201）：{entity_id: {x,y}}，仅节点集内。"""
+    out: dict[str, dict] = {}
+    for r in session.execute(
+            select(GraphNodePosition).where(GraphNodePosition.scope == scope)).scalars().all():
+        if r.entity_id in ents:
+            out[str(r.entity_id)] = {"x": float(r.x), "y": float(r.y)}
+    return out
 
 
 def _merged_edges(session: Session, ents: dict[int, Entity]) -> list[dict]:
@@ -60,27 +77,28 @@ def _merged_edges(session: Session, ents: dict[int, Entity]) -> list[dict]:
     return out
 
 
-def _graph(session: Session, entity_type: str) -> dict:
-    """按 entity_type 聚合 nodes + edges（两端都在该类型集合内的关系）。"""
+def _graph(session: Session, entity_type: str, scope: str) -> dict:
+    """按 entity_type 聚合 nodes（含 gen#201）+ edges + 已保存坐标 positions。"""
     ents = {e.id: e for e in session.execute(
         select(Entity).where(Entity.entity_type == entity_type)).scalars().all()}
     nodes = [
         {"id": e.id, "type": e.entity_type, "name": e.display_name or e.name,
-         "display_name": e.display_name, "status": e.status}
+         "display_name": e.display_name, "status": e.status, "gen": _node_gen(e)}
         for e in ents.values()
     ]
     edges = _merged_edges(session, ents)
-    return {"nodes": nodes, "edges": edges, "node_count": len(nodes), "edge_count": len(edges)}
+    return {"nodes": nodes, "edges": edges, "node_count": len(nodes),
+            "edge_count": len(edges), "positions": _positions(session, ents, scope)}
 
 
 def person_graph(session: Session) -> dict:
-    """人—人关系图（含亲缘推理边；跨类型边见 /graph/all）。"""
-    return _graph(session, "person")
+    """人—人关系图（含亲缘推理边、代际 gen、拖拽坐标 person 域；跨类型边见 /graph/all）。"""
+    return _graph(session, "person", "person")
 
 
 def company_graph(session: Session) -> dict:
     """公司—公司关系图（显式边；推理边无公司两端自然不出现）。"""
-    return _graph(session, "company")
+    return _graph(session, "company", "company")
 
 
 def all_graph(session: Session) -> dict:
@@ -88,8 +106,9 @@ def all_graph(session: Session) -> dict:
     ents = {e.id: e for e in session.execute(select(Entity)).scalars().all()}
     nodes = [
         {"id": e.id, "type": e.entity_type, "name": e.display_name or e.name,
-         "display_name": e.display_name, "status": e.status}
+         "display_name": e.display_name, "status": e.status, "gen": _node_gen(e)}
         for e in ents.values()
     ]
     edges = _merged_edges(session, ents)
-    return {"nodes": nodes, "edges": edges, "node_count": len(nodes), "edge_count": len(edges)}
+    return {"nodes": nodes, "edges": edges, "node_count": len(nodes),
+            "edge_count": len(edges), "positions": _positions(session, ents, "all")}

--- a/app/core/kinship.py
+++ b/app/core/kinship.py
@@ -24,7 +24,7 @@ from app.ingest.holders import TITLE_ENTITY
 PROTAGONISTS = {"Stijn Peeters", "夏LY"}
 
 _RE_LINK = re.compile(r"^(.+?)(?:的)?(父亲|母亲)$")   # 「养父的父亲」→(养父,父亲)
-_SIB = ("哥哥", "弟弟", "姐姐", "妹妹")
+_SIB = ("哥哥", "弟弟", "姐姐", "妹妹", "养兄", "养姐", "养弟", "兄长", "姐妹")
 _ANCESTOR = ("始祖", "世祖", "先祖")
 
 # 称谓 → (anchor, sex)。anchor 为相对主角的父/母侧（养父/养母/主角）；父/母互补成夫妻。
@@ -39,27 +39,48 @@ _ROLE_MAP: dict[str, tuple[str, str]] = {
 
 
 def _role_spec(role: str) -> dict | None:
-    """称谓 → 亲缘描述；未知返回 None（调用方兜底连主角）。"""
-    r = (role or "").strip().replace("，", "").replace(" ", "")
-    if not r or "领养养子" in r or "主角" == r:
+    """称谓 → 亲缘描述；未知返回 None（调用方兜底连主角）。
+
+    真实称谓常带尾部说明（「养母。1974年…」「主角的养姐，Karel的双胞胎姐姐…」），
+    取**首个分句**为称谓、去「主角的」文案前缀后匹配。
+    """
+    raw = (role or "").strip()
+    if not raw or "领养养子" in raw or raw == "主角":
         return {"kind": "self"}
-    if any(a in r for a in _ANCESTOR):
+    if any(a in raw for a in _ANCESTOR):
         return {"kind": "ancestor"}
-    if r.startswith("双胞胎"):
-        core = r.replace("双胞胎", "")
-        if core in _SIB or core == "":
-            return {"kind": "sibling"}
-    if r in _SIB:
+    head = re.split(r"[。；;，、（）()：:【】]", raw)[0].strip().replace("主角的", "").strip()
+    if head.startswith("双胞胎") and head.replace("双胞胎", "") in _SIB:
         return {"kind": "sibling"}
-    if r in _ROLE_MAP:
-        anchor, sex = _ROLE_MAP[r]
+    if head in _SIB:
+        return {"kind": "sibling"}
+    if head in _ROLE_MAP:
+        anchor, sex = _ROLE_MAP[head]
         return {"kind": "parent", "anchor": anchor, "sex": sex}
-    m = _RE_LINK.match(r)                       # 「X的父亲/母亲」
+    m = _RE_LINK.match(head)                    # 「X的父亲/母亲」
     if m:
-        anchor = m.group(1)
-        sex = "male" if m.group(2) == "父亲" else "female"
-        return {"kind": "parent", "anchor": anchor, "sex": sex}
+        return {"kind": "parent", "anchor": m.group(1),
+                "sex": "male" if m.group(2) == "父亲" else "female"}
     return None
+
+
+def person_generation(role: str | None) -> int:
+    """相对主角的代际深度（供多层级星型布局）：0=主角,1=父母/兄弟,2=祖辈,3=更远/始祖。"""
+    if not (role or "").strip():
+        return 1                                        # 无角色 → 非主角，落 1 环
+    spec = _role_spec(role)
+    if spec is None:
+        return 1
+    k = spec.get("kind")
+    if k == "self":
+        return 0
+    if k == "sibling":
+        return 1
+    if k == "ancestor":
+        return 3
+    if k == "parent":
+        return 1 if spec.get("anchor") in ("主角", "本人") else 2
+    return 1
 
 
 def _canonical(name: str, by_name_id: dict[str, int]) -> int | None:

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -15,6 +15,7 @@ from app.model.labor import LaborCpiGrowth, LaborTaxBenchmark, LaborWageBenchmar
 from app.model.movie_event import MovieEvent
 from app.model.stock_event import StockEvent
 from app.model.search import SearchIndex
+from app.model.graph_position import GraphNodePosition
 
 __all__ = [
     "Base",
@@ -26,4 +27,5 @@ __all__ = [
     "Investment", "InvestmentAlloc",
     "LaborWageBenchmark", "LaborCpiGrowth", "LaborTaxBenchmark",
     "MovieEvent", "StockEvent", "SearchIndex",
+    "GraphNodePosition",
 ]

--- a/app/model/graph_position.py
+++ b/app/model/graph_position.py
@@ -1,0 +1,26 @@
+"""图谱节点布局坐标持久化（#201 · 拖拽后刷新锁定）。
+
+按 (entity_id, scope) 存节点在 SVG viewBox 坐标系下的 x/y；scope ∈ {person, company, all}。
+前端拖拽后 POST 覆盖；图谱响应含该 scope 的坐标，有则用（锁定），无则自动多层级布局。
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Float, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class GraphNodePosition(Base):
+    __tablename__ = "graph_node_position"
+    __table_args__ = (UniqueConstraint("entity_id", "scope", name="uq_graph_pos_entity_scope"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    entity_id: Mapped[int] = mapped_column(ForeignKey("entity.id"), nullable=False)
+    scope: Mapped[str] = mapped_column(String, nullable=False)
+    x: Mapped[float] = mapped_column(Float, nullable=False)
+    y: Mapped[float] = mapped_column(Float, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now())

--- a/frontend/src/screens/Graph.jsx
+++ b/frontend/src/screens/Graph.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useFetch } from './useDataOp'
 
 const W = 720, H = 460, CX = W / 2, CY = H / 2
@@ -17,51 +17,60 @@ const TYPE_LABEL = {
 }
 
 /**
- * 图谱视图（F-P1-04/05 + /graph/all + #197）。
- * - 边：虚线=亲缘推理建议（inferred），实线=人工/文件显式。
- * - 点节点 → 左上资产面板（账户/初始资产/持仓/收益流）。
- * - 关系可编辑：✚ 连线(两节点建实线)、点边删/改/隐藏推理(不复活)。
+ * 图谱视图（F-P1-04/05 + /graph/all + #197 + #201）。
+ * - 多层级：person 节点按后端 gen（代际）分布同心环，主角居中；保存的位置覆盖自动布局（锁定）。
+ * - 拖拽：节点可拖，抬起即 POST /graph/positions 持久化 → 刷新/重开回到原位。
+ * - 重置布局：清空该 scope 坐标 → 回自动多层级。
+ * - 关系可编辑：虚线=推理建议/实线=人工，✚连线/删边/改称谓；点节点看资产面板。
  */
 export default function Graph({ url, emptyHint, action }) {
   const g = useFetch(url)
   const [selected, setSelected] = useState(null)      // 点人看资产
+  const assets = useFetch(selected ? `/api/v1/entities/${selected}/assets` : null)
   const [linkFrom, setLinkFrom] = useState(null)       // 连线起点
   const [edgeSel, setEdgeSel] = useState(null)         // 选中的边
   const [busy, setBusy] = useState(false)
-  const { nodes = [], edges = [] } = g.data || {}
-  const assets = useFetch(selected ? `/api/v1/entities/${selected}/assets` : null)
+  const [over, setOver] = useState({})                 // 拖拽本地覆盖(id->{x,y})
+  const svgRef = useRef(null)
+  const dragRef = useRef(null)                         // {id, orig, scaleX, scaleY, startCX, startCY}
+  const lastDrag = useRef(null)                        // 最近一次拖到位
+
+  const { nodes = [], edges = [], positions = {} } = g.data || {}
   const isAll = url.startsWith('/api/v1/graph/all')
   const title = isAll ? TYPE_LABEL.family
     : (url.startsWith('/api/v1/graph/persons') ? TYPE_LABEL.person : TYPE_LABEL.company)
+  const scopeFor = u => u.includes('/all') ? 'all' : u.includes('/companies') ? 'company' : 'person'
 
-  // #199 放射/星型布局：主角（或度最大节点）居中，其余按与中心的 BFS 边深度分布同心环
-  const layout = useMemo(() => {
+  // 自动多层级布局：按 person.gen 同心环（gen0=主角中心；无 gen 落最外环）
+  const autoPos = useMemo(() => {
     if (!nodes.length) return {}
-    const adj = new Map(nodes.map(n => [n.id, new Set()]))
-    for (const e of edges) { adj.get(e.from)?.add(e.to); adj.get(e.to)?.add(e.from) }
-    const proto = nodes.find(n => ['Stijn Peeters', '夏LY'].includes(n.name))
-    const centerId = (proto || nodes.reduce(
-      (a, b) => (adj.get(a.id).size >= adj.get(b.id).size ? a : b), nodes[0])).id
-    // BFS 深度（未达节点兜底深度 1，保证都环绕中心不丢失）
-    const depth = new Map([[centerId, 0]])
-    const q = [centerId]
-    while (q.length) { const c = q.shift(); for (const nb of adj.get(c) || []) if (!depth.has(nb)) { depth.set(nb, depth.get(c) + 1); q.push(nb) } }
-    let maxD = 1
-    for (const n of nodes) { if (depth.get(n.id) === undefined) depth.set(n.id, 1); maxD = Math.max(maxD, depth.get(n.id)) }
-    const R = Math.min(CX, CY) - 80
+    let maxG = 1
+    for (const n of nodes) maxG = Math.max(maxG, (n.gen == null ? 1 : n.gen))
     const layers = new Map()
-    for (const n of nodes) { const d = depth.get(n.id) ?? 1; if (!layers.has(d)) layers.set(d, []); layers.get(d).push(n.id) }
+    nodes.forEach(n => {
+      const gn = n.gen == null ? maxG : n.gen
+      if (!layers.has(gn)) layers.set(gn, [])
+      layers.get(gn).push(n.id)
+    })
+    const R = Math.min(CX, CY) - 80
     const pos = {}
     let offset = -Math.PI / 2
-    for (const [d, ids] of [...layers.entries()].sort((a, b) => a[0] - b[0])) {
-      const r = d === 0 ? 0 : R * (d / maxD)
+    for (const [gn, ids] of [...layers.entries()].sort((a, b) => a[0] - b[0])) {
+      const r = gn === 0 ? 0 : R * (gn / Math.max(1, maxG))
       const step = Math.PI * 2 / Math.max(1, ids.length)
       ids.forEach((id, i) => { pos[id] = { x: CX + r * Math.cos(offset + step * i), y: CY + r * Math.sin(offset + step * i) } })
-      offset += step / 2                       // 相邻环错开半格，减少连线重叠
+      offset += step / 2
     }
-    return { pos, R, centerId }
-  }, [nodes, edges])
-  const pos = layout.pos || {}
+    return pos
+  }, [nodes])
+
+  // 有效位置：拖拽覆盖 > 已保存(锁定) > 自动多层级
+  const pos = useMemo(() => {
+    const out = {}
+    for (const n of nodes) out[n.id] = over[n.id] || positions[n.id] || autoPos[n.id] || { x: CX, y: CY }
+    return out
+  }, [nodes, positions, autoPos, over])
+
   const nodeName = id => (nodes.find(n => n.id === id) || {}).name || `#${id}`
 
   async function api(method, path, body) {
@@ -72,6 +81,41 @@ export default function Graph({ url, emptyHint, action }) {
         body: body === undefined ? undefined : JSON.stringify(body) })
     } finally { setBusy(false); g.refresh() }
   }
+
+  // 拖拽
+  const onNodeDown = (e, id, px, py) => {
+    const svg = svgRef.current
+    if (!svg) return
+    const rect = svg.getBoundingClientRect()
+    dragRef.current = { id, orig: { x: px, y: py },
+      scaleX: W / Math.max(1, rect.width), scaleY: H / Math.max(1, rect.height),
+      startCX: e.clientX, startCY: e.clientY }
+    setLinkFrom(null); setEdgeSel(null)
+    e.preventDefault()
+  }
+  useEffect(() => {
+    const move = ev => {
+      const d = dragRef.current
+      if (!d) return
+      const x = Math.round(d.orig.x + (ev.clientX - d.startCX) * d.scaleX)
+      const y = Math.round(d.orig.y + (ev.clientY - d.startCY) * d.scaleY)
+      lastDrag.current = { x, y }
+      setOver(o => ({ ...o, [d.id]: { x, y } }))
+    }
+    const up = () => {
+      const d = dragRef.current
+      if (d && lastDrag.current) {
+        api('POST', '/api/v1/graph/positions',
+          { scope: scopeFor(url), positions: [{ entity_id: d.id, x: lastDrag.current.x, y: lastDrag.current.y }] })
+        lastDrag.current = null
+      }
+      dragRef.current = null
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+    return () => { window.removeEventListener('mousemove', move); window.removeEventListener('mouseup', up) }
+  }, [url])   // eslint-disable-line react-hooks/exhaustive-deps
+
   const onNode = id => {
     setEdgeSel(null)
     if (linkFrom !== null && linkFrom !== id) {
@@ -90,32 +134,16 @@ export default function Graph({ url, emptyHint, action }) {
 
   const edgeTool = edgeSel && (
     <div className="note" style={{ border: '1px dashed var(--warn)', padding: '4px 8px', borderRadius: 6 }}>
-      <b>边：{nodeName(edgeSel.from)} → {nodeName(edgeSel.to)}（{edgeSel.rel_type}）
-        {edgeSel.inferred ? ' · 【推理建议】' : ''}</b>
+      <b>边：{nodeName(edgeSel.from)} → {nodeName(edgeSel.to)}（{edgeSel.rel_type}）{edgeSel.inferred ? ' · 【推理建议】' : ''}</b>
       {edgeSel.inferred ? (
         <>
-          <button disabled={busy} onClick={() => {
-            api('POST', '/api/v1/graph/suppress', { from_id: edgeSel.from, to_id: edgeSel.to, rel_type: edgeSel.rel_type })
-            setEdgeSel(null)
-          }}>删（隐藏建议）</button>
-          <button disabled={busy} onClick={() => {
-            const rel = window.prompt('改为实线称谓：', edgeSel.rel_type)
-            if (rel) { api('POST', '/api/v1/graph/relationships', { from_id: edgeSel.from, to_id: edgeSel.to, rel_type: rel }); setEdgeSel(null) }
-          }}>改为实线</button>
+          <button disabled={busy} onClick={() => { api('POST', '/api/v1/graph/suppress', { from_id: edgeSel.from, to_id: edgeSel.to, rel_type: edgeSel.rel_type }); setEdgeSel(null) }}>删（隐藏建议）</button>
+          <button disabled={busy} onClick={() => { const rel = window.prompt('改为实线称谓：', edgeSel.rel_type); if (rel) { api('POST', '/api/v1/graph/relationships', { from_id: edgeSel.from, to_id: edgeSel.to, rel_type: rel }); setEdgeSel(null) } }}>改为实线</button>
         </>
       ) : (
         <>
-          <button disabled={busy} onClick={() => {
-            if (window.confirm('删除该关系？')) { api('DELETE', `/api/v1/graph/relationships/${edgeSel.id}`); setEdgeSel(null) }
-          }}>删除</button>
-          <button disabled={busy} onClick={() => {
-            const rel = window.prompt('改称谓：', edgeSel.rel_type)
-            if (rel) {
-              api('DELETE', `/api/v1/graph/relationships/${edgeSel.id}`)
-              api('POST', '/api/v1/graph/relationships', { from_id: edgeSel.from, to_id: edgeSel.to, rel_type: rel })
-              setEdgeSel(null)
-            }
-          }}>改称谓</button>
+          <button disabled={busy} onClick={() => { if (window.confirm('删除该关系？')) { api('DELETE', `/api/v1/graph/relationships/${edgeSel.id}`); setEdgeSel(null) } }}>删除</button>
+          <button disabled={busy} onClick={() => { const rel = window.prompt('改称谓：', edgeSel.rel_type); if (rel) { api('DELETE', `/api/v1/graph/relationships/${edgeSel.id}`); api('POST', '/api/v1/graph/relationships', { from_id: edgeSel.from, to_id: edgeSel.to, rel_type: rel }); setEdgeSel(null) } }}>改称谓</button>
         </>
       )}
       <button onClick={() => setEdgeSel(null)}>取消</button>
@@ -126,26 +154,20 @@ export default function Graph({ url, emptyHint, action }) {
     <div className="panel">
       <h3>{title}{action && <span style={{ float: 'right', marginLeft: 8 }}>{action}</span>}</h3>
       <p className="note">
-        {nodes.length} 节点 · {edges.length} 关系
-        {isAll ? ' · 形状/颜色按 entity_type' : ''} · 虚线=推理建议/实线=人工 · 点节点看资产
+        {nodes.length} 节点 · {edges.length} 关系{isAll ? ' · 形状/颜色按 entity_type' : ''}
+        {' · '}虚线=推理建议/实线=人工 · 点节点看资产 · 拖拽节点可调位置
         <span style={{ float: 'right' }}>
-          <button disabled={busy} onClick={() => {
-            if (linkFrom !== null) { setLinkFrom(null); return }
-            setEdgeSel(null); setSelected(null); setLinkFrom('MODE')
-          }}>{linkFrom !== null ? '✕ 取消连线' : '✚ 连线'}</button>
+          <button disabled={busy} onClick={resetLayout}>⟲ 重置布局</button>{' '}
+          <button disabled={busy} onClick={() => { if (linkFrom !== null) { setLinkFrom(null); return } setEdgeSel(null); setSelected(null); setLinkFrom('MODE') }}>{linkFrom !== null ? '✕ 取消连线' : '✚ 连线'}</button>
         </span>
       </p>
-      {linkFrom !== null && (
-        <p className="note" style={{ color: 'var(--warn)' }}>
-          连线模式：先点第一个节点（起点）→ 再点第二个节点 → 输入称谓建实线关系
-        </p>
-      )}
+      {linkFrom !== null && <p className="note" style={{ color: 'var(--warn)' }}>连线模式：先点第一个节点（起点）→ 再点第二个节点 → 输入称谓建实线关系</p>}
       {edgeTool}
       {nodes.length === 0 ? (
         <div className="plot"><span className="ph">{emptyHint || '暂无节点（需 entity / 关系数据）'}</span></div>
       ) : (
         <div className="plot" style={{ height: 460 }}>
-          <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="xMidYMid meet"
+          <svg ref={svgRef} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="xMidYMid meet"
             onClick={() => { if (linkFrom === null) { setSelected(null); setEdgeSel(null) } }}>
             {edges.map((e, i) => {
               const a = pos[e.from], b = pos[e.to]
@@ -155,18 +177,13 @@ export default function Graph({ url, emptyHint, action }) {
               const active = edgeSel === e
               return (
                 <g key={`${e.from}-${e.to}-${i}`}>
-                  <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="transparent" strokeWidth={14}
-                    onClick={ev => { ev.stopPropagation(); onEdge(e) }} />
+                  <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="transparent" strokeWidth={14} onClick={ev => { ev.stopPropagation(); onEdge(e) }} />
                   <line x1={a.x} y1={a.y} x2={b.x} y2={b.y}
                     stroke={active ? 'var(--warn)' : (isCross ? 'var(--warn)' : 'var(--axis)')}
                     strokeWidth={active ? 2.2 : (isCross ? 1.6 : 1.2)}
-                    strokeDasharray={dashed ? '5 4' : (isCross ? '4 3' : '')}
-                    pointerEvents="none" />
-                  <text x={(a.x + b.x) / 2} y={(a.y + b.y) / 2} fontSize="9" fill="var(--muted)"
-                    textAnchor="middle" dy="-2" pointerEvents="none"
-                    stroke="var(--surface-1)" strokeWidth={2} paintOrder="stroke">
-                    {e.rel_type}{dashed ? ' ⁂' : ''}
-                  </text>
+                    strokeDasharray={dashed ? '5 4' : (isCross ? '4 3' : '')} pointerEvents="none" />
+                  <text x={(a.x + b.x) / 2} y={(a.y + b.y) / 2} fontSize="9" fill="var(--muted)" textAnchor="middle" dy="-2" pointerEvents="none"
+                    stroke="var(--surface-1)" strokeWidth={2} paintOrder="stroke">{e.rel_type}{dashed ? ' ⁂' : ''}</text>
                 </g>
               )
             })}
@@ -174,28 +191,21 @@ export default function Graph({ url, emptyHint, action }) {
               const p = pos[n.id]
               if (!p) return null
               const style = (isAll && TYPE_STYLE[n.type]) || { fill: 'var(--s1)', shape: 'circle' }
+              const isCenter = !isAll && n.gen === 0
               return (
-                <g key={n.id} style={{ cursor: 'pointer' }} onClick={ev => { ev.stopPropagation(); onNode(n.id) }}>
-                  {renderShape(p, n, style, n.id === layout.centerId)}
-                  <text x={p.x} y={p.y} fontSize="9" fill={selected === n.id ? '#000' : '#fff'}
-                    textAnchor="middle" dominantBaseline="central" pointerEvents="none"
-                    fontWeight={selected === n.id ? 700 : 400}>{String(n.id)}</text>
-                  <text x={p.x} y={p.y + (style.shape === 'circle' || style.shape === 'diamond' ? 26 : 22)}
-                    fontSize="10" fill="var(--ink)" textAnchor="middle" pointerEvents="none">{n.name}</text>
+                <g key={n.id} style={{ cursor: 'grab' }}
+                  onMouseDown={ev => onNodeDown(ev, n.id, p.x, p.y)}
+                  onClick={ev => { ev.stopPropagation(); onNode(n.id) }}>
+                  {renderShape(p, n, style, isCenter)}
+                  <text x={p.x} y={p.y} fontSize="9" fill={selected === n.id ? '#000' : '#fff'} textAnchor="middle" dominantBaseline="central" pointerEvents="none" fontWeight={selected === n.id ? 700 : 400}>{String(n.id)}</text>
+                  <text x={p.x} y={p.y + (style.shape === 'circle' || style.shape === 'diamond' ? 26 : 22)} fontSize="10" fill="var(--ink)" textAnchor="middle" pointerEvents="none">{n.name}</text>
                 </g>
               )
             })}
           </svg>
           {selected && (
-            <div className="asset-panel" style={{
-              position: 'absolute', left: 8, top: 8, maxWidth: 300, minWidth: 220,
-              background: 'var(--surface-1)', border: '1px solid var(--border)', borderRadius: 6,
-              padding: 8, maxHeight: 400, overflow: 'auto', fontSize: 12,
-            }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                <b>{assets.data?.name || nodeName(selected)}</b>
-                <button onClick={() => setSelected(null)}>✕</button>
-              </div>
+            <div className="asset-panel" style={{ position: 'absolute', left: 8, top: 8, maxWidth: 300, minWidth: 220, background: 'var(--surface-1)', border: '1px solid var(--border)', borderRadius: 6, padding: 8, maxHeight: 400, overflow: 'auto', fontSize: 12 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}><b>{assets.data?.name || nodeName(selected)}</b><button onClick={() => setSelected(null)}>✕</button></div>
               {assetSections(assets.data)}
             </div>
           )}
@@ -203,37 +213,28 @@ export default function Graph({ url, emptyHint, action }) {
       )}
     </div>
   )
+
+  function resetLayout() {
+    api('DELETE', `/api/v1/graph/positions?scope=${scopeFor(url)}`)
+    setOver({})
+  }
 }
 
 function assetSections(d) {
   if (!d) return <div style={{ color: 'var(--muted)' }}>加载中…</div>
   const sec = (label, rows, fmt) => (
     rows && rows.length ? (
-      <div style={{ marginTop: 6 }}>
-        <b>{label}（{rows.length}）</b>
+      <div style={{ marginTop: 6 }}><b>{label}（{rows.length}）</b>
         <div>{rows.map((r, k) => <div key={k} style={{ fontSize: 11, color: 'var(--muted)' }}>{fmt(r)}</div>)}</div>
-      </div>
-    ) : null
+      </div>) : null
   )
   return (
     <>
-      {sec('银行账户', d.accounts, a =>
-        `${a.currency}${a.bank ? ' · ' + a.bank : ''}${a.status !== 'active' ? ' [' + a.status + ']' : ''}` +
-        (a.balance != null ? ` — ${Number(a.balance).toLocaleString()} ${a.currency}` : ''))}
-      {sec('初始资产', d.initial_assets, a =>
-        `${a.asset_type}${a.name ? ' · ' + a.name : ''}${a.currency ? ' · ' + a.currency : ''}` +
-        (a.face_value != null ? ` ${a.face_value.toLocaleString()}` : '') +
-        (a.pct != null ? `（${a.pct}%）` : ''))}
-      {sec('股票持仓', d.holdings, h =>
-        `[${h.event_type}] ${h.company}${h.ticker ? ' (' + h.ticker + ')' : ''} ${h.date}` +
-        (h.shares != null ? ` ${Number(h.shares).toLocaleString()} 股` : '') +
-        (h.amount_wusd != null ? `  ${h.amount_wusd.toLocaleString()} 万USD` : '') +
-        (h.pct != null ? ` ${h.pct}%` : ''))}
-      {sec('收益流', d.income, i =>
-        `${i.year} ${i.stream_type}${i.group_key ? ' · ' + i.group_key : ''} · ${i.currency}` +
-        ` ${Number(i.amount).toLocaleString()}`)}
-      {!d.accounts?.length && !d.initial_assets?.length && !d.holdings?.length && !d.income?.length
-        ? <div style={{ color: 'var(--muted)', marginTop: 6 }}>暂无资产数据</div> : null}
+      {sec('银行账户', d.accounts, a => `${a.currency}${a.bank ? ' · ' + a.bank : ''}${a.status !== 'active' ? ' [' + a.status + ']' : ''}` + (a.balance != null ? ` — ${Number(a.balance).toLocaleString()} ${a.currency}` : ''))}
+      {sec('初始资产', d.initial_assets, a => `${a.asset_type}${a.name ? ' · ' + a.name : ''}${a.currency ? ' · ' + a.currency : ''}` + (a.face_value != null ? ` ${a.face_value.toLocaleString()}` : '') + (a.pct != null ? `（${a.pct}%）` : ''))}
+      {sec('股票持仓', d.holdings, h => `[${h.event_type}] ${h.company}${h.ticker ? ' (' + h.ticker + ')' : ''} ${h.date}` + (h.shares != null ? ` ${Number(h.shares).toLocaleString()} 股` : '') + (h.amount_wusd != null ? `  ${h.amount_wusd.toLocaleString()} 万USD` : '') + (h.pct != null ? ` ${h.pct}%` : ''))}
+      {sec('收益流', d.income, i => `${i.year} ${i.stream_type}${i.group_key ? ' · ' + i.group_key : ''} · ${i.currency} ${Number(i.amount).toLocaleString()}`)}
+      {!d.accounts?.length && !d.initial_assets?.length && !d.holdings?.length && !d.income?.length ? <div style={{ color: 'var(--muted)', marginTop: 6 }}>暂无资产数据</div> : null}
     </>
   )
 }
@@ -241,11 +242,7 @@ function assetSections(d) {
 function renderShape(p, n, style, isCenter) {
   const fill = style.fill
   const stroke = isCenter ? 'var(--warn)' : 'var(--page)', sw = isCenter ? 3 : 2
-  if (style.shape === 'rect') {
-    return <rect x={p.x - 18} y={p.y - 12} width={36} height={24} rx={3} fill={fill} opacity="0.9" stroke={stroke} strokeWidth={sw} />
-  }
-  if (style.shape === 'diamond') {
-    return <polygon points={`${p.x},${p.y - 16} ${p.x + 16},${p.y} ${p.x},${p.y + 16} ${p.x - 16},${p.y}`} fill={fill} opacity="0.9" stroke={stroke} strokeWidth={sw} />
-  }
+  if (style.shape === 'rect') return <rect x={p.x - 18} y={p.y - 12} width={36} height={24} rx={3} fill={fill} opacity="0.9" stroke={stroke} strokeWidth={sw} />
+  if (style.shape === 'diamond') return <polygon points={`${p.x},${p.y - 16} ${p.x + 16},${p.y} ${p.x},${p.y + 16} ${p.x - 16},${p.y}`} fill={fill} opacity="0.9" stroke={stroke} strokeWidth={sw} />
   return <circle cx={p.x} cy={p.y} r={isCenter ? 22 : 16} fill={fill} opacity="0.85" stroke={stroke} strokeWidth={sw} />
 }

--- a/migrations/versions/b4c5d6e7f8a9_graph_node_position.py
+++ b/migrations/versions/b4c5d6e7f8a9_graph_node_position.py
@@ -1,0 +1,35 @@
+"""#201：图谱节点布局坐标表 graph_node_position（拖拽后刷新锁定）。
+
+新建表：entity_id(FK entity) × scope(person/company/all) 存 SVG viewBox 坐标；
+UNIQUE(entity_id, scope) 支持幂等 upsert。
+
+revision: b4c5d6e7f8a9
+revises: a3b4c5d6e7f8
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b4c5d6e7f8a9"
+down_revision = "a3b4c5d6e7f8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "graph_node_position",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("entity_id", sa.BigInteger(), sa.ForeignKey("entity.id"), nullable=False),
+        sa.Column("scope", sa.String(), nullable=False),
+        sa.Column("x", sa.Float(), nullable=False),
+        sa.Column("y", sa.Float(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True),
+                  server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("entity_id", "scope", name="uq_graph_pos_entity_scope"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("graph_node_position")

--- a/tests/test_kinship.py
+++ b/tests/test_kinship.py
@@ -63,6 +63,38 @@ def test_infer_core_roles(session):
     assert len(es) == 3                       # 养父/养母未导入，无父子边
 
 
+def test_person_generation():
+    from app.core.kinship import person_generation
+    assert person_generation(None) == 1
+    assert person_generation("家族领养养子") == 0
+    assert person_generation("养父") == 1
+    assert person_generation("主角的养姐，Karel的双胞胎姐姐") == 1
+    assert person_generation("祖父") == 2
+    assert person_generation("养母的母亲") == 2
+    assert person_generation("家族始祖，主角Stijn的十五世祖") == 3
+
+
+def test_infer_prose_roles(session):
+    """真实称谓带尾部说明/「主角的」前缀：取首分句解析。"""
+    for name, role in [
+        ("Stijn Peeters", None),
+        ("Joren Peeters", "养父"),
+        ("Johanna Peeters", "养母。1974年与Joren Peeters结婚嫁入Peeters家"),
+        ("Maaike Peeters", "主角的养姐，Karel的双胞胎姐姐，家族正统继承人"),
+        ("Karel Peeters", "主角的养兄，Maaike的双胞胎弟弟"),
+    ]:
+        session.add(Entity(entity_type="person", name=name,
+                           fields={} if role is None else {"与主角的关系": role}))
+    session.commit()
+    j = _id(session, "Joren Peeters"); jo = _id(session, "Johanna Peeters")
+    s = _id(session, "Stijn Peeters")
+    m = _id(session, "Maaike Peeters"); k = _id(session, "Karel Peeters")
+    es = _es(infer_person_edges(session))
+    assert (j, jo, "夫妻") in es
+    assert (j, s, "父子") in es and (jo, s, "母女") in es
+    assert (m, s, "兄弟姐妹") in es and (k, s, "兄弟姐妹") in es
+
+
 def test_infer_with_parents(session):
     _seed_core(session)
     session.add(Entity(entity_type="person", name="Joren Peeters", fields={"与主角的关系": "养父"}))


### PR DESCRIPTION
Closes #201

## 改动
- **多层级星型**：person 节点按后端 `gen`（代际）分同心环——主角(0)居中 → 父母/双子(1) → 祖辈(2) → 更远/始祖(3)；新人物自动落对应环。
- **节点可拖拽**：抬起 `POST /graph/positions` 持久化，刷新/重开回到锁定位。
- **⟲ 重置布局**：`DELETE /graph/positions` 回自动多层级。
- 位置优先级：拖拽覆盖 > 已保存(锁定) > 自动 gen。

## 后端
- 新表 `graph_node_position`(entity×scope,x,y) + 迁移 b4c5d6e7f8a9。
- `person_graph`/`all_graph` 响应含 `gen` + `positions`；新 `GET/POST/DELETE /api/v1/graph/positions`。
- `kinship.person_generation` 分代际；`_role_spec` 分句解析（支持「养母。1974…」「主角的养姐…」）。

## 测试
- `pytest test_person_generation` / `test_infer_prose_roles`；全量 ~558 通过；前端 vite build 通过。
- 含一次运行时 TDZ 修复（assets/selected 声明顺序）。