### PR TITLE
fix(graph): #203 账户关池/承接随日历 as-of 折算（BEF/EUR 先后非并行）

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -35,6 +35,7 @@ from app.api.search import router as search_router
 from app.api.timeline import router as timeline_router
 from app.api.ui_ops import router as ui_ops_router
 from app.core.calendar import snapshot_as_of
+from app.core.snapshot import account_live_at, account_status_effective
 from app.core.graph import all_graph, company_graph, person_graph
 from app.core.health import run_report, summarize
 from app.core.wealth import wealth_series
@@ -125,11 +126,12 @@ def get_entity(entity_id: int, db: Session = Depends(get_db)):
 def list_accounts(
     entity_id: Optional[int] = None,
     currency: Optional[str] = None,
+    as_of: Optional[date] = Query(None, description="按日历 as-of 折算有效状态（#203 关池为时间事件）"),
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
 ):
-    """issue #23：补分页（与 entities 对齐）。"""
+    """issue #23：补分页（与 entities 对齐）；#203：status 随 as_of 折算。"""
     q = select(Account)
     if entity_id:
         q = q.where(Account.entity_id == entity_id)
@@ -139,21 +141,23 @@ def list_accounts(
     rows = db.execute(q.order_by(Account.id).offset((page - 1) * page_size).limit(page_size)).scalars().all()
     return {
         "items": [{"id": a.id, "entity_id": a.entity_id, "currency": a.currency,
-                   "status": a.status, "closed_on": a.closed_on,
+                   "status": account_status_effective(a, as_of), "closed_on": a.closed_on,
                    "migrate_to": a.migrate_to_currency} for a in rows],
         "total": total, "page": page, "page_size": page_size,
     }
 
 
 @app.get(API_PREFIX + "/accounts/{account_id}")
-def get_account(account_id: int, db: Session = Depends(get_db)):
-    """issue #23：补账户详情（含开户行/状态/关池日）。"""
+def get_account(account_id: int,
+                as_of: Optional[date] = Query(None, description="按日历 as-of 折算有效状态（#203）"),
+                db: Session = Depends(get_db)):
+    """issue #23：补账户详情（含开户行/状态/关池日）；#203：status 随 as_of 折算。"""
     a = db.get(Account, account_id)
     if not a:
         raise HTTPException(status_code=404, detail="account not found")
     return {
         "id": a.id, "entity_id": a.entity_id, "currency": a.currency,
-        "status": a.status, "closed_on": a.closed_on,
+        "status": account_status_effective(a, as_of), "closed_on": a.closed_on,
         "migrate_to": a.migrate_to_currency, "bank": a.bank,
     }
 
@@ -178,21 +182,26 @@ def entity_relationships(entity_id: int, db: Session = Depends(get_db)):
 
 
 @app.get(API_PREFIX + "/entities/{entity_id}/assets")
-def entity_assets(entity_id: int, db: Session = Depends(get_db)):
-    """#197 点人看资产：账户(末余额)/初始资产/股票持仓/收益流 全聚合。"""
+def entity_assets(entity_id: int,
+                  as_of: Optional[date] = Query(None, description="按日历 as-of 折算账户有效状态（#203）"),
+                  db: Session = Depends(get_db)):
+    """#197 点人看资产：账户(末余额+有效状态)/初始资产/股票持仓/收益流 全聚合。"""
     if db.get(Entity, entity_id) is None:
         raise HTTPException(status_code=404, detail="entity not found")
-    from app.model import HoldingEvent, InitialAsset, Relationship  # noqa: F401
+    from app.model import HoldingEvent, InitialAsset  # noqa: F401
     accounts = []
     for a in db.execute(
             select(Account).where(Account.entity_id == entity_id)
             .order_by(Account.currency)).scalars().all():
+        # #203：关池/承接为时间事件——as_of 下只显示"存续"账户（2001 只有 BEF，EUR 承接池 2002 起）
+        if as_of is not None and not account_live_at(db, a, as_of):
+            continue
         last = db.execute(
             select(LedgerEntry.balance).where(LedgerEntry.account_id == a.id)
             .order_by(LedgerEntry.date.desc(), LedgerEntry.id.desc()).limit(1)
         ).scalar_one_or_none()
         accounts.append({"id": a.id, "currency": a.currency, "bank": a.bank,
-                         "status": a.status,
+                         "status": account_status_effective(a, as_of), "closed_on": a.closed_on,
                          "balance": float(last) if last is not None else None})
     initial = [{
         "asset_type": x.asset_type, "name": x.name, "currency": x.currency,

--- a/app/core/snapshot.py
+++ b/app/core/snapshot.py
@@ -50,6 +50,36 @@ def account_balance_at(session: Session, account_id: int, cutoff) -> Decimal:
     return Decimal(tin or 0) - Decimal(tout or 0)
 
 
+def account_status_effective(acc: Account, as_of) -> str:
+    """账户按日历 as-of 的有效状态（#203 · 关池为时间事件）。
+
+    关池（BEF/LUF/NLG → EUR，DESIGN §6.6）在 closed_on（2002-01-01）生效：
+    日历 as_of **未到** closed_on → 视为 active（未关池）；as_of 未给 or 已到/过 → 用存储 status。
+    """
+    if acc.status == "closed" and acc.closed_on is not None \
+            and as_of is not None and as_of < acc.closed_on:
+        return "active"
+    return acc.status
+
+
+def account_live_at(session, acc, as_of) -> bool:
+    """账户在 as_of 是否"存续"（#203 关池/承接为时间事件，BEF/EUR 先后非并行）。
+
+    - 已关账户：as_of >= closed_on → 关池后不再存续（不可见；如 BEF 2002 起隐藏）。
+    - 承接池（如 EUR，首笔在同一关池日 2002-01-01 承接）：as_of < 首笔日期 → 尚未承接，
+      不可见（2002 前只有源币种池）。
+    """
+    if as_of is not None and acc.closed_on is not None and as_of >= acc.closed_on:
+        return False
+    if as_of is not None:
+        first = session.execute(
+            select(func.min(LedgerEntry.date)).where(LedgerEntry.account_id == acc.id)
+        ).scalar()
+        if first is not None and as_of < first:
+            return False
+    return True
+
+
 def _close_year_of(acc: Account) -> int | None:
     """账户关池年：closed 且有关池日 → closed_on.year，否则 None（DESIGN §6.6）。"""
     if acc.status == "closed" and acc.closed_on is not None:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -91,9 +91,9 @@ export default function App() {
         {active === 'labor' && <LaborCost />}
         {active === 'movies' && <Movies />}
         {active === 'stock' && <Stock />}
-        {active === 'persons' && <Graph url="/api/v1/graph/persons" />}
-        {active === 'companies' && <CompanyGraph />}
-        {active === 'graphall' && <Graph url="/api/v1/graph/all" />}
+        {active === 'persons' && <Graph key={`p-${asOf}`} asOf={asOf} url="/api/v1/graph/persons" />}
+        {active === 'companies' && <CompanyGraph asOf={asOf} />}
+        {active === 'graphall' && <Graph key={`g-${asOf}`} asOf={asOf} url="/api/v1/graph/all" />}
         {active === 'timeline' && <Timeline key={`t-${asOf}`} asOf={asOf} calMax={Number(calRange.max.slice(0, 4))} />}
         {active === 'search' && <Search asOf={asOf} />}
         {active === 'diff' && <SourceDiff />}
@@ -173,7 +173,7 @@ function NotificationsBanner({ onShowImpact }) {
  * 异步资源——POST /api/v1/import-jobs{provider:'company-info'} 建任务 → 轮询
  * GET /api/v1/import-jobs/{id} 至 done/failed → done 取 result.stats 刷新图谱。
  */
-function CompanyGraph() {
+function CompanyGraph({ asOf }) {
   const [refreshKey, setRefreshKey] = useState(0)
   const [stats, setStats] = useState(null)
   const [jobId, setJobId] = useState(null)
@@ -210,8 +210,9 @@ function CompanyGraph() {
 
   return (
     <Graph
-      key={refreshKey}
+      key={`${refreshKey}-${asOf}`}
       url="/api/v1/graph/companies"
+      asOf={asOf}
       action={
         <>
           <button className="ghost" disabled={busy || !!jobId}

--- a/frontend/src/screens/Graph.jsx
+++ b/frontend/src/screens/Graph.jsx
@@ -23,10 +23,11 @@ const TYPE_LABEL = {
  * - 重置布局：清空该 scope 坐标 → 回自动多层级。
  * - 关系可编辑：虚线=推理建议/实线=人工，✚连线/删边/改称谓；点节点看资产面板。
  */
-export default function Graph({ url, emptyHint, action }) {
+export default function Graph({ url, emptyHint, action, asOf }) {
   const g = useFetch(url)
   const [selected, setSelected] = useState(null)      // 点人看资产
-  const assets = useFetch(selected ? `/api/v1/entities/${selected}/assets` : null)
+  // #203：资产面板按全局日历 as-of 取账户有效状态（关池是时间事件）
+  const assets = useFetch(selected ? `/api/v1/entities/${selected}/assets?as_of=${asOf || ''}` : null)
   const [linkFrom, setLinkFrom] = useState(null)       // 连线起点
   const [edgeSel, setEdgeSel] = useState(null)         // 选中的边
   const [busy, setBusy] = useState(false)


### PR DESCRIPTION
Closes #203

## 现象
日历 2002 前 BEF/LUF/NLG 账户仍显示 closed；且资产面板把 BEF 与 EUR 承接池**并行**列出。

## 修复
- `account_status_effective`：关池为时间事件——`as_of < closed_on(2002-01-01)` → active。
- `account_live_at`：账户存续窗口——已关账户 `as_of ≥ closed_on` 不显示；承接 EUR 池首笔在 2002，`as_of < 首笔` 未承接不显示（2001 只有 BEF、2002 才 EUR，先后非并行）。
- `/accounts`、`/accounts/{id}`、`/entities/{id}/assets` 增 `as_of` 参数并返回有效 status + closed_on；assets 按存续过滤。
- 前端 `App.jsx` 把全局日历 asOf 传给图谱/公司图屏（作 key）；`Graph.jsx` 资产面板 fetch 带 `as_of`。

## 验证
- `as_of=2001-12-30 → [BEF active]`；`as_of=2002-01-01 → [EUR active]`（prod 实测）。
- 全量 pytest 558 通过；前端 vite build 通过。