### PR TITLE
fix(ingest): #209 版本/diff 屏收益表(R1-R5)/人物/时间线导入后永远「新增」——补记 source_file_version

### DIFF
--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -231,9 +231,13 @@ def import_all(session, source_dir, log=None, force: bool = False, force_files=N
         if r.category == "character" and r.records:
             imported_rs.append(r)
             ck += writer.import_characters(session, r.records, r.file)["imported"]
+            # issue #209：人物/收益曲线/时间线同为权威基准，导入后记版本，
+            # 否则 diff 屏永远判「新增」、采纳新版本也落不了版（与 fx-authority 对齐）
+            _record_current_version(session, r, source_dir)
         if r.category == "return_table" and r.records:
             imported_rs.append(r)
             rcur += writer.import_return_curves(session, r.records)["n"]
+            _record_current_version(session, r, source_dir)   # issue #209
         if r.category == "return_table" and not r.records and r.warnings:
             # 五轮审计 #177：零条告警达主链路（此前只进 run stdout，ingest 静默）——
             # 落 ingest_report(warn) + 日志，供数据调整员察觉 catch-all 误归档
@@ -244,6 +248,7 @@ def import_all(session, source_dir, log=None, force: bool = False, force_files=N
         if r.category == "timeline" and r.records:
             imported_rs.append(r)
             tl_n += writer.import_timeline(session, r.records)["n"]
+            _record_current_version(session, r, source_dir)   # issue #209
         if r.category == "bank" and r.records:
             src = r.file
             if _skip_by_state(session, r, source_dir, log, force_files):

--- a/tests/test_ingest_idempotency.py
+++ b/tests/test_ingest_idempotency.py
@@ -156,3 +156,37 @@ def test_legacy_rows_without_version_treated_unchanged(session, source_dir):
 def _has_no_sfv(session) -> bool:
     return session.execute(
         select(func.count()).select_from(SourceFileVersion)).scalar() == 0
+
+
+def test_authority_files_record_version(session, tmp_path):
+    """issue #209：character/return_table/timeline 导入成功后须写 source_file_version，
+    否则版本/diff 屏永远判「新增」、采纳新版本也落不了版（与 fx-authority 对齐）。"""
+    root = tmp_path
+    (root / "人物").mkdir(parents=True)
+    (root / "人物" / "Henri Peeters.md").write_text(
+        "- 姓名：Henri Peeters\n- 角色：养祖父\n", encoding="utf-8")
+    (root / "基准" / "收益表").mkdir(parents=True)
+    rt_rel = "基准/收益表/1999-2025 香港R1-R5投资风险分级收益测算表.md"
+    (root / rt_rel).write_text(
+        "#### 1999（测试）\n"
+        "R1：4.35｜R2：6.12｜R3：8.64｜R4：10.0｜R5：12.0\n", encoding="utf-8")
+    (root / "时间线.md").write_text(
+        "| 年份 | 事件 | 备注 |\n|---|---|---|\n| 1990-06-01 | 测试事件 | |\n",
+        encoding="utf-8")
+
+    st = import_all(session, root)
+    assert st["blocked"] == 0, st["summary"]
+    assert st["return_curves"] == 5 and st["characters"] >= 1 and st["timeline"] == 1
+
+    versioned = {v[0] for v in session.execute(
+        select(SourceFileVersion.file_path).where(
+            SourceFileVersion.is_current.is_(True))).all()}
+    assert "人物/Henri Peeters.md" in versioned
+    assert rt_rel in versioned
+    assert "时间线.md" in versioned
+
+    # 幂等：第二轮不新增版本行（同内容 _record_current_version 早退）
+    n1 = session.execute(select(func.count()).select_from(SourceFileVersion)).scalar()
+    import_all(session, root)
+    n2 = session.execute(select(func.count()).select_from(SourceFileVersion)).scalar()
+    assert n1 == n2


### PR DESCRIPTION
## 问题
版本/diff 决策屏（F-P2-06）中，5 张国别 R1-R5 收益表已成功入库（return_curve 1050 行）却始终显示「新增」而非「一致」；`人物/` 同样如此。

## 根因
`import_all` 主循环中，各类别成功导入后应调 `_record_current_version` 写 `source_file_version`（diff 屏据 is_current 版本指纹判 unchanged/changed/new）。

已记版本：bank / initial_asset / income_* / household_expense / fx（权威+其他）。
**漏记三个分支**：`character`、`return_table`（5 张 R1-R5 表）、`timeline`。

这三类从不写版本行 → `list_tracked` 按 `cur is None` 判 `new`；`adopt_current` 内部复用 `import_all(force_files)`，对这三类也落不了版（「采纳新版本」按钮对它们同样失效）。

## 修复
在 character / return_table / timeline 三个分支成功导入后补 `_record_current_version(session, r, source_dir)`，与 fx-authority（权威基准数据「自动 upsert + 记版本」）对齐。

三类 writer 均幂等（return_curve ON CONFLICT DO NOTHING / timeline 去重 / character merge），**合并后重跑一次 `ingest --env prod` 即可回填存量库版本**，diff 屏即转「一致」，无需清库。

注：`时间线.md` 现为空占位（时间线改由 timeline-defaults 派生），解析 0 条记录、按 `r.records` 守卫不记版本；真正导入时间线数据时才记，符合预期。

## 验证
- 新增回归测试 `test_authority_files_record_version`：import_all 后三类文件均有 is_current 版本行、二次导入不新增版本。
- 全量 `pytest`：**559 passed**。
- dev 端到端：重跑 ingest 后 5 张 R1-R5 表 + 44 人物均补出版本 1 行。

Closes #209